### PR TITLE
Add plant health report utility

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -36,6 +36,7 @@ from .nutrient_manager import (
     list_supported_plants as list_nutrient_plants,
 )
 from .growth_stage import get_stage_info, list_growth_stages
+from .health_report import generate_health_report
 from .yield_manager import (
     HarvestRecord,
     load_yield_history,
@@ -74,4 +75,5 @@ __all__ = [
     "load_yield_history",
     "record_harvest",
     "get_total_yield",
+    "generate_health_report",
 ]

--- a/plant_engine/health_report.py
+++ b/plant_engine/health_report.py
@@ -1,0 +1,51 @@
+"""Generate consolidated plant health reports."""
+from __future__ import annotations
+
+from typing import Mapping, Iterable, Dict
+
+from . import (
+    environment_manager,
+    nutrient_manager,
+    deficiency_manager,
+    pest_manager,
+    disease_manager,
+    growth_stage,
+)
+
+
+def generate_health_report(
+    plant_type: str,
+    stage: str,
+    env: Mapping[str, float],
+    nutrient_levels: Mapping[str, float],
+    *,
+    pests: Iterable[str] = (),
+    diseases: Iterable[str] = (),
+) -> Dict[str, object]:
+    """Return a consolidated health report for a plant.
+
+    The report includes optimized environment data, nutrient deficiencies with
+    symptoms, and recommended pest and disease treatments.
+    """
+    env_opt = environment_manager.optimize_environment(env, plant_type, stage)
+    deficits = nutrient_manager.calculate_deficiencies(
+        nutrient_levels, plant_type, stage
+    )
+    symptoms = deficiency_manager.diagnose_deficiencies(
+        nutrient_levels, plant_type, stage
+    )
+    pest_actions = pest_manager.recommend_treatments(plant_type, pests)
+    disease_actions = disease_manager.recommend_treatments(plant_type, diseases)
+    stage_info = growth_stage.get_stage_info(plant_type, stage)
+
+    return {
+        "environment": env_opt,
+        "deficiencies": deficits,
+        "symptoms": symptoms,
+        "pest_actions": pest_actions,
+        "disease_actions": disease_actions,
+        "stage_info": stage_info,
+    }
+
+__all__ = ["generate_health_report"]
+

--- a/tests/test_health_report.py
+++ b/tests/test_health_report.py
@@ -1,0 +1,19 @@
+from plant_engine.health_report import generate_health_report
+
+
+def test_generate_health_report():
+    env = {"temp_c": 18, "humidity_pct": 90}
+    nutrients = {"N": 50, "K": 70}
+    report = generate_health_report(
+        "citrus",
+        "vegetative",
+        env,
+        nutrients,
+        pests=["aphids"],
+        diseases=["root rot"],
+    )
+    assert "environment" in report
+    assert report["deficiencies"]
+    assert report["pest_actions"]["aphids"].startswith("Apply")
+    assert report["disease_actions"]["root rot"].startswith("Ensure")
+


### PR DESCRIPTION
## Summary
- add new `generate_health_report` helper to consolidate environment, nutrient and pest/disease recommendations
- expose new helper from package init
- cover new functionality with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1b71e680833093aa8278ec4519f9