### PR TITLE
Improve dataset management

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Key reference datasets reside in the `data/` directory:
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
 
+You can override the default `data/` directory by setting the environment
+variable `HORTICULTURE_DATA_DIR` when running scripts or tests.
+
 The datasets are snapshots compiled from public resources. They may be outdated
 or incomplete and should only be used as a starting point for your own research.
 

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -24,13 +24,21 @@ def save_json(path: str, data: Dict[str, Any]) -> None:
         json.dump(data, f, indent=2)
 
 
-DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+# Default data directory is the repository "data" folder. It can be
+# overridden at runtime using the ``HORTICULTURE_DATA_DIR`` environment
+# variable which is helpful when packaging the library or running tests with
+# custom datasets.
+DEFAULT_DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+def _data_dir() -> Path:
+    env = os.getenv("HORTICULTURE_DATA_DIR")
+    return Path(env) if env else DEFAULT_DATA_DIR
 
 
 @lru_cache(maxsize=None)
 def load_dataset(filename: str) -> Dict[str, Any]:
-    """Load a JSON dataset from the repository ``data`` directory with caching."""
-    path = DATA_DIR / filename
+    """Load a JSON dataset from the resolved data directory with caching."""
+    path = _data_dir() / filename
     if not path.exists():
         return {}
     return load_json(str(path))

--- a/tests/test_dataset_override.py
+++ b/tests/test_dataset_override.py
@@ -1,0 +1,16 @@
+import importlib
+import json
+from pathlib import Path
+
+import plant_engine.utils as utils
+
+
+def test_dataset_env_override(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    test_data = {"foo": 1}
+    (data_dir / "sample.json").write_text(json.dumps(test_data))
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(utils)
+    result = utils.load_dataset("sample.json")
+    assert result == test_data


### PR DESCRIPTION
## Summary
- support configurable `HORTICULTURE_DATA_DIR`
- document dataset override in README
- test dataset directory override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb77e45ec8330b313be672bd0bf90