### PR TITLE
Extend fertigation with water-based mixing

### DIFF
--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -42,6 +42,7 @@ __all__ = [
     "recommend_correction_schedule",
     "recommend_batch_fertigation",
     "recommend_nutrient_mix",
+    "recommend_nutrient_mix_with_water",
     "estimate_daily_nutrient_uptake",
     "recommend_uptake_fertigation",
     "recommend_nutrient_mix_with_cost",
@@ -276,6 +277,36 @@ def recommend_nutrient_mix(
         schedule[fert] = round(grams_fert, 3)
 
     return schedule
+
+
+def recommend_nutrient_mix_with_water(
+    plant_type: str,
+    stage: str,
+    volume_l: float,
+    water_profile: Mapping[str, float],
+    *,
+    fertilizers: Mapping[str, str] | None = None,
+    purity_overrides: Mapping[str, float] | None = None,
+    include_micro: bool = False,
+    micro_fertilizers: Mapping[str, str] | None = None,
+) -> tuple[Dict[str, float], Dict[str, Dict[str, float]]]:
+    """Return fertilizer mix adjusted for nutrients in the irrigation water."""
+
+    from .water_quality import interpret_water_profile
+
+    baseline, warnings = interpret_water_profile(water_profile)
+    schedule = recommend_nutrient_mix(
+        plant_type,
+        stage,
+        volume_l,
+        current_levels=baseline,
+        fertilizers=fertilizers,
+        purity_overrides=purity_overrides,
+        include_micro=include_micro,
+        micro_fertilizers=micro_fertilizers,
+    )
+
+    return schedule, warnings
 
 
 def estimate_daily_nutrient_uptake(

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -6,6 +6,7 @@ from plant_engine.fertigation import (
     get_fertilizer_purity,
     recommend_batch_fertigation,
     recommend_nutrient_mix,
+    recommend_nutrient_mix_with_water,
     estimate_daily_nutrient_uptake,
     recommend_nutrient_mix_with_cost,
 )
@@ -104,6 +105,19 @@ def test_recommend_fertigation_with_water():
     assert round(schedule["N"], 2) == 0.8
     assert round(schedule["P"], 2) == 0.5
     assert round(schedule["K"], 2) == 0.7
+
+
+def test_recommend_nutrient_mix_with_water():
+    schedule, warnings = recommend_nutrient_mix_with_water(
+        "tomato",
+        "vegetative",
+        10.0,
+        {"N": 20, "K": 10},
+    )
+    assert warnings == {}
+    assert schedule["urea"] == pytest.approx(1.739, rel=1e-3)
+    assert schedule["map"] == pytest.approx(2.273, rel=1e-3)
+    assert schedule["kcl"] == pytest.approx(1.4, rel=1e-3)
 
 
 def test_estimate_daily_nutrient_uptake():


### PR DESCRIPTION
## Summary
- add `recommend_nutrient_mix_with_water` helper to fertigation module
- test new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688035b0d14083308cfefec97fe3646e