### PR TITLE
Add guideline summary helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Environment Quality Rating**: `classify_environment_quality` converts the
   numeric score from `score_environment` into `good`, `fair` or `poor` for
   quick evaluation.
+- **Guideline Summary**: `get_guideline_summary` consolidates environment,
+  nutrient and pest guidance for quick reference.
 
 
 ### Automation Blueprint Guide

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -59,6 +59,7 @@ from .micro_manager import (
     calculate_surplus as calculate_micro_surplus,
 )
 from .growth_stage import get_stage_info, list_growth_stages
+from .guidelines import get_guideline_summary
 from .health_report import generate_health_report
 from .deficiency_manager import (
     get_deficiency_treatment,
@@ -163,5 +164,6 @@ __all__ = [
     "calculate_all_surplus",
     "calculate_micro_surplus",
     "analyze_nutrient_profile",
+    "get_guideline_summary",
     "TranspirationMetrics",
 ]

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -1,0 +1,42 @@
+"""Helpers to consolidate dataset guidelines for a plant type."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from . import environment_manager, nutrient_manager, micro_manager, pest_manager, growth_stage
+
+__all__ = ["get_guideline_summary"]
+
+
+def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str, Any]:
+    """Return combined environment, nutrient and pest guidelines.
+
+    Parameters
+    ----------
+    plant_type : str
+        Plant type used to look up guideline entries.
+    stage : str, optional
+        Growth stage for stage specific data.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with keys ``environment``, ``nutrients``, ``micronutrients``,
+        ``pest_guidelines`` and either ``stage_info`` or ``stages`` when
+        ``stage`` is not provided.
+    """
+
+    summary: Dict[str, Any] = {
+        "environment": environment_manager.get_environmental_targets(plant_type, stage),
+        "nutrients": nutrient_manager.get_recommended_levels(plant_type, stage) if stage else {},
+        "micronutrients": micro_manager.get_recommended_levels(plant_type, stage) if stage else {},
+        "pest_guidelines": pest_manager.get_pest_guidelines(plant_type),
+    }
+
+    if stage:
+        summary["stage_info"] = growth_stage.get_stage_info(plant_type, stage)
+    else:
+        summary["stages"] = growth_stage.list_growth_stages(plant_type)
+
+    return summary

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -1,0 +1,16 @@
+from plant_engine.guidelines import get_guideline_summary
+
+
+def test_get_guideline_summary():
+    data = get_guideline_summary("citrus", "fruiting")
+    assert data["environment"]["temp_c"] == [18, 28]
+    assert data["nutrients"]["N"] == 120
+    assert "aphids" in data["pest_guidelines"]
+    assert data["stage_info"]["duration_days"] == 90
+    assert data["micronutrients"] == {}
+
+
+def test_guideline_summary_no_stage():
+    data = get_guideline_summary("citrus")
+    assert "stages" in data and "vegetative" in data["stages"]
+


### PR DESCRIPTION
## Summary
- add `guidelines` module to consolidate dataset information
- expose `get_guideline_summary` from package
- document helper in README
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fce78a990833093e5249b50046577