### PR TITLE
Improve dataset lookups and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Key reference datasets reside in the `data/` directory:
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
 
+All dataset lookups are case-insensitive and ignore spaces thanks to the
+`normalize_key` helper, so references such as `"Citrus"` and `"citrus"` map to
+the same entries.
+
 You can override the default `data/` directory by setting the environment
 variable `HORTICULTURE_DATA_DIR` when running scripts or tests.
 

--- a/plant_engine/compute_transpiration.py
+++ b/plant_engine/compute_transpiration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Dict, Mapping
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 from plant_engine.et_model import calculate_et0, calculate_eta
 
@@ -37,11 +37,11 @@ class TranspirationMetrics:
 
 def lookup_crop_coefficient(plant_type: str, stage: str | None = None) -> float:
     """Return Kc value from :data:`crop_coefficients.json` or ``1.0``."""
-    plant = _KC_DATA.get(plant_type.lower())
+    plant = _KC_DATA.get(normalize_key(plant_type))
     if not plant:
         return 1.0
     if stage:
-        kc = plant.get(stage.lower())
+        kc = plant.get(normalize_key(stage))
         if kc is not None:
             return float(kc)
     return float(plant.get("default", 1.0))

--- a/plant_engine/disease_manager.py
+++ b/plant_engine/disease_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "disease_guidelines.json"
 
@@ -20,7 +20,7 @@ def list_supported_plants() -> list[str]:
 
 def get_disease_guidelines(plant_type: str) -> Dict[str, str]:
     """Return disease management guidelines for the specified plant type."""
-    return _DATA.get(plant_type, {})
+    return _DATA.get(normalize_key(plant_type), {})
 
 
 def recommend_treatments(plant_type: str, diseases: Iterable[str]) -> Dict[str, str]:

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "nutrient_guidelines.json"
 
@@ -32,13 +32,15 @@ def list_supported_plants() -> list[str]:
 def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
     """Return recommended nutrient levels for ``plant_type`` and ``stage``.
 
-    Parameters are matched case-insensitively. An empty dictionary is returned
-    if no guidelines exist for the provided keys.
+    Parameters are normalized using :func:`normalize_key` so lookups are
+    case-insensitive and spaces are ignored. If no guidelines exist the
+    function returns an empty dictionary.
     """
-    plant = _DATA.get(plant_type.lower())
+
+    plant = _DATA.get(normalize_key(plant_type))
     if not plant:
         return {}
-    return plant.get(stage.lower(), {})
+    return plant.get(normalize_key(stage), {})
 
 
 def calculate_deficiencies(

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
@@ -22,7 +22,7 @@ def list_supported_plants() -> list[str]:
 
 def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
     """Return pest management guidelines for the specified plant type."""
-    return _DATA.get(plant_type, {})
+    return _DATA.get(normalize_key(plant_type), {})
 
 
 def recommend_treatments(plant_type: str, pests: Iterable[str]) -> Dict[str, str]:

--- a/tests/test_compute_transpiration.py
+++ b/tests/test_compute_transpiration.py
@@ -33,3 +33,8 @@ def test_transpiration_metrics_dataclass():
 def test_lookup_crop_coefficient():
     kc = lookup_crop_coefficient("lettuce", "vegetative")
     assert kc == 1.0
+
+
+def test_lookup_crop_coefficient_case_insensitive():
+    kc = lookup_crop_coefficient("LeTtuce", "VeGeTaTiVe")
+    assert kc == 1.0

--- a/tests/test_disease_manager.py
+++ b/tests/test_disease_manager.py
@@ -7,6 +7,11 @@ def test_get_disease_guidelines():
     assert guide["citrus greening"].startswith("Remove infected")
 
 
+def test_get_disease_guidelines_case_insensitive():
+    guide = get_disease_guidelines("CiTrUs")
+    assert "root rot" in guide
+
+
 def test_recommend_treatments():
     actions = recommend_treatments("citrus", ["root rot", "unknown"])
     assert actions["root rot"].startswith("Ensure good drainage")

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -12,6 +12,11 @@ def test_get_pest_guidelines():
     assert guide["scale"].startswith("Use horticultural oil")
 
 
+def test_get_pest_guidelines_case_insensitive():
+    guide = get_pest_guidelines("CiTrUs")
+    assert "aphids" in guide
+
+
 def test_recommend_treatments():
     actions = recommend_treatments("citrus", ["aphids", "unknown"])
     assert actions["aphids"].startswith("Apply insecticidal soap")


### PR DESCRIPTION
## Summary
- normalize dataset lookup keys across several modules
- mention key normalization in README
- test case-insensitive lookups for crop coefficients, pests and diseases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fabd66cf883308f69a464d72a93bd