### PR TITLE
Enhance horticulture data utilities

### DIFF
--- a/data/environment_guidelines.json
+++ b/data/environment_guidelines.json
@@ -1,0 +1,7 @@
+{
+  "citrus": {
+    "optimal": {"temp_c": [20, 30], "humidity_pct": [50, 70]},
+    "seedling": {"temp_c": [22, 26], "humidity_pct": [60, 80]},
+    "fruiting": {"temp_c": [18, 28], "humidity_pct": [40, 60]}
+  }
+}

--- a/data/pest_guidelines.json
+++ b/data/pest_guidelines.json
@@ -1,0 +1,6 @@
+{
+  "citrus": {
+    "aphids": "Apply insecticidal soap weekly until populations decline.",
+    "scale": "Use horticultural oil spray at bud break."
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -1,7 +1,16 @@
 """Plant engine package utilities."""
 
 from .utils import load_json, save_json
+from .environment_manager import get_environmental_targets
+from .pest_manager import get_pest_guidelines
+from .fertigation import recommend_fertigation_schedule
 
 # Run functions should be imported explicitly to avoid heavy imports at package
 # initialization time.
-__all__ = ["load_json", "save_json"]
+__all__ = [
+    "load_json",
+    "save_json",
+    "get_environmental_targets",
+    "get_pest_guidelines",
+    "recommend_fertigation_schedule",
+]

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -1,0 +1,18 @@
+"""Environment guideline utilities."""
+from typing import Dict, Any
+import os
+from .utils import load_json
+
+DATA_PATH = os.path.join("data", "environment_guidelines.json")
+
+
+def get_environmental_targets(plant_type: str, stage: str | None = None) -> Dict[str, Any]:
+    """Return recommended environmental ranges for a plant type and stage."""
+    if not os.path.exists(DATA_PATH):
+        return {}
+    data = load_json(DATA_PATH).get(plant_type, {})
+    if stage:
+        stage = stage.lower()
+        if stage in data:
+            return data[stage]
+    return data.get("optimal", {})

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -1,0 +1,23 @@
+"""Utility functions for fertigation calculations."""
+from typing import Dict
+
+from .nutrient_manager import get_recommended_levels
+
+
+def recommend_fertigation_schedule(
+    plant_type: str,
+    stage: str,
+    volume_l: float,
+    purity: Dict[str, float],
+) -> Dict[str, float]:
+    """Return grams of fertilizer needed per nutrient for the solution volume."""
+    targets = get_recommended_levels(plant_type, stage)
+    schedule: Dict[str, float] = {}
+    for nutrient, ppm in targets.items():
+        mg = ppm * volume_l
+        grams = mg / 1000
+        fraction = purity.get(nutrient, 1.0)
+        if fraction <= 0:
+            raise ValueError(f"Purity for {nutrient} must be > 0")
+        schedule[nutrient] = round(grams / fraction, 3)
+    return schedule

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -1,0 +1,14 @@
+"""Pest management guideline utilities."""
+import os
+from typing import Dict
+from .utils import load_json
+
+DATA_PATH = os.path.join("data", "pest_guidelines.json")
+
+
+def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
+    """Return pest management guidelines for the specified plant type."""
+    if not os.path.exists(DATA_PATH):
+        return {}
+    data = load_json(DATA_PATH)
+    return data.get(plant_type, {})

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -1,0 +1,7 @@
+from plant_engine.environment_manager import get_environmental_targets
+
+
+def test_get_environmental_targets_seedling():
+    data = get_environmental_targets("citrus", "seedling")
+    assert data["temp_c"] == [22, 26]
+    assert data["humidity_pct"] == [60, 80]

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -1,0 +1,11 @@
+from plant_engine.fertigation import recommend_fertigation_schedule
+
+
+def test_recommend_fertigation_schedule():
+    result = recommend_fertigation_schedule(
+        "citrus",
+        "fruiting",
+        volume_l=10.0,
+        purity={"N": 0.2},
+    )
+    assert round(result["N"], 2) == 6.0

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -1,0 +1,7 @@
+from plant_engine.pest_manager import get_pest_guidelines
+
+
+def test_get_pest_guidelines():
+    guide = get_pest_guidelines("citrus")
+    assert "aphids" in guide
+    assert guide["scale"].startswith("Use horticultural oil")


### PR DESCRIPTION
## Summary
- add environment and pest guideline datasets
- support retrieving these guidelines
- add fertigation schedule helper
- expose new helpers in plant_engine
- expand tests for new features

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1ebdfba4833080e8196f3cd7c03c