### PR TITLE
Improve guideline summary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Environment Summary**: `summarize_environment` returns the quality rating
   alongside recommended adjustments and calculated metrics in one step.
 - **Guideline Summary**: `get_guideline_summary` consolidates environment,
-  nutrient and pest guidance for quick reference.
+  nutrient and pest guidance for quick reference. When called without a
+  specific stage it now returns the full set of nutrient guidelines for all
+  stages.
 
 
 ### Automation Blueprint Guide

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -53,11 +53,13 @@ from .irrigation_manager import (
 from .nutrient_manager import (
     calculate_deficiencies,
     calculate_all_surplus,
+    get_stage_guidelines as get_nutrient_stage_guidelines,
     list_supported_plants as list_nutrient_plants,
 )
 from .micro_manager import (
     list_supported_plants as list_micro_plants,
     get_recommended_levels as get_micro_levels,
+    get_stage_guidelines as get_micro_stage_guidelines,
     calculate_deficiencies as calculate_micro_deficiencies,
     calculate_surplus as calculate_micro_surplus,
 )
@@ -150,6 +152,8 @@ __all__ = [
     "get_fertilizer_purity",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
+    "get_nutrient_stage_guidelines",
+    "get_micro_stage_guidelines",
     "get_deficiency_treatment",
     "recommend_deficiency_treatments",
     "list_surplus_nutrients",

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -29,14 +29,16 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
 
     summary: Dict[str, Any] = {
         "environment": environment_manager.get_environmental_targets(plant_type, stage),
-        "nutrients": nutrient_manager.get_recommended_levels(plant_type, stage) if stage else {},
-        "micronutrients": micro_manager.get_recommended_levels(plant_type, stage) if stage else {},
         "pest_guidelines": pest_manager.get_pest_guidelines(plant_type),
     }
 
     if stage:
+        summary["nutrients"] = nutrient_manager.get_recommended_levels(plant_type, stage)
+        summary["micronutrients"] = micro_manager.get_recommended_levels(plant_type, stage)
         summary["stage_info"] = growth_stage.get_stage_info(plant_type, stage)
     else:
+        summary["nutrients"] = nutrient_manager.get_stage_guidelines(plant_type)
+        summary["micronutrients"] = micro_manager.get_stage_guidelines(plant_type)
         summary["stages"] = growth_stage.list_growth_stages(plant_type)
 
     return summary

--- a/plant_engine/micro_manager.py
+++ b/plant_engine/micro_manager.py
@@ -13,6 +13,7 @@ _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 __all__ = [
     "list_supported_plants",
     "get_recommended_levels",
+    "get_stage_guidelines",
     "calculate_deficiencies",
     "calculate_surplus",
 ]
@@ -21,6 +22,12 @@ __all__ = [
 def list_supported_plants() -> list[str]:
     """Return plants with micronutrient guidelines."""
     return sorted(_DATA.keys())
+
+
+def get_stage_guidelines(plant_type: str) -> Dict[str, Dict[str, float]]:
+    """Return micronutrient guidelines for all stages of ``plant_type``."""
+
+    return _DATA.get(normalize_key(plant_type), {})
 
 
 def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -14,6 +14,7 @@ _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 __all__ = [
     "list_supported_plants",
     "get_recommended_levels",
+    "get_stage_guidelines",
     "get_all_recommended_levels",
     "calculate_deficiencies",
     "calculate_all_deficiencies",
@@ -28,6 +29,12 @@ __all__ = [
 def list_supported_plants() -> list[str]:
     """Return all plant types with nutrient guidelines."""
     return sorted(_DATA.keys())
+
+
+def get_stage_guidelines(plant_type: str) -> Dict[str, Dict[str, float]]:
+    """Return nutrient guidelines for all stages of ``plant_type``."""
+
+    return _DATA.get(normalize_key(plant_type), {})
 
 
 def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -13,4 +13,5 @@ def test_get_guideline_summary():
 def test_guideline_summary_no_stage():
     data = get_guideline_summary("citrus")
     assert "stages" in data and "vegetative" in data["stages"]
+    assert data["nutrients"]["vegetative"]["N"] == 80
 


### PR DESCRIPTION
## Summary
- expose full-stage nutrient lookup helpers
- expand guideline summary to return data for all stages
- export new helper functions and document usage
- test the updated guideline summary behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688039ef45548330bbd17a84c4b940cf