### PR TITLE
Refactor repeated JSON helpers into utility module

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Plant engine package utilities."""
+from .engine import run_daily_cycle
+from .utils import load_json, save_json
+
+__all__ = ["run_daily_cycle", "load_json", "save_json"]

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -1,0 +1,18 @@
+import json
+import os
+from typing import Any, Dict
+
+__all__ = ["load_json", "save_json"]
+
+
+def load_json(path: str) -> Dict[str, Any]:
+    """Load a JSON file and return its contents."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: str, data: Dict[str, Any]) -> None:
+    """Write a dictionary to a JSON file, creating parent dirs if needed."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/scripts/approval_queue.py
+++ b/scripts/approval_queue.py
@@ -2,6 +2,7 @@ import os
 import json
 from datetime import datetime
 from typing import Dict
+from plant_engine.utils import load_json, save_json
 
 PENDING_DIR = "data/pending_thresholds"
 
@@ -54,14 +55,3 @@ def apply_approved_thresholds(plant_path: str, pending_file: str):
     print(f"✅ Applied {applied} approved changes for {pending['plant_id']}")
     return applied
 
-
-# --- Utilities (copied from recalc script for independence) ---
-
-def load_json(path: str) -> Dict:
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
-
-def save_json(path: str, data: Dict) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)

--- a/scripts/daily_threshold_recalc.py
+++ b/scripts/daily_threshold_recalc.py
@@ -2,8 +2,9 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 from water_deficit_tracker import update_water_balance
+from plant_engine.utils import load_json, save_json
 
 
 # === CONFIGURATION ===
@@ -15,17 +16,6 @@ AUTO_APPROVE_FIELD = "auto_approve_all"
 
 
 # === HELPER FUNCTIONS ===
-
-def load_json(path: str) -> Dict[str, Any]:
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
-
-def save_json(path: str, data: Dict[str, Any]) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
-
-
 def generate_daily_report(plant_id: str, profile: Dict[str, Any]) -> Dict[str, Any]:
     """
     Mock version of AI input data packaging.

--- a/scripts/review_thresholds.py
+++ b/scripts/review_thresholds.py
@@ -1,6 +1,7 @@
 import os
 import json
-from approval_queue import apply_approved_thresholds, load_json, save_json
+from approval_queue import apply_approved_thresholds
+from plant_engine.utils import load_json, save_json
 
 PENDING_DIR = "data/pending_thresholds"
 PLANT_DIR = "plants"


### PR DESCRIPTION
## Summary
- centralize `load_json`/`save_json` helpers in `plant_engine.utils`
- expose them from new `plant_engine` package
- clean up scripts to use shared helpers and drop duplicates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c171806e48330a862a771dedd2dd2