### PR TITLE
Refactor CLI scripts and add env override

### DIFF
--- a/plant_engine/nutrient_efficiency.py
+++ b/plant_engine/nutrient_efficiency.py
@@ -1,9 +1,14 @@
+"""Calculate nutrient use efficiency from application and yield logs."""
+
 import os
 import json
 from typing import Dict
 
-NUTRIENT_DIR = "data/nutrients_applied"
-YIELD_DIR = "data/yield"
+# Default storage locations can be overridden with environment variables. This
+# makes the module more flexible for testing and deployment scenarios where the
+# repository's ``data`` directory is not writable.
+NUTRIENT_DIR = os.getenv("HORTICULTURE_NUTRIENT_DIR", "data/nutrients_applied")
+YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 
 def calculate_nue(plant_id: str) -> Dict:
     """

--- a/scripts/et_model.py
+++ b/scripts/et_model.py
@@ -1,46 +1,31 @@
-import math
-from typing import Optional
+"""CLI wrapper around :mod:`plant_engine.et_model`."""
 
-def calculate_et0(
-    temperature_c: float,
-    rh_percent: float,
-    solar_rad_w_m2: float,
-    wind_m_s: Optional[float] = 1.0,
-    elevation_m: Optional[float] = 200
-) -> float:
-    """
-    Calculate ET₀ (reference evapotranspiration) using the FAO-56 Penman-Monteith equation approximation.
-    Based on air temp, RH, solar radiation, wind, elevation.
-    Returns ET₀ in mm/day.
-    """
+from __future__ import annotations
 
-    # Convert solar radiation to MJ/m²/day
-    solar_rad_mj = solar_rad_w_m2 * 0.0864
-
-    # Psychrometric constant (kPa/°C)
-    gamma = 0.665e-3 * (101.3 * ((293 - 0.0065 * elevation_m) / 293)**5.26)
-
-    # Saturation vapor pressure (kPa)
-    es = 0.6108 * math.exp((17.27 * temperature_c) / (temperature_c + 237.3))
-
-    # Actual vapor pressure
-    ea = es * (rh_percent / 100)
-
-    # Slope of vapor pressure curve (Δ) (kPa/°C)
-    delta = 4098 * es / ((temperature_c + 237.3)**2)
-
-    # Net radiation estimate (assuming albedo 0.23)
-    rn = 0.77 * solar_rad_mj  # MJ/m²/day
-
-    # ET₀ estimate
-    et0 = (
-        (0.408 * delta * rn) +
-        (gamma * 900 * wind_m_s * (es - ea) / (temperature_c + 273))
-    ) / (delta + gamma * (1 + 0.34 * wind_m_s))
-
-    return round(et0, 2)  # mm/day
+import argparse
+from plant_engine.et_model import calculate_et0, calculate_eta
 
 
-def calculate_eta(et0: float, kc: float = 1.0) -> float:
-    """Calculate Actual Evapotranspiration based on Kc coefficient."""
-    return round(et0 * kc, 2)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Calculate ET0 and ETA")
+    parser.add_argument("temperature_c", type=float)
+    parser.add_argument("rh_percent", type=float)
+    parser.add_argument("solar_rad_w_m2", type=float)
+    parser.add_argument("--wind", type=float, default=1.0)
+    parser.add_argument("--elevation", type=float, default=200)
+    parser.add_argument("--kc", type=float, default=1.0)
+    args = parser.parse_args()
+
+    et0 = calculate_et0(
+        args.temperature_c,
+        args.rh_percent,
+        args.solar_rad_w_m2,
+        wind_m_s=args.wind,
+        elevation_m=args.elevation,
+    )
+    eta = calculate_eta(et0, args.kc)
+    print({"et0_mm_day": et0, "eta_mm_day": eta})
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/growth_model.py
+++ b/scripts/growth_model.py
@@ -1,48 +1,25 @@
+"""CLI helper using :func:`plant_engine.growth_model.update_growth_index`."""
+
+from __future__ import annotations
+
+import argparse
 import json
-import os
-from datetime import datetime
-from typing import Dict
+from plant_engine.growth_model import update_growth_index
 
-GROWTH_DIR = "data/growth"
-YIELD_DIR = "data/yield"
 
-def update_growth_index(plant_id: str, env_data: Dict, transpiration_ml: float) -> Dict:
-    """
-    Update the daily vegetative growth index (VGI) using ETa, PAR, and temp.
-    Returns updated VGI stats for the plant.
-    """
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update plant VGI")
+    parser.add_argument("plant_id")
+    parser.add_argument("environment", help="Environment JSON")
+    parser.add_argument("transpiration_ml", type=float)
+    args = parser.parse_args()
 
-    date_str = datetime.now().strftime("%Y-%m-%d")
-    gdd = max(0, ((env_data["temp_c_max"] + env_data["temp_c_min"]) / 2) - 10)
-    par_mj = env_data["par_w_m2"] * 0.0864  # Convert to MJ/m²/day
-    eta_factor = transpiration_ml / 1000  # Normalize to liters
+    with open(args.environment, "r", encoding="utf-8") as f:
+        env = json.load(f)
 
-    vgi_today = round(gdd * par_mj * eta_factor, 2)
+    result = update_growth_index(args.plant_id, env, args.transpiration_ml)
+    print(json.dumps(result, indent=2))
 
-    os.makedirs(GROWTH_DIR, exist_ok=True)
-    path = os.path.join(GROWTH_DIR, f"{plant_id}.json")
 
-    if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as f:
-            growth_data = json.load(f)
-    else:
-        growth_data = {}
-
-    growth_data[date_str] = {
-        "vgi": vgi_today,
-        "gdd": gdd,
-        "par": par_mj,
-        "et_liters": eta_factor
-    }
-
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(growth_data, f, indent=2)
-
-    cumulative_vgi = round(sum(day["vgi"] for day in growth_data.values()), 2)
-
-    return {
-        "plant_id": plant_id,
-        "vgi_today": vgi_today,
-        "vgi_total": cumulative_vgi,
-        "days_tracked": len(growth_data)
-    }
+if __name__ == "__main__":
+    main()

--- a/scripts/nutrient_efficiency.py
+++ b/scripts/nutrient_efficiency.py
@@ -1,47 +1,18 @@
-import os
-import json
-from typing import Dict
+"""Command line wrapper for :mod:`plant_engine.nutrient_efficiency`."""
 
-NUTRIENT_DIR = "data/nutrients_applied"
-YIELD_DIR = "data/yield"
+from __future__ import annotations
 
-def calculate_nue(plant_id: str) -> Dict:
-    """
-    Calculate Nutrient Use Efficiency (NUE) for all nutrients based on applied nutrients vs yield.
-    Returns NUE per nutrient as g yield per g nutrient applied.
-    """
+import argparse
+from plant_engine.nutrient_efficiency import calculate_nue
 
-    # Load total nutrients applied
-    path_nutrients = os.path.join(NUTRIENT_DIR, f"{plant_id}.json")
-    if not os.path.exists(path_nutrients):
-        raise FileNotFoundError(f"No nutrient record found for {plant_id}")
 
-    with open(path_nutrients, "r", encoding="utf-8") as f:
-        nutrient_log = json.load(f)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Calculate nutrient use efficiency")
+    parser.add_argument("plant_id", help="ID of the plant")
+    args = parser.parse_args()
+    result = calculate_nue(args.plant_id)
+    print(result)
 
-    total_applied_mg = {}
-    for entry in nutrient_log.get("records", []):
-        for k, v in entry["nutrients_mg"].items():
-            total_applied_mg[k] = total_applied_mg.get(k, 0) + v
 
-    # Load total yield
-    path_yield = os.path.join(YIELD_DIR, f"{plant_id}.json")
-    if not os.path.exists(path_yield):
-        raise FileNotFoundError(f"No yield record found for {plant_id}")
-
-    with open(path_yield, "r", encoding="utf-8") as f:
-        yield_data = json.load(f)
-
-    total_yield_g = sum(h["yield_grams"] for h in yield_data.get("harvests", []))
-
-    # Calculate NUE
-    nue = {}
-    for nutrient, mg in total_applied_mg.items():
-        g_applied = mg / 1000
-        nue[nutrient] = round(total_yield_g / g_applied, 2) if g_applied else None
-
-    return {
-        "plant_id": plant_id,
-        "total_yield_g": total_yield_g,
-        "nue": nue
-    }
+if __name__ == "__main__":
+    main()

--- a/scripts/rootzone_model.py
+++ b/scripts/rootzone_model.py
@@ -1,39 +1,28 @@
-from typing import Dict
-import math
+"""CLI wrapper for root zone calculations from :mod:`plant_engine.rootzone_model`."""
 
-DEFAULT_DENSITY = 1.2  # g/cm³ typical for loose potting mix
-DEFAULT_AREA_CM2 = 900  # ~30 cm x 30 cm surface area
+from __future__ import annotations
 
-def estimate_rootzone_depth(plant_profile: Dict, growth: Dict) -> float:
-    """
-    Estimate root depth (cm) using VGI or age-based growth curve.
-    Uses sigmoid: max_depth / (1 + e^(-k*(vgi - midpoint)))
-    """
-
-    max_depth_cm = plant_profile.get("max_root_depth_cm", 30)
-    growth_index = growth.get("vgi_total", 0)
-
-    # Sigmoid parameters
-    midpoint = 60
-    k = 0.08
-
-    depth = max_depth_cm / (1 + math.exp(-k * (growth_index - midpoint)))
-    return round(depth, 2)
+import argparse
+import json
+from plant_engine.rootzone_model import estimate_rootzone_depth, estimate_water_capacity
 
 
-def estimate_water_capacity(root_depth_cm: float, area_cm2: float = DEFAULT_AREA_CM2, bd: float = DEFAULT_DENSITY) -> Dict:
-    """
-    Estimate TAW, RAW, and MAD thresholds.
-    Assumes 20% volumetric water content at field capacity.
-    """
-    volume_cm3 = root_depth_cm * area_cm2
-    water_capacity_ml = volume_cm3 * 0.20  # 20% FC
-    taw = water_capacity_ml
-    raw = taw * 0.5  # MAD = 50%
-    return {
-        "root_depth_cm": root_depth_cm,
-        "root_volume_cm3": volume_cm3,
-        "total_available_water_ml": round(taw, 1),
-        "readily_available_water_ml": round(raw, 1),
-        "mad_pct": 0.5
-    }
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Estimate root zone parameters")
+    parser.add_argument("profile", help="Plant profile JSON")
+    parser.add_argument("growth", help="Growth stats JSON")
+    args = parser.parse_args()
+
+    with open(args.profile, "r", encoding="utf-8") as f:
+        profile = json.load(f)
+    with open(args.growth, "r", encoding="utf-8") as f:
+        growth = json.load(f)
+
+    depth = estimate_rootzone_depth(profile, growth)
+    zone = estimate_water_capacity(depth)
+    result = zone.to_dict()
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_nutrient_efficiency_env.py
+++ b/tests/test_nutrient_efficiency_env.py
@@ -1,0 +1,22 @@
+import importlib
+import json
+import os
+from pathlib import Path
+
+import plant_engine.nutrient_efficiency as ne
+
+
+def test_env_overrides(tmp_path, monkeypatch):
+    nutrient_dir = tmp_path / "nutes"
+    yield_dir = tmp_path / "yield"
+    nutrient_dir.mkdir()
+    yield_dir.mkdir()
+    (nutrient_dir / "foo.json").write_text(json.dumps({"records": []}))
+    (yield_dir / "foo.json").write_text(json.dumps({"harvests": []}))
+
+    monkeypatch.setenv("HORTICULTURE_NUTRIENT_DIR", str(nutrient_dir))
+    monkeypatch.setenv("HORTICULTURE_YIELD_DIR", str(yield_dir))
+    importlib.reload(ne)
+
+    assert ne.NUTRIENT_DIR == str(nutrient_dir)
+    assert ne.YIELD_DIR == str(yield_dir)


### PR DESCRIPTION
## Summary
- refactor scripts to wrap plant_engine helpers instead of duplicating logic
- add env-variable overrides for nutrient efficiency paths
- add CLI wrappers for ET, transpiration, root zone, growth and approvals
- cover env-variable override in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa4786480833091187bf74c506f00