### PR TITLE
Improve environment utilities and daily reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Key reference datasets reside in the `data/` directory:
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `fertilizer_purity.json` – default purity factors for common fertilizers
 - `nutrient_deficiency_treatments.json` – remedies for common nutrient shortages
+- `growth_stages.json` – lifecycle stage durations and notes by crop
 - `yield/` – per‑plant yield logs created during operation
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -18,6 +18,7 @@ from plant_engine.environment_manager import (
     score_environment,
     optimize_environment,
     calculate_environment_metrics,
+    compare_environment,
 )
 
 
@@ -212,3 +213,16 @@ def test_calculate_dli_series():
         calculate_dli_series([-1, 100])
     with pytest.raises(ValueError):
         calculate_dli_series([100], 0)
+
+
+def test_compare_environment():
+    targets = {"temp_c": [18, 22], "humidity_pct": [60, 80]}
+    current = {"temperature": 20, "humidity": 70}
+    result = compare_environment(current, targets)
+    assert result["temp_c"] == "within range"
+    assert result["humidity_pct"] == "within range"
+
+    off = {"temp": 30, "rh": 40}
+    result2 = compare_environment(off, targets)
+    assert result2["temp_c"] == "above range"
+    assert result2["humidity_pct"] == "below range"


### PR DESCRIPTION
## Summary
- document growth stage data in README
- add `compare_environment` helper in `environment_manager`
- refactor daily cycle report to use new helper and load datasets via `load_dataset`
- create tests for `compare_environment`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edc138df88330bfcc1306d0cbedc2