### PR TITLE
Add pruning guidelines and manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Key reference datasets reside in the `data/` directory:
 - `fertilizer_purity.json` – default purity factors for common fertilizers
 - `nutrient_deficiency_treatments.json` – remedies for common nutrient shortages
 - `growth_stages.json` – lifecycle stage durations and notes by crop
+- `pruning_guidelines.json` – stage-specific pruning recommendations
 - `yield/` – per‑plant yield logs created during operation
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
@@ -168,6 +169,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.
+- **Pruning Recommendations**: Call `get_pruning_instructions` for stage-specific
+  pruning tips loaded from `pruning_guidelines.json`.
 
 
 ### Automation Blueprint Guide

--- a/data/pruning_guidelines.json
+++ b/data/pruning_guidelines.json
@@ -1,0 +1,12 @@
+{
+  "tomato": {
+    "vegetative": "Remove side shoots (suckers) weekly to promote strong stems and airflow.",
+    "fruiting": "Prune lower leaves and excess foliage to improve light penetration."
+  },
+  "citrus": {
+    "dormant": "Remove dead or crossing branches and shape the canopy."
+  },
+  "strawberry": {
+    "post-harvest": "Trim runners and old leaves to encourage new growth."
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -67,6 +67,11 @@ from .yield_manager import (
     record_harvest,
     get_total_yield,
 )
+from .pruning_manager import (
+    list_supported_plants as list_pruning_plants,
+    list_stages as list_pruning_stages,
+    get_pruning_instructions,
+)
 from .water_quality import (
     list_analytes as list_water_analytes,
     get_threshold as get_water_threshold,
@@ -135,5 +140,8 @@ __all__ = [
     "list_ph_plants",
     "get_ph_range",
     "recommend_ph_adjustment",
+    "list_pruning_plants",
+    "list_pruning_stages",
+    "get_pruning_instructions",
     "TranspirationMetrics",
 ]

--- a/plant_engine/pruning_manager.py
+++ b/plant_engine/pruning_manager.py
@@ -1,0 +1,35 @@
+"""Pruning guideline helpers."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "pruning_guidelines.json"
+
+# Loaded once via load_dataset which uses caching
+_DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "list_stages",
+    "get_pruning_instructions",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return all plant types with pruning data."""
+    return sorted(_DATA.keys())
+
+
+def list_stages(plant_type: str) -> list[str]:
+    """Return available pruning stages for ``plant_type``."""
+    return sorted(_DATA.get(normalize_key(plant_type), {}).keys())
+
+
+def get_pruning_instructions(plant_type: str, stage: str) -> str:
+    """Return pruning instructions for a plant type and stage."""
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return ""
+    return plant.get(normalize_key(stage), "")

--- a/tests/test_pruning_manager.py
+++ b/tests/test_pruning_manager.py
@@ -1,0 +1,23 @@
+from plant_engine.pruning_manager import (
+    list_supported_plants,
+    list_stages,
+    get_pruning_instructions,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+    assert "citrus" in plants
+
+
+def test_list_stages():
+    stages = list_stages("tomato")
+    assert "vegetative" in stages
+    assert "fruiting" in stages
+
+
+def test_get_pruning_instructions():
+    instr = get_pruning_instructions("tomato", "vegetative")
+    assert instr.startswith("Remove side shoots")
+    assert get_pruning_instructions("unknown", "stage") == ""


### PR DESCRIPTION
## Summary
- add new `pruning_guidelines.json` dataset
- implement `pruning_manager` helper module
- expose pruning helpers from package init
- document dataset and helper usage in README
- cover pruning manager with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f925121b0833082dd7b298df477cb