### PR TITLE
Add integrated pest management planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.
+- **Pest Management Plans**: The `recommend_ipm_plan` helper provides
+  threshold-aware treatment suggestions along with beneficial insects to deploy
+  for common pests.
 
 
 ### Automation Blueprint Guide

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -2,6 +2,7 @@ from plant_engine.pest_monitor import (
     get_pest_thresholds,
     assess_pest_pressure,
     recommend_threshold_actions,
+    recommend_ipm_plan,
 )
 
 
@@ -22,3 +23,11 @@ def test_recommend_threshold_actions():
     actions = recommend_threshold_actions("citrus", obs)
     assert "aphids" in actions
     assert "scale" in actions
+
+
+def test_recommend_ipm_plan():
+    obs = {"aphids": 6, "scale": 3}
+    plan = recommend_ipm_plan("citrus", obs)
+    assert "aphids" in plan
+    assert "beneficials" in plan["aphids"]
+    assert plan["aphids"]["treatment"]


### PR DESCRIPTION
## Summary
- expand pest monitor utilities with a new `recommend_ipm_plan` helper
- add corresponding unit tests
- document pest management planner in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f92c9f4a08330b1ec4d606fb75184