### PR TITLE
Add yield estimation module and refactor approval queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ or incomplete and should only be used as a starting point for your own research.
   beneficial insects to deploy when pest thresholds are exceeded.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily
   reports provide an estimated harvest date based on `growth_stages.json`.
+- **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to
+  expected totals from `yield_estimates.json`.
 - **Environment Quality Rating**: `classify_environment_quality` converts the
   numeric score from `score_environment` into `good`, `fair` or `poor` for
   quick evaluation.

--- a/data/yield_estimates.json
+++ b/data/yield_estimates.json
@@ -1,0 +1,5 @@
+{
+  "lettuce": 150,
+  "tomato": 3500,
+  "strawberry": 500
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -70,6 +70,11 @@ from .yield_manager import (
     record_harvest,
     get_total_yield,
 )
+from .yield_prediction import (
+    list_supported_plants as list_yield_plants,
+    get_estimated_yield,
+    estimate_remaining_yield,
+)
 from .pruning_manager import (
     list_supported_plants as list_pruning_plants,
     list_stages as list_pruning_stages,
@@ -145,6 +150,9 @@ __all__ = [
     "load_yield_history",
     "record_harvest",
     "get_total_yield",
+    "list_yield_plants",
+    "get_estimated_yield",
+    "estimate_remaining_yield",
     "generate_health_report",
     "list_water_analytes",
     "get_water_threshold",

--- a/plant_engine/approval_queue.py
+++ b/plant_engine/approval_queue.py
@@ -1,15 +1,14 @@
 import os
-import json
 from datetime import datetime
 from typing import Dict
-from plant_engine.utils import load_json, save_json
+
+from .utils import load_json, save_json
 
 PENDING_DIR = "data/pending_thresholds"
 
-def queue_threshold_updates(plant_id: str, old: Dict, new: Dict):
-    """
-    Save proposed threshold changes to a file awaiting manual approval.
-    """
+def queue_threshold_updates(plant_id: str, old: Dict, new: Dict) -> str:
+    """Write pending threshold updates for ``plant_id`` and return file path."""
+
     os.makedirs(PENDING_DIR, exist_ok=True)
     pending_file = os.path.join(PENDING_DIR, f"{plant_id}.json")
 
@@ -27,18 +26,15 @@ def queue_threshold_updates(plant_id: str, old: Dict, new: Dict):
                 "status": "pending"
             }
 
-    with open(pending_file, "w", encoding="utf-8") as f:
-        json.dump(record, f, indent=2)
+    save_json(pending_file, record)
 
     print(f"📝 Queued {len(record['changes'])} threshold changes for {plant_id}")
+    return pending_file
 
+def apply_approved_thresholds(plant_path: str, pending_file: str) -> int:
+    """Apply approved threshold changes to ``plant_path`` and return count."""
 
-def apply_approved_thresholds(plant_path: str, pending_file: str):
-    """
-    Apply approved threshold changes to plant profile.
-    """
-    with open(pending_file, "r", encoding="utf-8") as f:
-        pending = json.load(f)
+    pending = load_json(pending_file)
 
     plant = load_json(plant_path)
     updated = plant["thresholds"]

--- a/plant_engine/yield_manager.py
+++ b/plant_engine/yield_manager.py
@@ -8,7 +8,10 @@ from typing import Dict, Iterable, List, Optional
 
 from .utils import load_json, save_json
 
-YIELD_DIR = "data/yield"
+# Default yield directory. Can be overridden with the ``HORTICULTURE_YIELD_DIR``
+# environment variable to support custom data locations during testing or
+# deployment.
+YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 
 
 @dataclass

--- a/plant_engine/yield_prediction.py
+++ b/plant_engine/yield_prediction.py
@@ -1,0 +1,44 @@
+"""Utility functions for predicting crop yield from logged harvests."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, normalize_key
+from .yield_manager import get_total_yield
+
+DATA_FILE = "yield_estimates.json"
+
+# Cached dataset loaded at import time
+_YIELD_DATA: Dict[str, float] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_estimated_yield", "estimate_remaining_yield"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types that have yield estimates available."""
+    return sorted(_YIELD_DATA.keys())
+
+
+def get_estimated_yield(plant_type: str) -> float | None:
+    """Return expected total yield (g) for the given plant type."""
+    key = normalize_key(plant_type)
+    value = _YIELD_DATA.get(key)
+    return float(value) if value is not None else None
+
+
+def estimate_remaining_yield(plant_id: str, plant_type: str) -> float | None:
+    """Return remaining yield (g) based on logged harvests.
+
+    Parameters
+    ----------
+    plant_id : str
+        Identifier used with :mod:`plant_engine.yield_manager`.
+    plant_type : str
+        Crop type used to look up the estimated total yield.
+    """
+    expected = get_estimated_yield(plant_type)
+    if expected is None:
+        return None
+    harvested = get_total_yield(plant_id)
+    remaining = max(0.0, expected - harvested)
+    return round(remaining, 2)

--- a/tests/test_yield_prediction.py
+++ b/tests/test_yield_prediction.py
@@ -1,0 +1,33 @@
+import importlib
+import json
+from pathlib import Path
+
+import plant_engine.yield_prediction as yp
+from plant_engine import yield_manager
+
+
+def test_get_estimated_yield(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "yield_estimates.json").write_text(json.dumps({"tomato": 100}))
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(yp)
+    assert yp.get_estimated_yield("tomato") == 100
+
+
+def test_estimate_remaining_yield(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "yield_estimates.json").write_text(json.dumps({"tomato": 100}))
+    yield_dir = tmp_path / "yield"
+    yield_dir.mkdir()
+    harvest_data = {"harvests": [{"date": "2024-01-01", "yield_grams": 30}]}
+    (yield_dir / "plant1.json").write_text(json.dumps(harvest_data))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("HORTICULTURE_YIELD_DIR", str(yield_dir))
+    importlib.reload(yield_manager)
+    importlib.reload(yp)
+
+    remaining = yp.estimate_remaining_yield("plant1", "tomato")
+    assert remaining == 70


### PR DESCRIPTION
## Summary
- add `yield_estimates.json` dataset with baseline yields
- implement new `yield_prediction` helpers for estimating remaining yield
- expose yield prediction helpers via package init
- allow `HORTICULTURE_YIELD_DIR` override in yield manager
- refactor approval queue utilities for clarity
- document new yield estimation feature
- test yield prediction utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcde9481083308c14fab58ad01391