### PR TITLE
Enhance daily cycle reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ or incomplete and should only be used as a starting point for your own research.
   each day.
 - **Pruning Recommendations**: Call `get_pruning_instructions` for stage-specific
   pruning tips loaded from `pruning_guidelines.json`.
+- **Beneficial Insect Suggestions**: Daily reports list natural predators for
+  observed pests using `beneficial_insects.json`.
+- **Harvest Date Prediction**: If plant profiles include a `start_date`, daily
+  reports provide an estimated harvest date based on `growth_stages.json`.
 
 
 ### Automation Blueprint Guide

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -15,6 +15,8 @@ from custom_components.horticulture_assistant.utils.plant_profile_loader import 
     load_profile_by_id,
 )
 from plant_engine.environment_manager import compare_environment
+from plant_engine.growth_stage import predict_harvest_date
+from plant_engine.pest_manager import recommend_beneficials
 from plant_engine.utils import load_dataset
 from plant_engine.rootzone_model import estimate_water_capacity
 
@@ -159,6 +161,20 @@ def run_daily_cycle(plant_id: str, base_path: str = "plants", output_path: str =
         disease_actions[disease] = action
     report["pest_actions"] = pest_actions
     report["disease_actions"] = disease_actions
+    # Suggest beneficial insects for observed pests
+    if observed_pests:
+        report["beneficial_insects"] = recommend_beneficials(observed_pests)
+
+    # Predict harvest date if a start date is provided
+    start_date_str = general.get("start_date")
+    if start_date_str:
+        try:
+            start_date = datetime.fromisoformat(start_date_str).date()
+            harvest = predict_harvest_date(general.get("plant_type", ""), start_date)
+            if harvest:
+                report["predicted_harvest_date"] = harvest.isoformat()
+        except Exception:  # noqa: broad-except -- ignore parse errors
+            pass
     # Calculate root zone water metrics (TAW, MAD, current moisture)
     root_depth_cm = general.get("max_root_depth_cm", 30.0)
     try:

--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -1,0 +1,29 @@
+import json
+from custom_components.horticulture_assistant.engine.run_daily_cycle import run_daily_cycle
+
+
+def test_run_daily_cycle_extended(tmp_path):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    out_dir = tmp_path / "reports"
+
+    plant_path = plants_dir / "sample.json"
+    plant_path.write_text(
+        json.dumps(
+            {
+                "general": {
+                    "plant_type": "tomato",
+                    "lifecycle_stage": "vegetative",
+                    "start_date": "2025-01-01",
+                    "observed_pests": ["aphids"],
+                    "observed_diseases": []
+                }
+            }
+        )
+    )
+
+    report = run_daily_cycle("sample", base_path=str(plants_dir), output_path=str(out_dir))
+
+    assert report["beneficial_insects"]["aphids"][0] == "ladybugs"
+    assert report["predicted_harvest_date"] == "2025-05-01"
+    assert (out_dir / f"sample_{report['timestamp'][:10]}.json").exists()


### PR DESCRIPTION
## Summary
- extend daily report generation to suggest beneficial insects and predict harvest date
- document new features in README
- test daily cycle extensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa47469ec8330b09095aa7b8df969