### PR TITLE
Enable config flow and platform support

### DIFF
--- a/custom_components/horticulture_assistant/const.py
+++ b/custom_components/horticulture_assistant/const.py
@@ -6,7 +6,7 @@ VERSION = "0.1.0"
 ISSUE_URL = "https://github.com/TraverseJurcisin/Horticulture-Assistant/issues"
 
 # Platform support
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "binary_sensor", "switch"]
 
 # Configuration
 CONF_ENABLE_AUTO_APPROVE = "enable_auto_approve"

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "codeowners": ["@TraverseJurcisin"],
   "dependencies": [],
   "requirements": [],
-  "config_flow": false,
+  "config_flow": true,
   "iot_class": "calculated",
   "integration_type": "hub",
   "quality_scale": "silver"

--- a/scripts/daily_threshold_recalc.py
+++ b/scripts/daily_threshold_recalc.py
@@ -112,13 +112,6 @@ def run_daily_threshold_updates():
         else:
             queue_threshold_updates(plant_id, profile["thresholds"], new_thresholds)
             print("🛑 Threshold changes queued for approval.")
-        
-
-        if profile.get(AUTO_APPROVE_FIELD, False):
-            update_plant_profile(profile_path, new_thresholds)
-            print("✅ Thresholds auto-updated (auto_approve_all: true)")
-        else:
-            print("🛑 Awaiting manual approval for threshold updates")
 
     print("\n✅ Daily threshold recalculation complete.")
 


### PR DESCRIPTION
## Summary
- enable config flow in manifest
- forward binary_sensor and switch platforms
- load/unload all platforms in __init__
- clean up redundant condition in threshold recalculation script

## Testing
- `python -m py_compile custom_components/horticulture_assistant/__init__.py custom_components/horticulture_assistant/const.py scripts/daily_threshold_recalc.py`

------
https://chatgpt.com/codex/tasks/task_e_687c08768df48330aa4717d8c4962918