### PR TITLE
Refactor dataset key normalization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -6,7 +6,7 @@ import math
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 from . import ph_manager
 
 DATA_FILE = "environment_guidelines.json"
@@ -67,9 +67,6 @@ _DLI_DATA: Dict[str, Any] = load_dataset(DLI_DATA_FILE)
 _VPD_DATA: Dict[str, Any] = load_dataset(VPD_DATA_FILE)
 
 
-def _norm(key: str) -> str:
-    """Normalize keys for case-insensitive lookups."""
-    return key.lower()
 
 
 def saturation_vapor_pressure(temp_c: float) -> float:
@@ -137,9 +134,9 @@ def get_environmental_targets(
     plant_type: str, stage: str | None = None
 ) -> Dict[str, Any]:
     """Return recommended environmental ranges for a plant type and stage."""
-    data = _DATA.get(_norm(plant_type), {})
+    data = _DATA.get(normalize_key(plant_type), {})
     if stage:
-        stage = _norm(stage)
+        stage = normalize_key(stage)
         if stage in data:
             return data[stage]
     return data.get("optimal", {})
@@ -414,9 +411,9 @@ def calculate_dli_series(ppfd_values: Iterable[float], interval_hours: float = 1
 
 def get_target_dli(plant_type: str, stage: str | None = None) -> tuple[float, float] | None:
     """Return recommended DLI range for ``plant_type`` and ``stage`` if available."""
-    data = _DLI_DATA.get(_norm(plant_type), {})
+    data = _DLI_DATA.get(normalize_key(plant_type), {})
     if stage:
-        stage = _norm(stage)
+        stage = normalize_key(stage)
         if stage in data:
             vals = data[stage]
             if len(vals) == 2:
@@ -429,9 +426,9 @@ def get_target_dli(plant_type: str, stage: str | None = None) -> tuple[float, fl
 
 def get_target_vpd(plant_type: str, stage: str | None = None) -> tuple[float, float] | None:
     """Return recommended VPD range for ``plant_type`` and ``stage`` if available."""
-    data = _VPD_DATA.get(_norm(plant_type), {})
+    data = _VPD_DATA.get(normalize_key(plant_type), {})
     if stage:
-        stage = _norm(stage)
+        stage = normalize_key(stage)
         if stage in data:
             vals = data[stage]
             if len(vals) == 2:

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, Any
 from datetime import date, timedelta
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "growth_stages.json"
 
@@ -15,9 +15,6 @@ DATA_FILE = "growth_stages.json"
 _DATA: Dict[str, Dict[str, Any]] = load_dataset(DATA_FILE)
 
 
-def _norm(key: str) -> str:
-    """Normalize keys for case-insensitive lookups."""
-    return key.lower()
 
 __all__ = [
     "get_stage_info",
@@ -30,12 +27,12 @@ __all__ = [
 
 def get_stage_info(plant_type: str, stage: str) -> Dict[str, Any]:
     """Return information about a particular growth stage."""
-    return _DATA.get(_norm(plant_type), {}).get(_norm(stage), {})
+    return _DATA.get(normalize_key(plant_type), {}).get(normalize_key(stage), {})
 
 
 def list_growth_stages(plant_type: str) -> list[str]:
     """Return all defined growth stages for a plant type."""
-    return sorted(_DATA.get(_norm(plant_type), {}).keys())
+    return sorted(_DATA.get(normalize_key(plant_type), {}).keys())
 
 
 def get_stage_duration(plant_type: str, stage: str) -> int | None:
@@ -59,7 +56,7 @@ def estimate_stage_from_age(plant_type: str, days_since_start: int) -> str | Non
     if days_since_start < 0:
         raise ValueError("days_since_start must be non-negative")
 
-    stages = _DATA.get(_norm(plant_type))
+    stages = _DATA.get(normalize_key(plant_type))
     if not isinstance(stages, dict):
         return None
 
@@ -76,7 +73,7 @@ def estimate_stage_from_age(plant_type: str, days_since_start: int) -> str | Non
 
 def predict_harvest_date(plant_type: str, start_date: date) -> date | None:
     """Return estimated harvest date based on growth stage durations."""
-    stages = _DATA.get(_norm(plant_type))
+    stages = _DATA.get(normalize_key(plant_type))
     if not isinstance(stages, dict):
         return None
 

--- a/plant_engine/micro_manager.py
+++ b/plant_engine/micro_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Mapping
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "micronutrient_guidelines.json"
 
@@ -17,11 +17,6 @@ __all__ = [
 ]
 
 
-def _norm(key: str) -> str:
-    """Normalize a key for case-insensitive lookup."""
-    return key.lower()
-
-
 def list_supported_plants() -> list[str]:
     """Return plants with micronutrient guidelines."""
     return sorted(_DATA.keys())
@@ -29,10 +24,10 @@ def list_supported_plants() -> list[str]:
 
 def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
     """Return recommended micronutrient levels."""
-    plant = _DATA.get(_norm(plant_type))
+    plant = _DATA.get(normalize_key(plant_type))
     if not plant:
         return {}
-    return plant.get(_norm(stage), {})
+    return plant.get(normalize_key(stage), {})
 
 
 def calculate_deficiencies(

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict
 
-__all__ = ["load_json", "save_json", "load_dataset"]
+__all__ = ["load_json", "save_json", "load_dataset", "normalize_key"]
 
 
 def load_json(path: str) -> Dict[str, Any]:
@@ -42,3 +42,8 @@ def load_dataset(filename: str) -> Dict[str, Any]:
     if not path.exists():
         return {}
     return load_json(str(path))
+
+
+def normalize_key(key: str) -> str:
+    """Return ``key`` normalized for case-insensitive dataset lookups."""
+    return str(key).lower().replace(" ", "_")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pytest
+
+from plant_engine.utils import normalize_key
+
+
+def test_normalize_key_lowercase():
+    assert normalize_key("Hello") == "hello"
+
+
+def test_normalize_key_spaces_replaced():
+    assert normalize_key("My Plant") == "my_plant"
+
+
+def test_normalize_key_non_string():
+    assert normalize_key(123) == "123"


### PR DESCRIPTION
## Summary
- centralize dataset key normalization in new `normalize_key` helper
- refactor growth, micro and environment modules to use `normalize_key`
- cover the new helper with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8cfef9948330aa7458e86ba27b6e