### PR TITLE
Improve horticulture data utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently, this repository is **private and actively under development**. A suit
 * Individual plant automation leveraging detailed sensor inputs and dynamic JSON profiles
 * Sensors for moisture, EC, ET, nutrient levels and AI recommendations
 * Built-in nutrient guidelines for precise fertilizer planning
+* Reference datasets for environment, pests and growth stage info
 * Binary sensors for irrigation readiness, sensor health and fault detection
 * Switch entities to control irrigation and fertigation
 * Optional AI threshold recalculation using offline or OpenAI logic

--- a/data/environment_guidelines.json
+++ b/data/environment_guidelines.json
@@ -3,5 +3,10 @@
     "optimal": {"temp_c": [20, 30], "humidity_pct": [50, 70]},
     "seedling": {"temp_c": [22, 26], "humidity_pct": [60, 80]},
     "fruiting": {"temp_c": [18, 28], "humidity_pct": [40, 60]}
+  },
+  "tomato": {
+    "optimal": {"temp_c": [18, 26], "humidity_pct": [60, 80]},
+    "seedling": {"temp_c": [20, 28], "humidity_pct": [65, 90]},
+    "fruiting": {"temp_c": [18, 24], "humidity_pct": [55, 75]}
   }
 }

--- a/data/growth_stages.json
+++ b/data/growth_stages.json
@@ -1,0 +1,13 @@
+{
+  "citrus": {
+    "seedling": {"duration_days": 60, "notes": "Keep soil moist and warm."},
+    "vegetative": {"duration_days": 120, "notes": "Apply balanced fertilizer."},
+    "fruiting": {"duration_days": 90, "notes": "Increase potassium levels."}
+  },
+  "tomato": {
+    "seedling": {"duration_days": 30, "notes": "Provide ample light."},
+    "vegetative": {"duration_days": 40, "notes": "Maintain moderate nitrogen."},
+    "flowering": {"duration_days": 20, "notes": "Reduce nitrogen, increase phosphorus."},
+    "fruiting": {"duration_days": 30, "notes": "High potassium required."}
+  }
+}

--- a/data/nutrient_guidelines.json
+++ b/data/nutrient_guidelines.json
@@ -2,5 +2,9 @@
   "citrus": {
     "vegetative": {"N": 80, "P": 30, "K": 60, "Ca": 20, "Mg": 10},
     "fruiting": {"N": 120, "P": 40, "K": 100, "Ca": 40, "Mg": 20}
+  },
+  "tomato": {
+    "vegetative": {"N": 100, "P": 50, "K": 80, "Ca": 40, "Mg": 25},
+    "fruiting": {"N": 80, "P": 60, "K": 120, "Ca": 60, "Mg": 30}
   }
 }

--- a/data/pest_guidelines.json
+++ b/data/pest_guidelines.json
@@ -2,5 +2,9 @@
   "citrus": {
     "aphids": "Apply insecticidal soap weekly until populations decline.",
     "scale": "Use horticultural oil spray at bud break."
+  },
+  "tomato": {
+    "aphids": "Use neem oil spray weekly.",
+    "blight": "Apply copper-based fungicide at first sign."
   }
 }

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -4,6 +4,8 @@ from .utils import load_json, save_json
 from .environment_manager import get_environmental_targets
 from .pest_manager import get_pest_guidelines
 from .fertigation import recommend_fertigation_schedule
+from .nutrient_manager import calculate_deficiencies
+from .growth_stage import get_stage_info
 
 # Run functions should be imported explicitly to avoid heavy imports at package
 # initialization time.
@@ -13,4 +15,6 @@ __all__ = [
     "get_environmental_targets",
     "get_pest_guidelines",
     "recommend_fertigation_schedule",
+    "calculate_deficiencies",
+    "get_stage_info",
 ]

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -1,16 +1,22 @@
 """Environment guideline utilities."""
 from typing import Dict, Any
 import os
+from functools import lru_cache
 from .utils import load_json
 
 DATA_PATH = os.path.join("data", "environment_guidelines.json")
 
 
-def get_environmental_targets(plant_type: str, stage: str | None = None) -> Dict[str, Any]:
-    """Return recommended environmental ranges for a plant type and stage."""
+@lru_cache(maxsize=None)
+def _load_data() -> Dict[str, Any]:
     if not os.path.exists(DATA_PATH):
         return {}
-    data = load_json(DATA_PATH).get(plant_type, {})
+    return load_json(DATA_PATH)
+
+
+def get_environmental_targets(plant_type: str, stage: str | None = None) -> Dict[str, Any]:
+    """Return recommended environmental ranges for a plant type and stage."""
+    data = _load_data().get(plant_type, {})
     if stage:
         stage = stage.lower()
         if stage in data:

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -1,0 +1,21 @@
+"""Retrieve growth stage metadata for plants."""
+from __future__ import annotations
+
+import os
+from typing import Dict, Any
+from functools import lru_cache
+from .utils import load_json
+
+DATA_PATH = os.path.join("data", "growth_stages.json")
+
+
+@lru_cache(maxsize=None)
+def _load_data() -> Dict[str, Dict[str, Any]]:
+    if not os.path.exists(DATA_PATH):
+        return {}
+    return load_json(DATA_PATH)
+
+
+def get_stage_info(plant_type: str, stage: str) -> Dict[str, Any]:
+    """Return information about a particular growth stage."""
+    return _load_data().get(plant_type, {}).get(stage, {})

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -1,14 +1,42 @@
-"""Nutrient requirement helper functions."""
+"""Utility helpers for nutrient recommendation and analysis."""
+from __future__ import annotations
+
 from typing import Dict
 import os
-from plant_engine.utils import load_json
+from functools import lru_cache
+from .utils import load_json
 
 DATA_PATH = os.path.join("data", "nutrient_guidelines.json")
 
 
-def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
-    """Return recommended nutrient levels for the given plant type and stage."""
+@lru_cache(maxsize=None)
+def _load_data() -> Dict[str, Dict[str, Dict[str, float]]]:
     if not os.path.exists(DATA_PATH):
         return {}
-    data = load_json(DATA_PATH)
-    return data.get(plant_type, {}).get(stage, {})
+    return load_json(DATA_PATH)
+
+
+def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return recommended nutrient levels for the given plant type and stage."""
+    return _load_data().get(plant_type, {}).get(stage, {})
+
+
+def calculate_deficiencies(
+    current_levels: Dict[str, float],
+    plant_type: str,
+    stage: str,
+) -> Dict[str, float]:
+    """Return nutrient deficiencies compared to guidelines.
+
+    Only nutrients below the recommended level are returned with the amount
+    needed (ppm) to reach the target.
+    """
+
+    recommended = get_recommended_levels(plant_type, stage)
+    deficiencies: Dict[str, float] = {}
+    for nutrient, target in recommended.items():
+        current = current_levels.get(nutrient, 0.0)
+        diff = round(target - current, 2)
+        if diff > 0:
+            deficiencies[nutrient] = diff
+    return deficiencies

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -1,14 +1,19 @@
 """Pest management guideline utilities."""
 import os
 from typing import Dict
+from functools import lru_cache
 from .utils import load_json
 
 DATA_PATH = os.path.join("data", "pest_guidelines.json")
 
 
-def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
-    """Return pest management guidelines for the specified plant type."""
+@lru_cache(maxsize=None)
+def _load_data() -> Dict[str, Dict[str, str]]:
     if not os.path.exists(DATA_PATH):
         return {}
-    data = load_json(DATA_PATH)
-    return data.get(plant_type, {})
+    return load_json(DATA_PATH)
+
+
+def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
+    """Return pest management guidelines for the specified plant type."""
+    return _load_data().get(plant_type, {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -1,0 +1,6 @@
+from plant_engine.growth_stage import get_stage_info
+
+
+def test_get_stage_info():
+    info = get_stage_info("tomato", "flowering")
+    assert info["duration_days"] == 20

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -1,7 +1,14 @@
-from plant_engine.nutrient_manager import get_recommended_levels
+from plant_engine.nutrient_manager import get_recommended_levels, calculate_deficiencies
 
 
 def test_get_recommended_levels():
     levels = get_recommended_levels("citrus", "fruiting")
     assert levels["N"] == 120
     assert levels["K"] == 100
+
+
+def test_calculate_deficiencies():
+    current = {"N": 60, "P": 50, "K": 100, "Ca": 50, "Mg": 20}
+    defs = calculate_deficiencies(current, "tomato", "fruiting")
+    assert defs["N"] == 20
+    assert defs["K"] == 20


### PR DESCRIPTION
## Summary
- add `growth_stages.json` dataset
- extend sample guidelines for tomato crops
- cache environment and pest data
- support nutrient deficiency calculations and stage info
- include tests and pytest config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2368d6d883309d8c3545c5bf7c98