### PR TITLE
Improve environment calculations

### DIFF
--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -4,6 +4,8 @@ from plant_engine.environment_manager import (
     get_environmental_targets,
     recommend_environment_adjustments,
     suggest_environment_setpoints,
+    saturation_vapor_pressure,
+    actual_vapor_pressure,
     calculate_vpd,
     calculate_dew_point,
     calculate_heat_index,
@@ -52,6 +54,13 @@ def test_suggest_environment_setpoints():
     assert setpoints["humidity_pct"] == 70
     assert setpoints["light_ppfd"] == 225
     assert setpoints["co2_ppm"] == 500
+
+
+def test_vapor_pressure_helpers():
+    es = saturation_vapor_pressure(25)
+    ea = actual_vapor_pressure(25, 50)
+    assert round(es, 3) == 3.168
+    assert round(ea, 3) == round(es * 0.5, 3)
 
 
 def test_calculate_vpd():


### PR DESCRIPTION
## Summary
- add reusable vapor pressure helpers
- use helpers in VPD and RH calculations
- test vapor pressure functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e961eee6483308825a474cdfcb844