### PR TITLE
Enhance environment utilities and add nutrient deficiency diagnostics

### DIFF
--- a/data/nutrient_deficiency_symptoms.json
+++ b/data/nutrient_deficiency_symptoms.json
@@ -1,0 +1,8 @@
+{
+  "N": "Older leaves turn yellow and growth is stunted.",
+  "P": "Leaves may darken and growth slows.",
+  "K": "Leaf edges may scorch or curl.",
+  "Ca": "New leaves appear distorted or die back.",
+  "Mg": "Yellowing between veins on older leaves.",
+  "Fe": "Young leaves become yellow while veins remain green."
+}

--- a/plant_engine/deficiency_manager.py
+++ b/plant_engine/deficiency_manager.py
@@ -1,0 +1,38 @@
+"""Nutrient deficiency diagnosis utilities."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .nutrient_manager import calculate_deficiencies
+from .utils import load_dataset
+
+DATA_FILE = "nutrient_deficiency_symptoms.json"
+
+# Load dataset once using cached loader
+_SYMPTOMS: Dict[str, str] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_known_nutrients",
+    "get_deficiency_symptom",
+    "diagnose_deficiencies",
+]
+
+
+def list_known_nutrients() -> list[str]:
+    """Return all nutrients with recorded deficiency symptoms."""
+    return sorted(_SYMPTOMS.keys())
+
+
+def get_deficiency_symptom(nutrient: str) -> str:
+    """Return the symptom description for a nutrient or an empty string."""
+    return _SYMPTOMS.get(nutrient, "")
+
+
+def diagnose_deficiencies(
+    current_levels: Mapping[str, float],
+    plant_type: str,
+    stage: str,
+) -> Dict[str, str]:
+    """Return deficiency symptoms based on current nutrient levels."""
+    deficits = calculate_deficiencies(current_levels, plant_type, stage)
+    return {n: get_deficiency_symptom(n) for n in deficits}

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -1,4 +1,4 @@
-"""Utilities for retrieving environment guidelines and computing adjustments."""
+"""Utilities for environment targets and optimization helpers."""
 
 from __future__ import annotations
 
@@ -7,6 +7,15 @@ from typing import Any, Dict, Mapping, Tuple
 from .utils import load_dataset
 
 DATA_FILE = "environment_guidelines.json"
+
+# map of dataset keys to human readable labels used when recommending
+# adjustments. defined here once to avoid recreating each call.
+ACTION_LABELS = {
+    "temp_c": "temperature",
+    "humidity_pct": "humidity",
+    "light_ppfd": "light",
+    "co2_ppm": "co2",
+}
 
 
 
@@ -52,14 +61,7 @@ def recommend_environment_adjustments(
     if not targets:
         return actions
 
-    mappings = {
-        "temp_c": "temperature",
-        "humidity_pct": "humidity",
-        "light_ppfd": "light",
-        "co2_ppm": "co2",
-    }
-
-    for key, label in mappings.items():
+    for key, label in ACTION_LABELS.items():
         if key in targets and key in current:
             suggestion = _check_range(current[key], tuple(targets[key]))
             if suggestion:

--- a/tests/test_deficiency_manager.py
+++ b/tests/test_deficiency_manager.py
@@ -1,0 +1,28 @@
+from plant_engine.deficiency_manager import (
+    list_known_nutrients,
+    get_deficiency_symptom,
+    diagnose_deficiencies,
+)
+from plant_engine.nutrient_manager import get_recommended_levels
+
+
+def test_list_known_nutrients():
+    nutrients = list_known_nutrients()
+    assert "N" in nutrients
+    assert "Fe" in nutrients
+
+
+def test_get_deficiency_symptom():
+    assert "yellow" in get_deficiency_symptom("N").lower()
+    assert get_deficiency_symptom("unknown") == ""
+
+
+def test_diagnose_deficiencies():
+    # choose spinach harvest stage as dataset exists
+    guidelines = get_recommended_levels("spinach", "harvest")
+    # current levels missing N and Mg
+    current = {key: 0 for key in guidelines}
+    symptoms = diagnose_deficiencies(current, "spinach", "harvest")
+    assert "N" in symptoms
+    assert "Mg" in symptoms
+


### PR DESCRIPTION
## Summary
- refactor `environment_manager` for clarity and reuse of adjustment labels
- add nutrient deficiency symptoms dataset
- implement `deficiency_manager` for diagnosing nutrient issues
- test new deficiency utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d14a529208330a61566dc246c66a9