### PR TITLE
Add fertilizer mix cost estimation utility

### DIFF
--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -113,10 +113,40 @@ def calculate_fertilizer_cost(fertilizer_id: str, volume_ml: float) -> float:
     return round(cost, 2)
 
 
+def estimate_mix_cost(schedule: Mapping[str, float]) -> float:
+    """Return estimated USD cost for a fertilizer mix.
+
+    ``schedule`` maps fertilizer identifiers to grams of product. Prices are
+    stored in :data:`PRICE_FILE` as USD per liter and densities are read from
+    :data:`DATA_FILE` to convert grams to liters. A ``KeyError`` is raised if
+    any product lacks price or density information.
+    """
+
+    prices = _price_map()
+    inventory = _inventory()
+
+    total = 0.0
+    for fert_id, grams in schedule.items():
+        if grams <= 0:
+            continue
+        if fert_id not in prices:
+            raise KeyError(f"Price for '{fert_id}' is not defined")
+        if fert_id not in inventory:
+            raise KeyError(f"Density for '{fert_id}' is not defined")
+
+        density = inventory[fert_id].density_kg_per_l  # kg/L
+        grams_per_liter = density * 1000
+        volume_l = grams / grams_per_liter
+        total += prices[fert_id] * volume_l
+
+    return round(total, 2)
+
+
 __all__ = [
     "calculate_fertilizer_nutrients",
     "convert_guaranteed_analysis",
     "calculate_fertilizer_cost",
+    "estimate_mix_cost",
     "list_products",
     "get_product_info",
 ]

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -17,6 +17,7 @@ convert_guaranteed_analysis = fert_mod.convert_guaranteed_analysis
 list_products = fert_mod.list_products
 get_product_info = fert_mod.get_product_info
 calculate_fertilizer_cost = fert_mod.calculate_fertilizer_cost
+estimate_mix_cost = fert_mod.estimate_mix_cost
 
 
 def test_convert_guaranteed_analysis():
@@ -59,3 +60,11 @@ def test_calculate_fertilizer_cost():
         calculate_fertilizer_cost("foxfarm_grow_big", -1)
     with pytest.raises(KeyError):
         calculate_fertilizer_cost("unknown", 10)
+
+
+def test_estimate_mix_cost():
+    mix = {"foxfarm_grow_big": 20}
+    cost = estimate_mix_cost(mix)
+    assert round(cost, 2) == 0.42
+    with pytest.raises(KeyError):
+        estimate_mix_cost({"unknown": 10})


### PR DESCRIPTION
## Summary
- implement `estimate_mix_cost` helper for calculating blended fertilizer cost
- export new helper from module
- cover new functionality in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebd37d3008330818a12e419d29da4