### PR TITLE
Improve nutrient utilities and tests

### DIFF
--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Dict, Mapping, Iterable
 
-from .nutrient_manager import calculate_deficiencies, get_recommended_levels
+from .nutrient_manager import (
+    calculate_deficiencies,
+    get_recommended_levels,
+    calculate_all_deficiencies,
+    get_all_recommended_levels,
+)
 from .utils import load_dataset
 
 PURITY_DATA = "fertilizer_purity.json"
@@ -243,21 +248,16 @@ def recommend_nutrient_mix(
             "Mo": "sodium_molybdate",
         }
 
-    if current_levels is None:
-        deficits = get_recommended_levels(plant_type, stage)
-    else:
-        deficits = calculate_deficiencies(current_levels, plant_type, stage)
-
     if include_micro:
-        from .micro_manager import (
-            get_recommended_levels as get_micro_levels,
-            calculate_deficiencies as calc_micro,
-        )
         if current_levels is None:
-            micro_def = get_micro_levels(plant_type, stage)
+            deficits = get_all_recommended_levels(plant_type, stage)
         else:
-            micro_def = calc_micro(current_levels, plant_type, stage)
-        deficits.update(micro_def)
+            deficits = calculate_all_deficiencies(current_levels, plant_type, stage)
+    else:
+        if current_levels is None:
+            deficits = get_recommended_levels(plant_type, stage)
+        else:
+            deficits = calculate_deficiencies(current_levels, plant_type, stage)
 
     schedule: Dict[str, float] = {}
     for nutrient, target_ppm in deficits.items():

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -14,7 +14,9 @@ _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 __all__ = [
     "list_supported_plants",
     "get_recommended_levels",
+    "get_all_recommended_levels",
     "calculate_deficiencies",
+    "calculate_all_deficiencies",
     "calculate_nutrient_balance",
     "calculate_surplus",
     "get_npk_ratio",
@@ -146,5 +148,27 @@ def score_nutrient_levels(
         return 0.0
 
     return round((score / count) * 100, 1)
+
+
+def get_all_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return combined macro and micro nutrient guidelines."""
+
+    levels = get_recommended_levels(plant_type, stage)
+    from .micro_manager import get_recommended_levels as _micro
+
+    levels.update(_micro(plant_type, stage))
+    return levels
+
+
+def calculate_all_deficiencies(
+    current_levels: Dict[str, float], plant_type: str, stage: str
+) -> Dict[str, float]:
+    """Return overall nutrient deficiencies including micronutrients."""
+
+    deficits = calculate_deficiencies(current_levels, plant_type, stage)
+    from .micro_manager import calculate_deficiencies as _micro_def
+
+    deficits.update(_micro_def(current_levels, plant_type, stage))
+    return deficits
 
 

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -1,6 +1,8 @@
 from plant_engine.nutrient_manager import (
     get_recommended_levels,
+    get_all_recommended_levels,
     calculate_deficiencies,
+    calculate_all_deficiencies,
     calculate_nutrient_balance,
     calculate_surplus,
     get_npk_ratio,
@@ -61,3 +63,15 @@ def test_score_nutrient_levels():
     deficit = {"N": 40, "P": 30, "K": 60}
     score = score_nutrient_levels(deficit, "tomato", "fruiting")
     assert 49.9 < score < 50.1
+
+
+def test_get_all_recommended_levels():
+    levels = get_all_recommended_levels("lettuce", "seedling")
+    assert "N" in levels and "Fe" in levels
+
+
+def test_calculate_all_deficiencies():
+    current = {"N": 0.0, "Fe": 0.0}
+    defs = calculate_all_deficiencies(current, "lettuce", "seedling")
+    assert defs["N"] > 0
+    assert defs["Fe"] > 0


### PR DESCRIPTION
## Summary
- extend nutrient_manager with helper methods for macro + micro nutrient lookups
- refactor fertigation.recommend_nutrient_mix to use new helpers
- add unit tests for combined nutrient functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa907f9508330a5f8ef97d105a1e0