### PR TITLE
Add nutrient balance and DLI utilities

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -161,6 +161,19 @@ def relative_humidity_from_dew_point(temp_c: float, dew_point_c: float) -> float
     return round(rh, 1)
 
 
+def calculate_dli(ppfd: float, photoperiod_hours: float) -> float:
+    """Return Daily Light Integral (mol m⁻² day⁻¹).
+
+    The calculation converts the given Photosynthetic Photon Flux
+    Density (PPFD) in µmol⋅m⁻²⋅s⁻¹ over a ``photoperiod_hours`` span.
+    """
+    if ppfd < 0 or photoperiod_hours <= 0:
+        raise ValueError("ppfd must be non-negative and photoperiod_hours > 0")
+
+    dli = ppfd * 3600 * photoperiod_hours / 1_000_000
+    return round(dli, 2)
+
+
 def optimize_environment(
     current: Mapping[str, float], plant_type: str, stage: str | None = None
 ) -> Dict[str, object]:

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -43,3 +43,20 @@ def calculate_deficiencies(
             deficiencies[nutrient] = diff
     return deficiencies
 
+
+def calculate_nutrient_balance(
+    current_levels: Dict[str, float],
+    plant_type: str,
+    stage: str,
+) -> Dict[str, float]:
+    """Return ratio of current to recommended nutrient levels."""
+
+    recommended = get_recommended_levels(plant_type, stage)
+    ratios: Dict[str, float] = {}
+    for nutrient, target in recommended.items():
+        if target <= 0:
+            continue
+        current = current_levels.get(nutrient, 0.0)
+        ratios[nutrient] = round(current / target, 2)
+    return ratios
+

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -8,6 +8,7 @@ from plant_engine.environment_manager import (
     calculate_dew_point,
     calculate_heat_index,
     relative_humidity_from_dew_point,
+    calculate_dli,
     optimize_environment,
 )
 
@@ -96,3 +97,14 @@ def test_optimize_environment():
     assert round(result["vpd"], 3) == calculate_vpd(18, 90)
     assert round(result["dew_point_c"], 1) == round(calculate_dew_point(18, 90), 1)
     assert round(result["heat_index_c"], 1) == round(calculate_heat_index(18, 90), 1)
+
+
+def test_calculate_dli():
+    dli = calculate_dli(500, 16)
+    assert round(dli, 1) == 28.8
+
+    with pytest.raises(ValueError):
+        calculate_dli(-1, 16)
+
+    with pytest.raises(ValueError):
+        calculate_dli(100, 0)

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -1,4 +1,8 @@
-from plant_engine.nutrient_manager import get_recommended_levels, calculate_deficiencies
+from plant_engine.nutrient_manager import (
+    get_recommended_levels,
+    calculate_deficiencies,
+    calculate_nutrient_balance,
+)
 
 
 def test_get_recommended_levels():
@@ -12,3 +16,12 @@ def test_calculate_deficiencies():
     defs = calculate_deficiencies(current, "tomato", "fruiting")
     assert defs["N"] == 20
     assert defs["K"] == 20
+
+
+def test_calculate_nutrient_balance():
+    current = {"N": 60, "P": 50, "K": 100}
+    ratios = calculate_nutrient_balance(current, "tomato", "fruiting")
+    # dataset tomato fruiting: N 80, P 60, K 120
+    assert ratios["N"] == 0.75
+    assert round(ratios["P"], 2) == round(50 / 60, 2)
+    assert round(ratios["K"], 2) == round(100 / 120, 2)


### PR DESCRIPTION
## Summary
- expose new helper `calculate_dli` to compute Daily Light Integral
- expose `calculate_nutrient_balance` for checking nutrient ratios
- test the new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3772e3b883309c16d240e1100f4c