### PR TITLE
Add WSDA fertilizer lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Key reference datasets reside in the `data/` directory:
 - `nutrient_guidelines.json` – recommended N‑P‑K levels across stages
 - `disease_guidelines.json` and `pest_guidelines.json` – treatment references
 - `yield/` – per‑plant yield logs created during operation
+- `wsda_fertilizer_database.json` – full fertilizer analysis database used by
+  `plant_engine.wsda_lookup` for product N‑P‑K values
 
 The datasets are snapshots compiled from public resources. They may be outdated
 or incomplete and should only be used as a starting point for your own research.

--- a/plant_engine/wsda_lookup.py
+++ b/plant_engine/wsda_lookup.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+# Path to the WSDA fertilizer database packaged with the repository
+_WSDA_PATH = Path(__file__).resolve().parents[1] / "wsda_fertilizer_database.json"
+
+__all__ = [
+    "get_product_npk_by_name",
+    "get_product_npk_by_number",
+]
+
+@lru_cache(maxsize=None)
+def _database() -> List[Dict[str, object]]:
+    """Return parsed WSDA database records."""
+    if not _WSDA_PATH.exists():
+        return []
+    with open(_WSDA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _match_record(predicate) -> Dict[str, object] | None:
+    for item in _database():
+        if predicate(item):
+            return item
+    return None
+
+
+def _extract_npk(record: Dict[str, object]) -> Dict[str, float]:
+    ga = record.get("guaranteed_analysis", {}) if record else {}
+    return {
+        "N": float(ga.get("Total Nitrogen (N)") or 0),
+        "P": float(ga.get("Available Phosphoric Acid (P2O5)") or 0),
+        "K": float(ga.get("Soluble Potash (K2O)") or 0),
+    }
+
+
+def get_product_npk_by_name(name: str) -> Dict[str, float]:
+    """Return N, P and K percentages for a product ``name``.
+
+    Matching is case-insensitive and the full product name should be supplied.
+    An empty dictionary is returned if the product cannot be found.
+    """
+    name_l = name.lower()
+    rec = _match_record(lambda d: d.get("product_name", "").lower() == name_l)
+    return _extract_npk(rec)
+
+
+def get_product_npk_by_number(number: str) -> Dict[str, float]:
+    """Return NPK percentages for a WSDA ``number`` such as ``(#4083-0001)``."""
+    rec = _match_record(lambda d: d.get("wsda_product_number") == number)
+    return _extract_npk(rec)

--- a/tests/test_wsda_lookup.py
+++ b/tests/test_wsda_lookup.py
@@ -1,0 +1,26 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / "plant_engine/wsda_lookup.py"
+spec = importlib.util.spec_from_file_location("wsda_lookup", module_path)
+wsda = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = wsda
+spec.loader.exec_module(wsda)
+
+get_product_npk_by_name = wsda.get_product_npk_by_name
+get_product_npk_by_number = wsda.get_product_npk_by_number
+
+
+def test_lookup_by_name():
+    result = get_product_npk_by_name("1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6")
+    assert result["N"] == 5.0
+    assert result["P"] == 6.0
+    assert result["K"] == 6.0
+
+
+def test_lookup_by_number():
+    result = get_product_npk_by_number("(#4083-0001)")
+    assert result["N"] == 5.0
+    assert result["P"] == 6.0
+    assert result["K"] == 6.0


### PR DESCRIPTION
## Summary
- integrate WSDA fertilizer database via `plant_engine.wsda_lookup`
- document the database in README
- add tests for fertilizer lookups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da20aefbc8330a9453ab368bb0717