### PR TITLE
Improve dataset lookups

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -50,6 +50,11 @@ _DATA: Dict[str, Any] = load_dataset(DATA_FILE)
 _DLI_DATA: Dict[str, Any] = load_dataset(DLI_DATA_FILE)
 
 
+def _norm(key: str) -> str:
+    """Normalize keys for case-insensitive lookups."""
+    return key.lower()
+
+
 def saturation_vapor_pressure(temp_c: float) -> float:
     """Return saturation vapor pressure (kPa) at ``temp_c``."""
     return 0.6108 * math.exp((17.27 * temp_c) / (temp_c + 237.3))
@@ -102,9 +107,9 @@ def get_environmental_targets(
     plant_type: str, stage: str | None = None
 ) -> Dict[str, Any]:
     """Return recommended environmental ranges for a plant type and stage."""
-    data = _DATA.get(plant_type, {})
+    data = _DATA.get(_norm(plant_type), {})
     if stage:
-        stage = stage.lower()
+        stage = _norm(stage)
         if stage in data:
             return data[stage]
     return data.get("optimal", {})
@@ -318,9 +323,9 @@ def calculate_dli_series(ppfd_values: Iterable[float], interval_hours: float = 1
 
 def get_target_dli(plant_type: str, stage: str | None = None) -> tuple[float, float] | None:
     """Return recommended DLI range for ``plant_type`` and ``stage`` if available."""
-    data = _DLI_DATA.get(plant_type, {})
+    data = _DLI_DATA.get(_norm(plant_type), {})
     if stage:
-        stage = stage.lower()
+        stage = _norm(stage)
         if stage in data:
             vals = data[stage]
             if len(vals) == 2:

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -13,6 +13,11 @@ DATA_FILE = "growth_stages.json"
 # Load growth stage dataset once. ``load_dataset`` handles caching.
 _DATA: Dict[str, Dict[str, Any]] = load_dataset(DATA_FILE)
 
+
+def _norm(key: str) -> str:
+    """Normalize keys for case-insensitive lookups."""
+    return key.lower()
+
 __all__ = [
     "get_stage_info",
     "list_growth_stages",
@@ -23,12 +28,12 @@ __all__ = [
 
 def get_stage_info(plant_type: str, stage: str) -> Dict[str, Any]:
     """Return information about a particular growth stage."""
-    return _DATA.get(plant_type, {}).get(stage, {})
+    return _DATA.get(_norm(plant_type), {}).get(_norm(stage), {})
 
 
 def list_growth_stages(plant_type: str) -> list[str]:
     """Return all defined growth stages for a plant type."""
-    return sorted(_DATA.get(plant_type, {}).keys())
+    return sorted(_DATA.get(_norm(plant_type), {}).keys())
 
 
 def get_stage_duration(plant_type: str, stage: str) -> int | None:
@@ -52,7 +57,7 @@ def estimate_stage_from_age(plant_type: str, days_since_start: int) -> str | Non
     if days_since_start < 0:
         raise ValueError("days_since_start must be non-negative")
 
-    stages = _DATA.get(plant_type)
+    stages = _DATA.get(_norm(plant_type))
     if not isinstance(stages, dict):
         return None
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -29,6 +29,11 @@ def test_get_environmental_targets_seedling():
     assert data["co2_ppm"] == [400, 600]
 
 
+def test_get_environmental_targets_case_insensitive():
+    data = get_environmental_targets("CITRUS", "SeEdLiNg")
+    assert data["temp_c"] == [22, 26]
+
+
 def test_recommend_environment_adjustments():
     actions = recommend_environment_adjustments(
         {
@@ -166,6 +171,10 @@ def test_score_environment():
 def test_get_target_dli():
     assert get_target_dli("lettuce", "seedling") == (10, 12)
     assert get_target_dli("unknown") is None
+
+
+def test_get_target_dli_case_insensitive():
+    assert get_target_dli("LeTtUcE", "SeEdLiNg") == (10, 12)
 
 
 def test_calculate_dli_series():

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -12,9 +12,18 @@ def test_get_stage_info():
     assert info["duration_days"] == 20
 
 
+def test_get_stage_info_case_insensitive():
+    info = get_stage_info("ToMaTo", "FlOwErInG")
+    assert info["duration_days"] == 20
+
+
 def test_get_stage_duration():
     assert get_stage_duration("tomato", "flowering") == 20
     assert get_stage_duration("tomato", "unknown") is None
+
+
+def test_get_stage_duration_case_insensitive():
+    assert get_stage_duration("ToMaTo", "FlOwErInG") == 20
 
 
 def test_estimate_stage_from_age():
@@ -23,6 +32,11 @@ def test_estimate_stage_from_age():
     assert estimate_stage_from_age("tomato", 150) is None
 
 
+def test_estimate_stage_from_age_case_insensitive():
+    assert estimate_stage_from_age("ToMaTo", 5) == "seedling"
+
+
 def test_estimate_stage_from_age_negative():
     with pytest.raises(ValueError):
         estimate_stage_from_age("tomato", -1)
+


### PR DESCRIPTION
## Summary
- normalize plant names and stages for case-insensitive lookups in `environment_manager` and `growth_stage`
- add regression tests covering the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb77686dc8330bf48226919028bf2