### PR TITLE
Add growing degree day utilities

### DIFF
--- a/data/gdd_requirements.json
+++ b/data/gdd_requirements.json
@@ -1,0 +1,17 @@
+{
+  "lettuce": {
+    "seedling": 100,
+    "vegetative": 250,
+    "harvest": 400
+  },
+  "strawberry": {
+    "vegetative": 350,
+    "flowering": 500,
+    "fruiting": 700
+  },
+  "cucumber": {
+    "vegetative": 300,
+    "flowering": 450,
+    "fruiting": 600
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -86,6 +86,13 @@ from .ph_manager import (
     get_ph_range,
     recommend_ph_adjustment,
 )
+from .thermal_time import (
+    calculate_gdd,
+    list_supported_plants as list_gdd_plants,
+    get_stage_gdd_requirement,
+    predict_stage_completion,
+    accumulate_gdd_series,
+)
 from .compute_transpiration import TranspirationMetrics
 
 # Run functions should be imported explicitly to avoid heavy imports at package
@@ -148,6 +155,11 @@ __all__ = [
     "list_pruning_plants",
     "list_pruning_stages",
     "get_pruning_instructions",
+    "calculate_gdd",
+    "list_gdd_plants",
+    "get_stage_gdd_requirement",
+    "predict_stage_completion",
+    "accumulate_gdd_series",
     "calculate_all_surplus",
     "calculate_micro_surplus",
     "analyze_nutrient_profile",

--- a/plant_engine/thermal_time.py
+++ b/plant_engine/thermal_time.py
@@ -1,0 +1,58 @@
+"""Growing Degree Day (GDD) utilities for growth stage tracking."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "gdd_requirements.json"
+
+# Cached dataset loaded once
+_DATA: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "calculate_gdd",
+    "list_supported_plants",
+    "get_stage_gdd_requirement",
+    "predict_stage_completion",
+    "accumulate_gdd_series",
+]
+
+
+def calculate_gdd(temp_min_c: float, temp_max_c: float, base_temp_c: float = 10.0) -> float:
+    """Return Growing Degree Days for a single day."""
+    if temp_min_c > temp_max_c:
+        temp_min_c, temp_max_c = temp_max_c, temp_min_c
+    avg = (temp_min_c + temp_max_c) / 2
+    gdd = max(0.0, avg - base_temp_c)
+    return round(gdd, 1)
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with GDD data."""
+    return sorted(_DATA.keys())
+
+
+def get_stage_gdd_requirement(plant_type: str, stage: str) -> int | None:
+    """Return cumulative GDD required to reach ``stage`` for ``plant_type``."""
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return None
+    value = plant.get(normalize_key(stage))
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def predict_stage_completion(plant_type: str, stage: str, accumulated_gdd: float) -> bool:
+    """Return ``True`` if ``accumulated_gdd`` meets or exceeds the stage requirement."""
+    req = get_stage_gdd_requirement(plant_type, stage)
+    if req is None:
+        return False
+    return accumulated_gdd >= req
+
+
+def accumulate_gdd_series(temps: Iterable[tuple[float, float]], base_temp_c: float = 10.0) -> float:
+    """Return total GDD for a series of (min, max) temperature pairs."""
+    total = 0.0
+    for t_min, t_max in temps:
+        total += calculate_gdd(t_min, t_max, base_temp_c)
+    return round(total, 1)

--- a/tests/test_thermal_time.py
+++ b/tests/test_thermal_time.py
@@ -1,0 +1,25 @@
+from plant_engine import thermal_time
+
+
+def test_calculate_gdd_basic():
+    gdd = thermal_time.calculate_gdd(12, 22, base_temp_c=10)
+    assert gdd == 7.0
+
+
+def test_calculate_gdd_no_growth():
+    assert thermal_time.calculate_gdd(5, 9, base_temp_c=10) == 0.0
+
+
+def test_get_stage_requirement():
+    assert thermal_time.get_stage_gdd_requirement("lettuce", "vegetative") == 250
+
+
+def test_predict_stage_completion():
+    assert thermal_time.predict_stage_completion("lettuce", "vegetative", 260)
+    assert not thermal_time.predict_stage_completion("lettuce", "harvest", 300)
+
+
+def test_accumulate_gdd_series():
+    series = [(10, 20)] * 5
+    total = thermal_time.accumulate_gdd_series(series, base_temp_c=10)
+    assert total == 25.0


### PR DESCRIPTION
## Summary
- integrate new `gdd_requirements.json` dataset
- add `thermal_time` module for growing degree day calculations
- export thermal time helpers in package `__init__`
- test GDD utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fadb573188330afcb33549c20fcd6