### PR TITLE
Add fertilizer cost calculation utility

### DIFF
--- a/data/fertilizers/fertilizer_prices.json
+++ b/data/fertilizers/fertilizer_prices.json
@@ -1,0 +1,5 @@
+{
+  "foxfarm_grow_big": 20.0,
+  "magriculture": 10.0,
+  "intrepid_granular_potash_0_0_60": 5.0
+}

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -16,6 +16,7 @@ calculate_fertilizer_nutrients = fert_mod.calculate_fertilizer_nutrients
 convert_guaranteed_analysis = fert_mod.convert_guaranteed_analysis
 list_products = fert_mod.list_products
 get_product_info = fert_mod.get_product_info
+calculate_fertilizer_cost = fert_mod.calculate_fertilizer_cost
 
 
 def test_convert_guaranteed_analysis():
@@ -49,3 +50,12 @@ def test_invalid_inputs():
         calculate_fertilizer_nutrients("plant", "foxfarm_grow_big", 0)
     with pytest.raises(KeyError):
         get_product_info("unknown")
+
+
+def test_calculate_fertilizer_cost():
+    cost = calculate_fertilizer_cost("foxfarm_grow_big", 10)
+    assert round(cost, 2) == 0.2
+    with pytest.raises(ValueError):
+        calculate_fertilizer_cost("foxfarm_grow_big", -1)
+    with pytest.raises(KeyError):
+        calculate_fertilizer_cost("unknown", 10)


### PR DESCRIPTION
## Summary
- expand fertilizer data with price information
- expose `_price_map` and `calculate_fertilizer_cost` helpers
- test fertilizer cost calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb779ba4483308db110e841964e7b