### PR TITLE
Add environment quality rating utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ or incomplete and should only be used as a starting point for your own research.
   observed pests using `beneficial_insects.json`.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily
   reports provide an estimated harvest date based on `growth_stages.json`.
+- **Environment Quality Rating**: `classify_environment_quality` converts the
+  numeric score from `score_environment` into `good`, `fair` or `poor` for
+  quick evaluation.
 
 
 ### Automation Blueprint Guide

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -63,6 +63,7 @@ __all__ = [
     "EnvironmentOptimization",
     "compare_environment",
     "generate_environment_alerts",
+    "classify_environment_quality",
 ]
 
 
@@ -323,6 +324,19 @@ def score_environment(
     if count == 0:
         return 0.0
     return round((score / count) * 100, 1)
+
+
+def classify_environment_quality(
+    current: Mapping[str, float], plant_type: str, stage: str | None = None
+) -> str:
+    """Return ``good``, ``fair`` or ``poor`` based on environment score."""
+
+    score = score_environment(current, plant_type, stage)
+    if score >= 75:
+        return "good"
+    if score >= 50:
+        return "fair"
+    return "poor"
 
 
 def suggest_environment_setpoints(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -24,6 +24,7 @@ from plant_engine.environment_manager import (
     calculate_environment_metrics,
     compare_environment,
     generate_environment_alerts,
+    classify_environment_quality,
 )
 
 
@@ -289,3 +290,11 @@ def test_optimize_environment_heat_stress():
 def test_optimize_environment_cold_stress():
     result = optimize_environment({"temp_c": 2, "humidity_pct": 70}, "lettuce")
     assert result["cold_stress"] is True
+
+
+def test_classify_environment_quality():
+    good = {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450}
+    poor = {"temp_c": 10, "humidity_pct": 30, "light_ppfd": 50, "co2_ppm": 1500}
+
+    assert classify_environment_quality(good, "citrus", "seedling") == "good"
+    assert classify_environment_quality(poor, "citrus", "seedling") == "poor"


### PR DESCRIPTION
## Summary
- expose `classify_environment_quality` helper to quickly interpret environment scores
- document the new helper in the README
- test classification logic in environment manager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcb64a4e4833087141ec64831c5b2