### PR TITLE
Enhance fertigation utilities with water quality support

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -24,6 +24,7 @@ from .disease_manager import (
 from .fertigation import (
     recommend_fertigation_schedule,
     recommend_correction_schedule,
+    recommend_fertigation_with_water_profile,
     get_fertilizer_purity,
 )
 from .rootzone_model import (
@@ -75,6 +76,7 @@ __all__ = [
     "list_disease_plants",
     "recommend_fertigation_schedule",
     "recommend_correction_schedule",
+    "recommend_fertigation_with_water_profile",
     "get_fertilizer_purity",
     "calculate_deficiencies",
     "list_nutrient_plants",

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -3,6 +3,7 @@ from plant_engine.fertigation import (
     recommend_correction_schedule,
     get_fertilizer_purity,
     recommend_batch_fertigation,
+    recommend_fertigation_with_water_profile,
 )
 
 
@@ -68,5 +69,18 @@ def test_recommend_batch_fertigation():
     assert "citrus-vegetative" in batches
     assert "tomato-fruiting" in batches
     assert batches["citrus-vegetative"]["N"] > 0
+
+
+def test_fertigation_with_water_profile():
+    schedule, warnings = recommend_fertigation_with_water_profile(
+        "citrus",
+        "vegetative",
+        volume_l=1.0,
+        water_profile={"N": 10, "Na": 60},
+        product="urea",
+    )
+    assert "Na" in warnings
+    expected = round((0.08 / 0.46) - (0.01 / 0.46), 3)
+    assert round(schedule["N"], 3) == expected
 
 


### PR DESCRIPTION
## Summary
- support water-based nutrient offsets in fertigation
- export new helper from `plant_engine`
- test water-aware fertigation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e96257d5c83309bf85852d97c68bc