### PR TITLE
Enhance growth stage utilities

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -22,6 +22,8 @@ __all__ = [
     "get_stage_duration",
     "estimate_stage_from_age",
     "predict_harvest_date",
+    "stage_progress",
+    "days_until_harvest",
 ]
 
 
@@ -84,3 +86,31 @@ def predict_harvest_date(plant_type: str, start_date: date) -> date | None:
             total_days += int(days)
 
     return start_date + timedelta(days=total_days)
+
+
+def stage_progress(plant_type: str, stage: str, days_elapsed: int) -> float | None:
+    """Return percentage completion of ``stage`` based on ``days_elapsed``.
+
+    The returned value is clipped to the range 0-100. ``None`` is returned when
+    the stage duration is unknown.
+    """
+
+    duration = get_stage_duration(plant_type, stage)
+    if duration is None:
+        return None
+    if days_elapsed < 0:
+        raise ValueError("days_elapsed must be non-negative")
+    progress = min(max(days_elapsed / duration, 0.0), 1.0)
+    return round(progress * 100, 1)
+
+
+def days_until_harvest(
+    plant_type: str, start_date: date, current_date: date
+) -> int | None:
+    """Return the number of days until the estimated harvest date."""
+
+    harvest = predict_harvest_date(plant_type, start_date)
+    if harvest is None:
+        return None
+    remaining = (harvest - current_date).days
+    return max(0, remaining)

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -6,6 +6,8 @@ from plant_engine.growth_stage import (
     get_stage_duration,
     estimate_stage_from_age,
     predict_harvest_date,
+    stage_progress,
+    days_until_harvest,
 )
 
 
@@ -49,4 +51,19 @@ def test_predict_harvest_date():
     assert predict_harvest_date("tomato", start) == expected
 
     assert predict_harvest_date("unknown", start) is None
+
+
+def test_stage_progress():
+    assert stage_progress("tomato", "seedling", 5) == 16.7
+    assert stage_progress("tomato", "seedling", 30) == 100.0
+    assert stage_progress("tomato", "unknown", 10) is None
+    with pytest.raises(ValueError):
+        stage_progress("tomato", "seedling", -1)
+
+
+def test_days_until_harvest():
+    start = date(2025, 1, 1)
+    today = date(2025, 2, 1)
+    assert days_until_harvest("tomato", start, today) == 89
+    assert days_until_harvest("unknown", start, today) is None
 


### PR DESCRIPTION
## Summary
- add new `stage_progress` and `days_until_harvest` helpers in `growth_stage`
- test new helpers with coverage in `test_growth_stage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa6b608108330a9249df1097e7e69