### PR TITLE
Add EC guidelines and integrate with optimization

### DIFF
--- a/data/ec_guidelines.json
+++ b/data/ec_guidelines.json
@@ -1,0 +1,14 @@
+{
+  "citrus": {
+    "seedling": [1.0, 1.2],
+    "vegetative": [1.2, 1.8],
+    "fruiting": [1.8, 2.2],
+    "optimal": [1.5, 2.0]
+  },
+  "tomato": {
+    "seedling": [1.0, 1.4],
+    "vegetative": [2.0, 2.5],
+    "fruiting": [2.5, 3.5],
+    "optimal": [2.0, 3.0]
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -62,6 +62,12 @@ from .ph_manager import (
     get_ph_range,
     recommend_ph_adjustment,
 )
+from .ec_manager import (
+    list_supported_plants as list_ec_plants,
+    get_ec_range,
+    recommend_ec_adjustment,
+    recommended_ec_setpoint,
+)
 from .compute_transpiration import TranspirationMetrics
 
 # Run functions should be imported explicitly to avoid heavy imports at package
@@ -109,5 +115,9 @@ __all__ = [
     "list_ph_plants",
     "get_ph_range",
     "recommend_ph_adjustment",
+    "list_ec_plants",
+    "get_ec_range",
+    "recommend_ec_adjustment",
+    "recommended_ec_setpoint",
     "TranspirationMetrics",
 ]

--- a/plant_engine/ec_manager.py
+++ b/plant_engine/ec_manager.py
@@ -1,0 +1,65 @@
+"""Electrical conductivity (EC) guidelines and helpers."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from .utils import load_dataset
+
+DATA_FILE = "ec_guidelines.json"
+
+_DATA: Dict[str, Dict[str, Iterable[float]]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_ec_range",
+    "recommend_ec_adjustment",
+    "recommended_ec_setpoint",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return all plant types with EC guidelines."""
+    return sorted(_DATA.keys())
+
+
+def get_ec_range(plant_type: str, stage: str | None = None) -> list[float]:
+    """Return EC range for ``plant_type`` and ``stage`` if available."""
+    data = _DATA.get(plant_type.lower())
+    if not data:
+        return []
+    if stage and stage in data:
+        rng = data[stage]
+    else:
+        rng = data.get("optimal")
+    if isinstance(rng, Iterable):
+        values = list(rng)
+        if len(values) == 2:
+            return [float(values[0]), float(values[1])]
+    return []
+
+
+def recommend_ec_adjustment(
+    current_ec: float, plant_type: str, stage: str | None = None
+) -> str | None:
+    """Return 'increase' or 'decrease' recommendation for EC."""
+    if current_ec <= 0:
+        raise ValueError("current_ec must be positive")
+    target = get_ec_range(plant_type, stage)
+    if not target:
+        return None
+    low, high = target
+    if current_ec < low:
+        return "increase"
+    if current_ec > high:
+        return "decrease"
+    return None
+
+
+def recommended_ec_setpoint(
+    plant_type: str, stage: str | None = None
+) -> float | None:
+    """Return midpoint EC setpoint for a plant stage if available."""
+    rng = get_ec_range(plant_type, stage)
+    if not rng:
+        return None
+    return round((rng[0] + rng[1]) / 2, 2)

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, asdict
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
 from .utils import load_dataset
-from . import ph_manager
+from . import ph_manager, ec_manager
 
 DATA_FILE = "environment_guidelines.json"
 DLI_DATA_FILE = "light_dli_guidelines.json"
@@ -90,6 +90,8 @@ class EnvironmentOptimization:
     metrics: EnvironmentMetrics
     ph_setpoint: float | None = None
     ph_action: str | None = None
+    ec_setpoint: float | None = None
+    ec_action: str | None = None
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -100,6 +102,8 @@ class EnvironmentOptimization:
             "heat_index_c": self.metrics.heat_index_c,
             "ph_setpoint": self.ph_setpoint,
             "ph_action": self.ph_action,
+            "ec_setpoint": self.ec_setpoint,
+            "ec_action": self.ec_action,
         }
 
 
@@ -379,11 +383,19 @@ def optimize_environment(
     if "ph" in current and ph_set is not None:
         ph_act = ph_manager.recommend_ph_adjustment(current["ph"], plant_type, stage)
 
+    # EC integration
+    ec_set = ec_manager.recommended_ec_setpoint(plant_type, stage)
+    ec_act = None
+    if "ec" in current and ec_set is not None:
+        ec_act = ec_manager.recommend_ec_adjustment(current["ec"], plant_type, stage)
+
     result = EnvironmentOptimization(
         setpoints,
         actions,
         metrics,
         ph_setpoint=ph_set,
         ph_action=ph_act,
+        ec_setpoint=ec_set,
+        ec_action=ec_act,
     )
     return result.as_dict()

--- a/tests/test_ec_manager.py
+++ b/tests/test_ec_manager.py
@@ -1,0 +1,23 @@
+import pytest
+
+from plant_engine import ec_manager
+
+
+def test_get_ec_range():
+    rng = ec_manager.get_ec_range("citrus", "seedling")
+    assert rng == [1.0, 1.2]
+    assert ec_manager.get_ec_range("unknown") == []
+
+
+def test_recommend_ec_adjustment():
+    assert ec_manager.recommend_ec_adjustment(0.8, "citrus", "seedling") == "increase"
+    assert ec_manager.recommend_ec_adjustment(1.3, "citrus", "seedling") == "decrease"
+    assert ec_manager.recommend_ec_adjustment(1.1, "citrus", "seedling") is None
+    with pytest.raises(ValueError):
+        ec_manager.recommend_ec_adjustment(-1, "citrus")
+
+
+def test_recommended_ec_setpoint():
+    assert ec_manager.recommended_ec_setpoint("citrus", "seedling") == 1.1
+    assert ec_manager.recommended_ec_setpoint("unknown") is None
+

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -108,7 +108,7 @@ def test_relative_humidity_from_dew_point():
 
 def test_optimize_environment():
     result = optimize_environment(
-        {"temp_c": 18, "humidity_pct": 90},
+        {"temp_c": 18, "humidity_pct": 90, "ec": 2.5},
         "citrus",
         "seedling",
     )
@@ -119,14 +119,17 @@ def test_optimize_environment():
     assert round(result["heat_index_c"], 1) == round(calculate_heat_index(18, 90), 1)
     assert result["ph_setpoint"] == 6.0
     assert result["ph_action"] is None
+    assert result["ec_setpoint"] == 1.1
+    assert result["ec_action"] == "decrease"
 
     result2 = optimize_environment(
-        {"temp_c": 18, "humidity_pct": 90, "ph": 7.2},
+        {"temp_c": 18, "humidity_pct": 90, "ph": 7.2, "ec": 1.1},
         "citrus",
         "seedling",
     )
     assert result2["ph_setpoint"] == 6.0
     assert result2["ph_action"] == "decrease"
+    assert result2["ec_action"] is None
 
 
 def test_calculate_environment_metrics():


### PR DESCRIPTION
## Summary
- add EC guideline dataset
- implement `ec_manager` for EC range recommendations
- extend environment optimization to include EC adjustments
- expose EC helpers in package
- test EC logic and integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed9f0955c8330aa4a4ed155f46352