### PR TITLE
Enhance fertigation utilities and datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Dynamic Tags**: Tag plants (e.g. `"blueberry"`, `"fruiting"`) to generate grouped dashboards.
 - **Nutrient Mix Helper**: The `recommend_nutrient_mix` function computes exact
   fertilizer grams needed to hit N/P/K targets using the built-in purity data.
+- **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
+  ppm guidelines and irrigation volume into milligrams of nutrients consumed
+  each day.
 
 
 ### Automation Blueprint Guide

--- a/data/disease_guidelines.json
+++ b/data/disease_guidelines.json
@@ -34,5 +34,9 @@
   "arugula": {
     "downy mildew": "Ensure good air circulation and avoid overhead watering.",
     "leaf spot": "Remove affected leaves and avoid excess moisture."
+  },
+  "blueberry": {
+    "mummy berry": "Remove mummified fruit and apply fungicide early.",
+    "botrytis": "Prune for airflow and remove infected berries."
   }
 }

--- a/data/environment_guidelines.json
+++ b/data/environment_guidelines.json
@@ -310,5 +310,13 @@
       "light_ppfd": [150, 250],
       "co2_ppm": [400, 800]
     }
+  },
+  "blueberry": {
+    "optimal": {
+      "temp_c": [18, 26],
+      "humidity_pct": [60, 80],
+      "light_ppfd": [200, 400],
+      "co2_ppm": [500, 900]
+    }
   }
 }

--- a/data/growth_stages.json
+++ b/data/growth_stages.json
@@ -115,5 +115,10 @@
     "germination": {"duration_days": 7, "notes": "Keep moist until emergence."},
     "vegetative": {"duration_days": 25, "notes": "Rapid leaf growth."},
     "harvest": {"duration_days": 15, "notes": "Harvest young leaves for best flavor."}
+  },
+  "blueberry": {
+    "vegetative": {"duration_days": 60, "notes": "Focus on cane development."},
+    "flowering": {"duration_days": 20, "notes": "Monitor for frost damage."},
+    "fruiting": {"duration_days": 40, "notes": "Maintain soil acidity."}
   }
 }

--- a/data/nutrient_guidelines.json
+++ b/data/nutrient_guidelines.json
@@ -130,5 +130,9 @@
   "arugula": {
     "vegetative": {"N": 80, "P": 30, "K": 120, "Ca": 40, "Mg": 15},
     "harvest": {"N": 60, "P": 25, "K": 100, "Ca": 40, "Mg": 15}
+  },
+  "blueberry": {
+    "vegetative": {"N": 60, "P": 20, "K": 50, "Ca": 30, "Mg": 15},
+    "fruiting": {"N": 40, "P": 30, "K": 80, "Ca": 40, "Mg": 20}
   }
 }

--- a/data/pest_guidelines.json
+++ b/data/pest_guidelines.json
@@ -34,5 +34,9 @@
   "arugula": {
     "flea beetles": "Use row covers and apply neem if needed.",
     "aphids": "Use insecticidal soap or introduce ladybugs."
+  },
+  "blueberry": {
+    "fruitworms": "Apply Bacillus thuringiensis when larvae appear.",
+    "spotted wing drosophila": "Use traps and pick fruit frequently."
   }
 }

--- a/data/pest_thresholds.json
+++ b/data/pest_thresholds.json
@@ -18,5 +18,9 @@
   "spinach": {
     "aphids": 5,
     "leaf miners": 2
+  },
+  "blueberry": {
+    "fruitworms": 2,
+    "spotted wing drosophila": 1
   }
 }

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -37,6 +37,7 @@ __all__ = [
     "recommend_correction_schedule",
     "recommend_batch_fertigation",
     "recommend_nutrient_mix",
+    "estimate_daily_nutrient_uptake",
 ]
 
 
@@ -243,4 +244,26 @@ def recommend_nutrient_mix(
         schedule[fert] = round(grams_fert, 3)
 
     return schedule
+
+
+def estimate_daily_nutrient_uptake(
+    plant_type: str,
+    stage: str,
+    daily_water_ml: float,
+) -> Dict[str, float]:
+    """Return estimated nutrient uptake per day in milligrams.
+
+    The calculation multiplies recommended ppm values by the amount of
+    irrigation water used each day (in milliliters).
+    """
+
+    if daily_water_ml < 0:
+        raise ValueError("daily_water_ml must be non-negative")
+
+    targets = get_recommended_levels(plant_type, stage)
+    liters = daily_water_ml / 1000
+    uptake: Dict[str, float] = {}
+    for nutrient, ppm in targets.items():
+        uptake[nutrient] = round(ppm * liters, 2)
+    return uptake
 

--- a/tests/test_dataset_integration.py
+++ b/tests/test_dataset_integration.py
@@ -18,12 +18,14 @@ def test_list_supported_plants():
     assert "cucumber" in plants
     assert "pepper" in plants
     assert "arugula" in plants
+    assert "blueberry" in plants
 
     pest_plants = pest_manager.list_supported_plants()
     assert "lettuce" in pest_plants
     assert "cucumber" in pest_plants
     assert "pepper" in pest_plants
     assert "arugula" in pest_plants
+    assert "blueberry" in pest_plants
 
     disease_plants = disease_manager.list_supported_plants()
     assert "lettuce" in disease_plants
@@ -33,6 +35,7 @@ def test_list_supported_plants():
     assert "cucumber" in disease_plants
     assert "pepper" in disease_plants
     assert "arugula" in disease_plants
+    assert "blueberry" in disease_plants
 
     purity = fertigation.get_fertilizer_purity("map")
     assert purity["P"] == 0.22
@@ -59,6 +62,9 @@ def test_list_supported_plants():
     aru_env = environment_manager.get_environmental_targets("arugula")
     assert aru_env["temp_c"] == [15, 22]
 
+    blue_env = environment_manager.get_environmental_targets("blueberry")
+    assert blue_env["humidity_pct"] == [60, 80]
+
 
 def test_lettuce_stage_info():
     stages = growth_stage.list_growth_stages("lettuce")
@@ -77,6 +83,9 @@ def test_lettuce_stage_info():
 
     aru_info = growth_stage.get_stage_info("arugula", "vegetative")
     assert aru_info["duration_days"] == 25
+
+    blue_info = growth_stage.get_stage_info("blueberry", "fruiting")
+    assert blue_info["duration_days"] == 40
 
 
 def test_nutrient_guidelines_lettuce():
@@ -100,6 +109,9 @@ def test_nutrient_guidelines_lettuce():
 
     aru_levels = nutrient_manager.get_recommended_levels("arugula", "vegetative")
     assert aru_levels["K"] == 120
+
+    blue_levels = nutrient_manager.get_recommended_levels("blueberry", "vegetative")
+    assert blue_levels["N"] == 60
 
 
 def test_treatment_guidelines_lettuce():
@@ -136,6 +148,9 @@ def test_treatment_guidelines_lettuce():
     aru_pests = pest_manager.recommend_treatments("arugula", ["flea beetles"])
     assert aru_pests["flea beetles"].startswith("Use row covers")
 
+    blue_pests = pest_manager.recommend_treatments("blueberry", ["fruitworms"])
+    assert "bacillus" in blue_pests["fruitworms"].lower()
+
     cuc_dis = disease_manager.recommend_treatments("cucumber", ["bacterial wilt"])
     assert "beetles" in cuc_dis["bacterial wilt"].lower()
 
@@ -144,3 +159,6 @@ def test_treatment_guidelines_lettuce():
 
     aru_dis = disease_manager.recommend_treatments("arugula", ["leaf spot"])
     assert "excess moisture" in aru_dis["leaf spot"].lower()
+
+    blue_dis = disease_manager.recommend_treatments("blueberry", ["mummy berry"])
+    assert "mummified" in blue_dis["mummy berry"].lower()

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -6,6 +6,7 @@ from plant_engine.fertigation import (
     get_fertilizer_purity,
     recommend_batch_fertigation,
     recommend_nutrient_mix,
+    estimate_daily_nutrient_uptake,
 )
 
 
@@ -102,5 +103,13 @@ def test_recommend_fertigation_with_water():
     assert round(schedule["N"], 2) == 0.8
     assert round(schedule["P"], 2) == 0.5
     assert round(schedule["K"], 2) == 0.7
+
+
+def test_estimate_daily_nutrient_uptake():
+    uptake = estimate_daily_nutrient_uptake(
+        "tomato", "vegetative", daily_water_ml=2000.0
+    )
+    assert uptake["N"] == pytest.approx(200.0)
+    assert uptake["P"] == pytest.approx(100.0)
 
 


### PR DESCRIPTION
## Summary
- add new `estimate_daily_nutrient_uptake` helper
- document new helper in README
- expand datasets with blueberry crop information
- cover blueberry data in dataset integration tests
- test new fertigation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edc15bfbc83308d84202700bc2b0c