### PR TITLE
Add pH management dataset and utilities

### DIFF
--- a/data/ph_guidelines.json
+++ b/data/ph_guidelines.json
@@ -1,0 +1,11 @@
+{
+  "citrus": {"optimal": [5.5, 6.5]},
+  "tomato": {"optimal": [5.5, 6.5]},
+  "lettuce": {"optimal": [5.8, 6.2]},
+  "strawberry": {"optimal": [5.5, 6.5]},
+  "basil": {"optimal": [5.5, 6.5]},
+  "spinach": {"optimal": [6.0, 7.0]},
+  "cucumber": {"optimal": [5.5, 6.8]},
+  "pepper": {"optimal": [5.5, 6.8]},
+  "arugula": {"optimal": [6.0, 7.0]}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -52,6 +52,11 @@ from .water_quality import (
     get_threshold as get_water_threshold,
     interpret_water_profile,
 )
+from .ph_manager import (
+    list_supported_plants as list_ph_plants,
+    get_ph_range,
+    recommend_ph_adjustment,
+)
 from .compute_transpiration import TranspirationMetrics
 
 # Run functions should be imported explicitly to avoid heavy imports at package
@@ -93,5 +98,8 @@ __all__ = [
     "list_water_analytes",
     "get_water_threshold",
     "interpret_water_profile",
+    "list_ph_plants",
+    "get_ph_range",
+    "recommend_ph_adjustment",
     "TranspirationMetrics",
 ]

--- a/plant_engine/ph_manager.py
+++ b/plant_engine/ph_manager.py
@@ -1,0 +1,51 @@
+"""pH management utilities."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from .utils import load_dataset
+
+DATA_FILE = "ph_guidelines.json"
+
+# Cached dataset loaded once
+_DATA: Dict[str, Dict[str, Iterable[float]]] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_ph_range", "recommend_ph_adjustment"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return all plant types with pH guidelines."""
+    return sorted(_DATA.keys())
+
+
+def get_ph_range(plant_type: str, stage: str | None = None) -> list[float]:
+    """Return pH range for ``plant_type`` and ``stage``."""
+    data = _DATA.get(plant_type.lower())
+    if not data:
+        return []
+    if stage and stage in data:
+        rng = data[stage]
+    else:
+        rng = data.get("optimal")
+    if isinstance(rng, Iterable):
+        values = list(rng)
+        if len(values) == 2:
+            return [float(values[0]), float(values[1])]
+    return []
+
+
+def recommend_ph_adjustment(
+    current_ph: float, plant_type: str, stage: str | None = None
+) -> str | None:
+    """Return 'increase' or 'decrease' recommendation for pH."""
+    if current_ph <= 0:
+        raise ValueError("current_ph must be positive")
+    target = get_ph_range(plant_type, stage)
+    if not target:
+        return None
+    low, high = target
+    if current_ph < low:
+        return "increase"
+    if current_ph > high:
+        return "decrease"
+    return None

--- a/tests/test_ph_manager.py
+++ b/tests/test_ph_manager.py
@@ -1,0 +1,24 @@
+import pytest
+
+from plant_engine import ph_manager
+
+
+def test_get_ph_range():
+    rng = ph_manager.get_ph_range("citrus")
+    assert rng == [5.5, 6.5]
+    lettuce = ph_manager.get_ph_range("lettuce")
+    assert lettuce == [5.8, 6.2]
+
+
+def test_recommend_ph_adjustment():
+    assert ph_manager.recommend_ph_adjustment(5.0, "citrus") == "increase"
+    assert ph_manager.recommend_ph_adjustment(7.0, "citrus") == "decrease"
+    assert ph_manager.recommend_ph_adjustment(6.0, "citrus") is None
+
+
+def test_recommend_unknown_or_invalid():
+    assert ph_manager.get_ph_range("unknown") == []
+    assert ph_manager.recommend_ph_adjustment(6.0, "unknown") is None
+    with pytest.raises(ValueError):
+        ph_manager.recommend_ph_adjustment(-1, "citrus")
+


### PR DESCRIPTION
## Summary
- add `ph_guidelines.json` dataset
- add `ph_manager` module for pH range lookup and recommendations
- expose new pH APIs via `plant_engine.__init__`
- test pH manager utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e94285f9883309113ef9f956687ab