### PR TITLE
Add pest monitoring thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Key reference datasets reside in the `data/` directory:
 - `environment_guidelines.json` – optimal temperature, humidity and light by crop
 - `nutrient_guidelines.json` – recommended N‑P‑K levels across stages
 - `disease_guidelines.json` and `pest_guidelines.json` – treatment references
+- `pest_thresholds.json` – action thresholds for common pests
 - `yield/` – per‑plant yield logs created during operation
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values

--- a/data/pest_thresholds.json
+++ b/data/pest_thresholds.json
@@ -1,0 +1,22 @@
+{
+  "citrus": {
+    "aphids": 5,
+    "scale": 2
+  },
+  "tomato": {
+    "aphids": 10,
+    "blight": 1
+  },
+  "lettuce": {
+    "aphids": 8,
+    "leafminers": 4
+  },
+  "strawberry": {
+    "spider mites": 3,
+    "slugs": 2
+  },
+  "spinach": {
+    "aphids": 5,
+    "leaf miners": 2
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -16,6 +16,11 @@ from .pest_manager import (
     recommend_treatments as recommend_pest_treatments,
     list_supported_plants as list_pest_plants,
 )
+from .pest_monitor import (
+    get_pest_thresholds,
+    assess_pest_pressure,
+    recommend_threshold_actions,
+)
 from .disease_manager import (
     get_disease_guidelines,
     recommend_treatments as recommend_disease_treatments,
@@ -75,6 +80,9 @@ __all__ = [
     "get_pest_guidelines",
     "recommend_pest_treatments",
     "list_pest_plants",
+    "get_pest_thresholds",
+    "assess_pest_pressure",
+    "recommend_threshold_actions",
     "get_disease_guidelines",
     "recommend_disease_treatments",
     "list_disease_plants",

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Pest monitoring utilities using threshold datasets."""
+
+from typing import Dict, Mapping
+
+from .utils import load_dataset
+from .pest_manager import recommend_treatments
+
+DATA_FILE = "pest_thresholds.json"
+
+# Load once with caching
+_THRESHOLDS: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "get_pest_thresholds",
+    "assess_pest_pressure",
+    "recommend_threshold_actions",
+]
+
+
+def get_pest_thresholds(plant_type: str) -> Dict[str, int]:
+    """Return pest count thresholds for ``plant_type``."""
+    return _THRESHOLDS.get(plant_type, {})
+
+
+def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:
+    """Return mapping of pests to ``True`` if threshold exceeded."""
+    thresholds = get_pest_thresholds(plant_type)
+    pressure: Dict[str, bool] = {}
+    for pest, count in observations.items():
+        thresh = thresholds.get(pest)
+        if thresh is None:
+            continue
+        pressure[pest] = count >= thresh
+    return pressure
+
+
+def recommend_threshold_actions(plant_type: str, observations: Mapping[str, int]) -> Dict[str, str]:
+    """Return treatment actions for pests exceeding thresholds."""
+    pressure = assess_pest_pressure(plant_type, observations)
+    exceeded = [p for p, flag in pressure.items() if flag]
+    if not exceeded:
+        return {}
+    return recommend_treatments(plant_type, exceeded)

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -1,0 +1,24 @@
+from plant_engine.pest_monitor import (
+    get_pest_thresholds,
+    assess_pest_pressure,
+    recommend_threshold_actions,
+)
+
+
+def test_get_pest_thresholds():
+    thresh = get_pest_thresholds("citrus")
+    assert thresh["aphids"] == 5
+
+
+def test_assess_pest_pressure():
+    obs = {"aphids": 6, "scale": 1}
+    result = assess_pest_pressure("citrus", obs)
+    assert result["aphids"] is True
+    assert result.get("scale") is False
+
+
+def test_recommend_threshold_actions():
+    obs = {"aphids": 6, "scale": 3}
+    actions = recommend_threshold_actions("citrus", obs)
+    assert "aphids" in actions
+    assert "scale" in actions


### PR DESCRIPTION
## Summary
- introduce pest threshold dataset for monitoring
- add pest monitor helper module
- expose monitoring helpers via package init
- document new dataset in README
- test pest monitor utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e99fd769c83309e2d9771b92f331b