### PR TITLE
Add surplus nutrient management utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Key reference datasets reside in the `data/` directory:
 - `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress
 - `nutrient_deficiency_treatments.json` – remedies for common nutrient shortages
+- `nutrient_surplus_actions.json` – steps to mitigate excess nutrient levels
 - `nutrient_interactions.json` – warning ratios for antagonistic nutrients
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `pruning_guidelines.json` – stage-specific pruning recommendations

--- a/data/nutrient_surplus_actions.json
+++ b/data/nutrient_surplus_actions.json
@@ -1,0 +1,7 @@
+{
+  "N": "Leach soil with clean water and reduce nitrogen fertilizer.",
+  "P": "Add carbon-rich material or use plants to uptake phosphorus.",
+  "K": "Flush growing media and adjust potassium inputs.",
+  "Ca": "Leach soil and stop calcium amendments until levels drop.",
+  "Mg": "Leach soil and avoid high magnesium fertilizers."
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -64,6 +64,11 @@ from .deficiency_manager import (
     get_deficiency_treatment,
     recommend_deficiency_treatments,
 )
+from .surplus_manager import (
+    list_known_nutrients as list_surplus_nutrients,
+    get_surplus_action,
+    recommend_surplus_actions,
+)
 from .yield_manager import (
     HarvestRecord,
     load_yield_history,
@@ -130,6 +135,9 @@ __all__ = [
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",
     "recommend_deficiency_treatments",
+    "list_surplus_nutrients",
+    "get_surplus_action",
+    "recommend_surplus_actions",
     "list_nutrient_plants",
     "list_micro_plants",
     "get_micro_levels",

--- a/plant_engine/surplus_manager.py
+++ b/plant_engine/surplus_manager.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .nutrient_manager import calculate_all_surplus
+from .utils import load_dataset
+
+DATA_FILE = "nutrient_surplus_actions.json"
+
+_ACTIONS: Dict[str, str] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_known_nutrients",
+    "get_surplus_action",
+    "recommend_surplus_actions",
+]
+
+
+def list_known_nutrients() -> list[str]:
+    """Return nutrients with recorded surplus actions."""
+
+    return sorted(_ACTIONS.keys())
+
+
+def get_surplus_action(nutrient: str) -> str:
+    """Return recommended action string for a nutrient surplus."""
+
+    return _ACTIONS.get(nutrient, "")
+
+
+def recommend_surplus_actions(
+    current_levels: Mapping[str, float], plant_type: str, stage: str
+) -> Dict[str, str]:
+    """Return actions for nutrients exceeding recommended levels."""
+
+    surplus = calculate_all_surplus(current_levels, plant_type, stage)
+    actions: Dict[str, str] = {}
+    for nutrient in surplus:
+        action = get_surplus_action(nutrient)
+        if action:
+            actions[nutrient] = action
+    return actions

--- a/tests/test_surplus_manager.py
+++ b/tests/test_surplus_manager.py
@@ -1,0 +1,25 @@
+from plant_engine.surplus_manager import (
+    list_known_nutrients,
+    get_surplus_action,
+    recommend_surplus_actions,
+)
+from plant_engine.nutrient_manager import get_recommended_levels
+
+
+def test_list_known_nutrients():
+    nutrients = list_known_nutrients()
+    assert "N" in nutrients
+
+
+def test_get_surplus_action():
+    action = get_surplus_action("N")
+    assert "leach" in action.lower()
+    assert get_surplus_action("unknown") == ""
+
+
+def test_recommend_surplus_actions():
+    guidelines = get_recommended_levels("tomato", "fruiting")
+    # create levels double the recommended to ensure surplus
+    current = {k: v * 2 for k, v in guidelines.items()}
+    actions = recommend_surplus_actions(current, "tomato", "fruiting")
+    assert "N" in actions


### PR DESCRIPTION
## Summary
- add `nutrient_surplus_actions.json` dataset with mitigation steps
- introduce `plant_engine.surplus_manager` for handling nutrient excess
- expose new helpers via package `__all__`
- document new dataset in README
- include unit tests for surplus manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fce92eb2c8330bd0dfb558afd69d0