### PR TITLE
Improve nutrient management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ This repository is structured as a custom HACS integration but is currently priv
 
 ### Data & Analytics
 - Built-in nutrient guidelines and fertilizer purity data
+- Quick lookup of fertilizer product details for automation
 - Root zone and water balance utilities for irrigation planning
 - New helper to calculate irrigation interval based on ET rates
+- Calculate nutrient surpluses or deficits per growth stage
 - Yield tracking with integration to InfluxDB and Grafana
 - Tagging system to group plants for aggregated analytics
 

--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -82,9 +82,18 @@ __all__ = [
     "calculate_fertilizer_nutrients",
     "convert_guaranteed_analysis",
     "list_products",
+    "get_product_info",
 ]
 
 
 def list_products() -> list[str]:
     """Return available fertilizer product identifiers."""
     return sorted(_inventory().keys())
+
+
+def get_product_info(fertilizer_id: str) -> Fertilizer:
+    """Return :class:`Fertilizer` details for ``fertilizer_id``."""
+    inv = _inventory()
+    if fertilizer_id not in inv:
+        raise KeyError(f"Unknown fertilizer '{fertilizer_id}'")
+    return inv[fertilizer_id]

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 
 from typing import Dict
 
+"""Helpers for plant nutrient guidelines and analysis."""
+
+from typing import Dict
+
 from .utils import load_dataset
 
 DATA_FILE = "nutrient_guidelines.json"
 
 
 
-# Cache dataset via ``load_dataset`` once at import time
+# Dataset cached via :func:`load_dataset` so this only happens once
 _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 
 
@@ -59,4 +63,22 @@ def calculate_nutrient_balance(
         current = current_levels.get(nutrient, 0.0)
         ratios[nutrient] = round(current / target, 2)
     return ratios
+
+
+def calculate_surplus(
+    current_levels: Dict[str, float],
+    plant_type: str,
+    stage: str,
+) -> Dict[str, float]:
+    """Return nutrient amounts exceeding recommendations."""
+
+    recommended = get_recommended_levels(plant_type, stage)
+    surplus: Dict[str, float] = {}
+    for nutrient, target in recommended.items():
+        current = current_levels.get(nutrient, 0.0)
+        diff = round(current - target, 2)
+        if diff > 0:
+            surplus[nutrient] = diff
+    return surplus
+
 

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -15,6 +15,7 @@ spec.loader.exec_module(fert_mod)
 calculate_fertilizer_nutrients = fert_mod.calculate_fertilizer_nutrients
 convert_guaranteed_analysis = fert_mod.convert_guaranteed_analysis
 list_products = fert_mod.list_products
+get_product_info = fert_mod.get_product_info
 
 
 def test_convert_guaranteed_analysis():
@@ -37,9 +38,14 @@ def test_list_products_contains_inventory():
     ids = list_products()
     assert "foxfarm_grow_big" in ids
 
+    info = get_product_info("foxfarm_grow_big")
+    assert round(info.density_kg_per_l, 2) == 0.96
+
 
 def test_invalid_inputs():
     with pytest.raises(ValueError):
         calculate_fertilizer_nutrients("plant", "unknown", 10)
     with pytest.raises(ValueError):
         calculate_fertilizer_nutrients("plant", "foxfarm_grow_big", 0)
+    with pytest.raises(KeyError):
+        get_product_info("unknown")

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -2,6 +2,7 @@ from plant_engine.nutrient_manager import (
     get_recommended_levels,
     calculate_deficiencies,
     calculate_nutrient_balance,
+    calculate_surplus,
 )
 
 
@@ -25,3 +26,11 @@ def test_calculate_nutrient_balance():
     assert ratios["N"] == 0.75
     assert round(ratios["P"], 2) == round(50 / 60, 2)
     assert round(ratios["K"], 2) == round(100 / 120, 2)
+
+
+def test_calculate_surplus():
+    current = {"N": 150, "P": 70, "K": 130}
+    surplus = calculate_surplus(current, "tomato", "fruiting")
+    assert surplus["N"] == 70
+    assert surplus["P"] == 10
+    assert surplus["K"] == 10


### PR DESCRIPTION
## Summary
- extend README highlights
- add helper to fetch fertilizer product info
- add nutrient surplus calculation helper
- cover new features with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d397c8cf88330a2f4c0055147e699