### PR TITLE
Improve nutrient dataset handling and add uptake totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.
+- **Total Uptake Estimation**: `estimate_total_uptake` multiplies daily uptake
+  by growth stage durations from `growth_stages.json` to calculate nutrients
+  required for an entire crop cycle.
 
 
 ### Automation Blueprint Guide

--- a/plant_engine/disease_manager.py
+++ b/plant_engine/disease_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "disease_guidelines.json"
 
@@ -20,7 +20,7 @@ def list_supported_plants() -> list[str]:
 
 def get_disease_guidelines(plant_type: str) -> Dict[str, str]:
     """Return disease management guidelines for the specified plant type."""
-    return _DATA.get(plant_type, {})
+    return _DATA.get(normalize_key(plant_type), {})
 
 
 def recommend_treatments(plant_type: str, diseases: Iterable[str]) -> Dict[str, str]:

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "nutrient_guidelines.json"
 
@@ -33,10 +33,10 @@ def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
     Parameters are matched case-insensitively. An empty dictionary is returned
     if no guidelines exist for the provided keys.
     """
-    plant = _DATA.get(plant_type.lower())
+    plant = _DATA.get(normalize_key(plant_type))
     if not plant:
         return {}
-    return plant.get(stage.lower(), {})
+    return plant.get(normalize_key(stage), {})
 
 
 def calculate_deficiencies(

--- a/plant_engine/nutrient_uptake.py
+++ b/plant_engine/nutrient_uptake.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .utils import load_dataset
+from .growth_stage import get_stage_duration
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "nutrient_uptake.json"
 
 _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 
-__all__ = ["list_supported_plants", "get_daily_uptake"]
+__all__ = [
+    "list_supported_plants",
+    "get_daily_uptake",
+    "estimate_total_uptake",
+]
 
 
 def list_supported_plants() -> list[str]:
@@ -18,8 +23,27 @@ def list_supported_plants() -> list[str]:
 
 
 def get_daily_uptake(plant_type: str, stage: str) -> Dict[str, float]:
-    """Return mg/day uptake for ``plant_type`` and ``stage``."""
-    plant = _DATA.get(plant_type.lower())
+    """Return mg/day nutrient uptake for ``plant_type`` and ``stage``."""
+
+    plant = _DATA.get(normalize_key(plant_type))
     if not plant:
         return {}
-    return plant.get(stage.lower(), {})
+    return plant.get(normalize_key(stage), {})
+
+
+def estimate_total_uptake(plant_type: str) -> Dict[str, float]:
+    """Return total nutrient uptake (mg) over the full growth cycle."""
+
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return {}
+
+    totals: Dict[str, float] = {}
+    for stage, daily in plant.items():
+        days = get_stage_duration(plant_type, stage)
+        if not days:
+            continue
+        for nutrient, mg_per_day in daily.items():
+            totals[nutrient] = totals.get(nutrient, 0.0) + mg_per_day * days
+
+    return {k: round(v, 2) for k, v in totals.items()}

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
@@ -22,7 +22,7 @@ def list_supported_plants() -> list[str]:
 
 def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
     """Return pest management guidelines for the specified plant type."""
-    return _DATA.get(plant_type, {})
+    return _DATA.get(normalize_key(plant_type), {})
 
 
 def recommend_treatments(plant_type: str, pests: Iterable[str]) -> Dict[str, str]:

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, Mapping
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 from .pest_manager import recommend_treatments
 
 DATA_FILE = "pest_thresholds.json"
@@ -21,7 +21,7 @@ __all__ = [
 
 def get_pest_thresholds(plant_type: str) -> Dict[str, int]:
     """Return pest count thresholds for ``plant_type``."""
-    return _THRESHOLDS.get(plant_type, {})
+    return _THRESHOLDS.get(normalize_key(plant_type), {})
 
 
 def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:
@@ -29,7 +29,7 @@ def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Di
     thresholds = get_pest_thresholds(plant_type)
     pressure: Dict[str, bool] = {}
     for pest, count in observations.items():
-        thresh = thresholds.get(pest)
+        thresh = thresholds.get(normalize_key(pest))
         if thresh is None:
             continue
         pressure[pest] = count >= thresh

--- a/plant_engine/ph_manager.py
+++ b/plant_engine/ph_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "ph_guidelines.json"
 
@@ -25,12 +25,15 @@ def list_supported_plants() -> list[str]:
 
 def get_ph_range(plant_type: str, stage: str | None = None) -> list[float]:
     """Return pH range for ``plant_type`` and ``stage``."""
-    data = _DATA.get(plant_type.lower())
+    data = _DATA.get(normalize_key(plant_type))
     if not data:
         return []
-    if stage and stage in data:
-        rng = data[stage]
+    if stage:
+        stage = normalize_key(stage)
+        rng = data.get(stage)
     else:
+        rng = None
+    if rng is None:
         rng = data.get("optimal")
     if isinstance(rng, Iterable):
         values = list(rng)

--- a/tests/test_nutrient_uptake.py
+++ b/tests/test_nutrient_uptake.py
@@ -1,6 +1,10 @@
 import pytest
 
-from plant_engine.nutrient_uptake import list_supported_plants, get_daily_uptake
+from plant_engine.nutrient_uptake import (
+    list_supported_plants,
+    get_daily_uptake,
+    estimate_total_uptake,
+)
 from plant_engine.fertigation import recommend_uptake_fertigation
 
 
@@ -8,6 +12,11 @@ def test_get_daily_uptake():
     uptake = get_daily_uptake("lettuce", "vegetative")
     assert uptake["N"] == 60
     assert uptake["K"] == 80
+
+
+def test_get_daily_uptake_case_insensitive():
+    uptake = get_daily_uptake("LeTtUcE", "VeGeTaTiVe")
+    assert uptake["P"] == 20
 
 
 def test_list_supported_plants():
@@ -20,3 +29,10 @@ def test_recommend_uptake_fertigation():
     assert schedule["urea"] == pytest.approx((60*2)/1000/0.46, rel=1e-2)
     assert schedule["map"] == pytest.approx((20*2)/1000/0.22, rel=1e-2)
     assert schedule["kcl"] == pytest.approx((80*2)/1000/0.5, rel=1e-2)
+
+
+def test_estimate_total_uptake():
+    totals = estimate_total_uptake("lettuce")
+    assert totals["N"] == 3600
+    assert totals["P"] == 1150
+    assert totals["K"] == 4900


### PR DESCRIPTION
## Summary
- normalize plant type lookups across managers
- expose new `estimate_total_uptake` API for nutrient demand over a crop cycle
- add test coverage for the new function and case-insensitive uptake queries
- document total uptake estimation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f927887d0833086d979752eb9b027