### PR TITLE
Refine fertilizer utilities and tests

### DIFF
--- a/data/fertilizer_inventory.json
+++ b/data/fertilizer_inventory.json
@@ -1,0 +1,23 @@
+{
+  "foxfarm_grow_big": {
+    "density_kg_per_l": 0.96,
+    "guaranteed_analysis": {
+      "N": 0.06,
+      "P2O5": 0.04,
+      "K2O": 0.04,
+      "Mg": 0.006,
+      "Fe": 0.001,
+      "Mn": 0.0005,
+      "Zn": 0.0005,
+      "Cu": 0.0005,
+      "B": 0.0002
+    }
+  },
+  "magriculture": {
+    "density_kg_per_l": 1.0,
+    "guaranteed_analysis": {
+      "Mg": 0.098,
+      "S": 0.129
+    }
+  }
+}

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+import pytest
+
+module_path = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components/horticulture_assistant/fertilizer_formulator.py"
+)
+spec = importlib.util.spec_from_file_location("fertilizer_formulator", module_path)
+fert_mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = fert_mod
+spec.loader.exec_module(fert_mod)
+
+calculate_fertilizer_nutrients = fert_mod.calculate_fertilizer_nutrients
+convert_guaranteed_analysis = fert_mod.convert_guaranteed_analysis
+list_products = fert_mod.list_products
+
+
+def test_convert_guaranteed_analysis():
+    ga = {"N": 0.05, "P2O5": 0.1, "K2O": 0.2}
+    result = convert_guaranteed_analysis(ga)
+    assert result["N"] == 0.05
+    assert round(result["P"], 4) == 0.0436
+    assert round(result["K"], 3) == 0.166
+
+
+def test_calculate_fertilizer_nutrients():
+    payload = calculate_fertilizer_nutrients("plant1", "foxfarm_grow_big", 10)
+    nutrients = payload["nutrients"]
+    assert round(nutrients["N"], 1) == 576.0
+    assert round(nutrients["P"], 2) == 167.42
+    assert round(nutrients["K"], 2) == 318.72
+
+
+def test_list_products_contains_inventory():
+    ids = list_products()
+    assert "foxfarm_grow_big" in ids
+
+
+def test_invalid_inputs():
+    with pytest.raises(ValueError):
+        calculate_fertilizer_nutrients("plant", "unknown", 10)
+    with pytest.raises(ValueError):
+        calculate_fertilizer_nutrients("plant", "foxfarm_grow_big", 0)


### PR DESCRIPTION
## Summary
- rework fertilizer utils around a dataclass inventory
- expose `list_products` helper and validate inputs
- expand fertilizer unit tests for edge cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf94fb2e88330bd99f09a1daecbbe