### PR TITLE
Improve environment reading normalization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -35,17 +35,20 @@ ENV_ALIASES = {
     "ec": ["ec", "EC"],
 }
 
+# reverse mapping for constant time alias lookups
+_ALIAS_MAP: Dict[str, str] = {
+    alias: canonical
+    for canonical, aliases in ENV_ALIASES.items()
+    for alias in aliases
+}
+
 
 def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, float]:
-    """Return a copy of ``readings`` with keys normalized using ``ENV_ALIASES``."""
+    """Return ``readings`` with keys mapped to canonical environment names."""
 
     normalized: Dict[str, float] = {}
     for key, value in readings.items():
-        canonical = key
-        for target, aliases in ENV_ALIASES.items():
-            if key in aliases:
-                canonical = target
-                break
+        canonical = _ALIAS_MAP.get(key, key)
         try:
             normalized[canonical] = float(value)
         except (TypeError, ValueError):

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -25,6 +25,7 @@ from plant_engine.environment_manager import (
     compare_environment,
     generate_environment_alerts,
     classify_environment_quality,
+    normalize_environment_readings,
 )
 
 
@@ -320,3 +321,19 @@ def test_classify_environment_quality():
 
     assert classify_environment_quality(good, "citrus", "seedling") == "good"
     assert classify_environment_quality(poor, "citrus", "seedling") == "poor"
+
+
+def test_normalize_environment_readings_aliases():
+    data = {"temperature": 25, "humidity": 70, "co2": "700", "ec": 1.2}
+    result = normalize_environment_readings(data)
+    assert result == {
+        "temp_c": 25.0,
+        "humidity_pct": 70.0,
+        "co2_ppm": 700.0,
+        "ec": 1.2,
+    }
+
+
+def test_normalize_environment_readings_unknown_key():
+    result = normalize_environment_readings({"foo": 1})
+    assert result == {"foo": 1.0}


### PR DESCRIPTION
## Summary
- tweak environment reading normalization to use a fast alias map
- add regression tests for the normalization helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcddea75c8330af3543012e2bd126