### PR TITLE
Enhance root zone modeling with soil texture data

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Key reference datasets reside in the `data/` directory:
 - `nutrient_interactions.json` – warning ratios for antagonistic nutrients
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `pruning_guidelines.json` – stage-specific pruning recommendations
+- `soil_texture_parameters.json` – default field capacity and MAD values by soil texture
 - `yield/` – per‑plant yield logs created during operation
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values

--- a/data/soil_texture_parameters.json
+++ b/data/soil_texture_parameters.json
@@ -1,0 +1,9 @@
+{
+  "sand": {"field_capacity": 0.10, "mad_fraction": 0.5},
+  "loamy_sand": {"field_capacity": 0.12, "mad_fraction": 0.5},
+  "sandy_loam": {"field_capacity": 0.15, "mad_fraction": 0.45},
+  "loam": {"field_capacity": 0.25, "mad_fraction": 0.45},
+  "silt_loam": {"field_capacity": 0.30, "mad_fraction": 0.40},
+  "clay_loam": {"field_capacity": 0.35, "mad_fraction": 0.35},
+  "clay": {"field_capacity": 0.40, "mad_fraction": 0.30}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -40,6 +40,7 @@ from .fertigation import (
 from .rootzone_model import (
     estimate_rootzone_depth,
     estimate_water_capacity,
+    get_soil_parameters,
     RootZone,
 )
 from .irrigation_manager import (
@@ -126,6 +127,7 @@ __all__ = [
     "list_growth_stages",
     "estimate_rootzone_depth",
     "estimate_water_capacity",
+    "get_soil_parameters",
     "RootZone",
     "recommend_irrigation_volume",
     "recommend_irrigation_interval",

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -68,7 +68,10 @@ def run_daily_cycle(plant_id: str) -> Dict:
     growth = update_growth_index(plant_id, env, transp_ml)
 
     root_depth = estimate_rootzone_depth(profile, growth)
-    rootzone = estimate_water_capacity(root_depth)
+    rootzone = estimate_water_capacity(
+        root_depth,
+        texture=profile.get("soil_texture"),
+    )
 
     # Step 4: Water balance
     irrigated_ml = profile.get("last_irrigation_ml", 1000)

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -1,6 +1,7 @@
 from plant_engine.rootzone_model import (
     estimate_rootzone_depth,
     estimate_water_capacity,
+    get_soil_parameters,
     RootZone,
 )
 
@@ -30,4 +31,16 @@ def test_estimate_water_capacity_custom():
     assert result.readily_available_water_ml == 120.0
     assert result.field_capacity_pct == 0.30
     assert result.mad_pct == 0.4
+
+
+def test_get_soil_parameters():
+    params = get_soil_parameters("loam")
+    assert params["field_capacity"] == 0.25
+    assert params["mad_fraction"] == 0.45
+
+
+def test_estimate_water_capacity_texture():
+    result = estimate_water_capacity(10, area_cm2=100, texture="loam")
+    assert result.total_available_water_ml == 250.0
+    assert result.mad_pct == 0.45
 


### PR DESCRIPTION
## Summary
- add new `soil_texture_parameters.json` dataset
- expose `get_soil_parameters` and use texture data in `estimate_water_capacity`
- pass soil texture to root zone calculation in `run_daily_cycle`
- document dataset in README
- expand root zone unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa90d92388330aaab28107c2f582a