### PR TITLE
Improve irrigation scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is structured as a custom HACS integration but is currently priv
 ### Data & Analytics
 - Built-in nutrient guidelines and fertilizer purity data
 - Root zone and water balance utilities for irrigation planning
+- New helper to calculate irrigation interval based on ET rates
 - Yield tracking with integration to InfluxDB and Grafana
 - Tagging system to group plants for aggregated analytics
 

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -27,7 +27,10 @@ from .rootzone_model import (
     estimate_water_capacity,
     RootZone,
 )
-from .irrigation_manager import recommend_irrigation_volume
+from .irrigation_manager import (
+    recommend_irrigation_volume,
+    recommend_irrigation_interval,
+)
 from .nutrient_manager import (
     calculate_deficiencies,
     list_supported_plants as list_nutrient_plants,
@@ -66,6 +69,7 @@ __all__ = [
     "estimate_water_capacity",
     "RootZone",
     "recommend_irrigation_volume",
+    "recommend_irrigation_interval",
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -1,4 +1,7 @@
-from plant_engine.irrigation_manager import recommend_irrigation_volume
+from plant_engine.irrigation_manager import (
+    recommend_irrigation_volume,
+    recommend_irrigation_interval,
+)
 from plant_engine.rootzone_model import RootZone
 
 
@@ -23,4 +26,19 @@ def test_irrigation_no_action_when_sufficient():
     )
     vol = recommend_irrigation_volume(zone, available_ml=150.0, expected_et_ml=30.0)
     assert vol == 0.0
+
+
+def test_recommend_irrigation_interval():
+    zone = RootZone(
+        root_depth_cm=20,
+        root_volume_cm3=2000,
+        total_available_water_ml=400.0,
+        readily_available_water_ml=200.0,
+    )
+    days = recommend_irrigation_interval(zone, available_ml=400.0, expected_et_ml_day=50.0)
+    # (400 - 200)/50 = 4 days
+    assert days == 4.0
+
+    # When already below RAW, interval is zero
+    assert recommend_irrigation_interval(zone, available_ml=150.0, expected_et_ml_day=50.0) == 0.0
 


### PR DESCRIPTION
## Summary
- add `recommend_irrigation_interval` helper for estimating days until watering is needed
- export the new helper from the plant_engine API
- document irrigation interval utility in README
- test new irrigation interval calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d130d37248330b88b374b66c494e6