### PR TITLE
Improve guideline summary with disease and pH data

### DIFF
--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -1,42 +1,59 @@
-"""Helpers to consolidate dataset guidelines for a plant type."""
+"""Helpers to consolidate horticultural guidelines for plants."""
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
 
-from . import environment_manager, nutrient_manager, micro_manager, pest_manager, growth_stage
+from . import (
+    environment_manager,
+    nutrient_manager,
+    micro_manager,
+    pest_manager,
+    disease_manager,
+    ph_manager,
+    growth_stage,
+)
 
-__all__ = ["get_guideline_summary"]
+__all__ = ["GuidelineSummary", "get_guideline_summary"]
+
+
+@dataclass
+class GuidelineSummary:
+    """Container for consolidated plant guideline data."""
+
+    environment: Dict[str, Any]
+    nutrients: Dict[str, float]
+    micronutrients: Dict[str, float]
+    pest_guidelines: Dict[str, str]
+    disease_guidelines: Dict[str, str]
+    disease_prevention: Dict[str, str]
+    ph_range: List[float]
+    stage_info: Optional[Dict[str, Any]] = None
+    stages: Optional[List[str]] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return guidelines as a regular dictionary."""
+        return asdict(self)
 
 
 def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str, Any]:
     """Return combined environment, nutrient and pest guidelines.
 
-    Parameters
-    ----------
-    plant_type : str
-        Plant type used to look up guideline entries.
-    stage : str, optional
-        Growth stage for stage specific data.
-
-    Returns
-    -------
-    Dict[str, Any]
-        Dictionary with keys ``environment``, ``nutrients``, ``micronutrients``,
-        ``pest_guidelines`` and either ``stage_info`` or ``stages`` when
-        ``stage`` is not provided.
+    The summary now also includes disease management and pH guidance for
+    richer automation data.
     """
 
-    summary: Dict[str, Any] = {
-        "environment": environment_manager.get_environmental_targets(plant_type, stage),
-        "nutrients": nutrient_manager.get_recommended_levels(plant_type, stage) if stage else {},
-        "micronutrients": micro_manager.get_recommended_levels(plant_type, stage) if stage else {},
-        "pest_guidelines": pest_manager.get_pest_guidelines(plant_type),
-    }
+    summary = GuidelineSummary(
+        environment=environment_manager.get_environmental_targets(plant_type, stage),
+        nutrients=nutrient_manager.get_recommended_levels(plant_type, stage) if stage else {},
+        micronutrients=micro_manager.get_recommended_levels(plant_type, stage) if stage else {},
+        pest_guidelines=pest_manager.get_pest_guidelines(plant_type),
+        disease_guidelines=disease_manager.get_disease_guidelines(plant_type),
+        disease_prevention=disease_manager.get_disease_prevention(plant_type),
+        ph_range=ph_manager.get_ph_range(plant_type, stage),
+        stage_info=growth_stage.get_stage_info(plant_type, stage) if stage else None,
+        stages=None if stage else growth_stage.list_growth_stages(plant_type),
+    )
 
-    if stage:
-        summary["stage_info"] = growth_stage.get_stage_info(plant_type, stage)
-    else:
-        summary["stages"] = growth_stage.list_growth_stages(plant_type)
-
-    return summary
+    return summary.as_dict()

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -6,6 +6,9 @@ def test_get_guideline_summary():
     assert data["environment"]["temp_c"] == [18, 28]
     assert data["nutrients"]["N"] == 120
     assert "aphids" in data["pest_guidelines"]
+    assert "citrus greening" in data["disease_guidelines"]
+    assert "citrus greening" in data["disease_prevention"]
+    assert data["ph_range"] == [5.5, 6.5]
     assert data["stage_info"]["duration_days"] == 90
     assert data["micronutrients"] == {}
 


### PR DESCRIPTION
## Summary
- refactor guidelines module into dataclass
- add disease and pH info to guideline summary
- update tests for new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688039e7bd508330a7debd494d13d968