### PR TITLE
Add heat stress evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ applying it to your plants.
 ### Data & Analytics
 - Disease and pest treatment recommendations
 - Environment optimization suggestions with pH guidance
+- Heat stress warnings using heat index thresholds
 - Stage-adjusted nutrient targets
 - Example crop profiles for strawberries, basil, spinach and more
 
@@ -141,6 +142,7 @@ Key reference datasets reside in the `data/` directory:
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `fertilizer_purity.json` – default purity factors for common fertilizers
+- `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `nutrient_deficiency_treatments.json` – remedies for common nutrient shortages
 - `nutrient_interactions.json` – warning ratios for antagonistic nutrients
 - `growth_stages.json` – lifecycle stage durations and notes by crop

--- a/data/heat_stress_thresholds.json
+++ b/data/heat_stress_thresholds.json
@@ -1,0 +1,6 @@
+{
+  "default": 38,
+  "citrus": 40,
+  "lettuce": 35,
+  "tomato": 39
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -17,6 +17,7 @@ from plant_engine.environment_manager import (
     get_target_dli,
     get_target_vpd,
     humidity_for_target_vpd,
+    evaluate_heat_stress,
     score_environment,
     optimize_environment,
     calculate_environment_metrics,
@@ -267,3 +268,13 @@ def test_generate_environment_alerts():
     assert alerts["temperature"].startswith("temperature above")
     assert "humidity" in alerts
     assert alerts["humidity"].startswith("humidity below")
+
+
+def test_evaluate_heat_stress():
+    assert evaluate_heat_stress(32, 70, "citrus")
+    assert not evaluate_heat_stress(26, 70, "citrus")
+
+
+def test_optimize_environment_heat_stress():
+    result = optimize_environment({"temp_c": 32, "humidity_pct": 70}, "citrus")
+    assert result["heat_stress"] is True


### PR DESCRIPTION
## Summary
- add heat_stress_thresholds dataset
- support heat-stress warnings in environment_manager
- document heat stress dataset and feature
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fadbca0948330b79c468be208d6ce