### PR TITLE
Enhance disease management with prevention guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Key reference datasets reside in the `data/` directory:
 - `nutrient_guidelines.json` – recommended N‑P‑K levels across stages
 - `micronutrient_guidelines.json` – Fe/Mn/Zn/B/Cu/Mo levels across stages
 - `disease_guidelines.json` and `pest_guidelines.json` – treatment references
+- `disease_prevention.json` – cultural practices to prevent common diseases
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water

--- a/data/disease_prevention.json
+++ b/data/disease_prevention.json
@@ -1,0 +1,38 @@
+{
+  "citrus": {
+    "citrus greening": "Use disease-free seedlings and control psyllids.",
+    "root rot": "Plant in well-drained soil and avoid overwatering."
+  },
+  "tomato": {
+    "blight": "Rotate crops yearly and avoid wet foliage.",
+    "powdery mildew": "Ensure good air circulation and lower humidity."
+  },
+  "lettuce": {
+    "downy mildew": "Provide ample spacing and water early in the day.",
+    "lettuce drop": "Use clean transplants and remove plant debris."
+  },
+  "strawberry": {
+    "powdery mildew": "Plant resistant varieties and reduce humidity.",
+    "botrytis": "Improve airflow and remove dead berries."
+  },
+  "spinach": {
+    "downy mildew": "Use resistant cultivars and irrigate at soil level.",
+    "leaf spot": "Avoid overhead watering and remove infected leaves."
+  },
+  "cucumber": {
+    "powdery mildew": "Plant in full sun and space plants properly.",
+    "bacterial wilt": "Control cucumber beetles and remove infected vines."
+  },
+  "pepper": {
+    "powdery mildew": "Maintain low humidity and provide air movement.",
+    "bacterial spot": "Use certified seed and avoid working when leaves are wet."
+  },
+  "arugula": {
+    "downy mildew": "Rotate crops and avoid excessive moisture.",
+    "leaf spot": "Promote airflow and remove debris."
+  },
+  "blueberry": {
+    "mummy berry": "Rake and destroy mummified fruit to break the cycle.",
+    "botrytis": "Prune regularly to increase airflow."
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -31,6 +31,8 @@ from .disease_manager import (
     get_disease_guidelines,
     recommend_treatments as recommend_disease_treatments,
     list_supported_plants as list_disease_plants,
+    get_disease_prevention,
+    recommend_prevention as recommend_disease_prevention,
 )
 from .fertigation import (
     recommend_fertigation_schedule,
@@ -138,6 +140,8 @@ __all__ = [
     "recommend_threshold_actions",
     "get_disease_guidelines",
     "recommend_disease_treatments",
+    "get_disease_prevention",
+    "recommend_disease_prevention",
     "list_disease_plants",
     "recommend_fertigation_schedule",
     "recommend_correction_schedule",

--- a/plant_engine/disease_manager.py
+++ b/plant_engine/disease_manager.py
@@ -6,11 +6,13 @@ from typing import Dict, Iterable
 from .utils import load_dataset, normalize_key
 
 DATA_FILE = "disease_guidelines.json"
+PREVENTION_FILE = "disease_prevention.json"
 
 
 
 # Dataset is cached by ``load_dataset`` so load once at import time
 _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
+_PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -30,3 +32,26 @@ def recommend_treatments(plant_type: str, diseases: Iterable[str]) -> Dict[str, 
     for dis in diseases:
         actions[dis] = guide.get(dis, "No guideline available")
     return actions
+
+
+def get_disease_prevention(plant_type: str) -> Dict[str, str]:
+    """Return disease prevention guidelines for the specified plant type."""
+    return _PREVENTION.get(normalize_key(plant_type), {})
+
+
+def recommend_prevention(plant_type: str, diseases: Iterable[str]) -> Dict[str, str]:
+    """Return recommended prevention steps for each observed disease."""
+    guide = get_disease_prevention(plant_type)
+    actions: Dict[str, str] = {}
+    for dis in diseases:
+        actions[dis] = guide.get(dis, "No guideline available")
+    return actions
+
+
+__all__ = [
+    "list_supported_plants",
+    "get_disease_guidelines",
+    "recommend_treatments",
+    "get_disease_prevention",
+    "recommend_prevention",
+]

--- a/tests/test_dataset_integration.py
+++ b/tests/test_dataset_integration.py
@@ -162,3 +162,6 @@ def test_treatment_guidelines_lettuce():
 
     blue_dis = disease_manager.recommend_treatments("blueberry", ["mummy berry"])
     assert "mummified" in blue_dis["mummy berry"].lower()
+
+    prev = disease_manager.recommend_prevention("lettuce", ["lettuce drop"])
+    assert prev["lettuce drop"].startswith("Use clean transplants")

--- a/tests/test_disease_prevention.py
+++ b/tests/test_disease_prevention.py
@@ -1,0 +1,13 @@
+from plant_engine.disease_manager import get_disease_prevention, recommend_prevention
+
+
+def test_get_disease_prevention():
+    guide = get_disease_prevention("citrus")
+    assert "root rot" in guide
+    assert guide["citrus greening"].startswith("Use disease-free")
+
+
+def test_recommend_prevention():
+    actions = recommend_prevention("citrus", ["root rot", "unknown"])
+    assert actions["root rot"].startswith("Plant in well-drained")
+    assert actions["unknown"] == "No guideline available"


### PR DESCRIPTION
## Summary
- add `disease_prevention.json` dataset
- extend `disease_manager` with prevention lookups
- export new helpers from `plant_engine`
- document dataset in README
- test prevention utilities and integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880348dc43483308f414b374372c005