### PR TITLE
Add irrigation guidelines dataset and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Key reference datasets reside in the `data/` directory:
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `pruning_guidelines.json` – stage-specific pruning recommendations
 - `soil_texture_parameters.json` – default field capacity and MAD values by soil texture
+- `irrigation_guidelines.json` – default daily irrigation volume per plant stage
 - `yield/` – per‑plant yield logs created during operation
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
@@ -183,6 +184,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.
+- **Irrigation Targets**: `get_daily_irrigation_target` returns default
+  milliliters per plant based on `irrigation_guidelines.json`.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and
   micro guidelines with interaction checks to summarize deficiencies and
   surpluses at once.

--- a/data/irrigation_guidelines.json
+++ b/data/irrigation_guidelines.json
@@ -1,0 +1,5 @@
+{
+  "citrus": {"seedling": 100, "vegetative": 250, "fruiting": 300},
+  "lettuce": {"seedling": 50, "vegetative": 150, "harvest": 120},
+  "strawberry": {"vegetative": 200, "fruiting": 300}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -50,6 +50,8 @@ from .rootzone_model import (
 from .irrigation_manager import (
     recommend_irrigation_volume,
     recommend_irrigation_interval,
+    list_supported_plants as list_irrigation_plants,
+    get_daily_irrigation_target,
 )
 from .nutrient_manager import (
     calculate_deficiencies,
@@ -168,6 +170,8 @@ __all__ = [
     "RootZone",
     "recommend_irrigation_volume",
     "recommend_irrigation_interval",
+    "list_irrigation_plants",
+    "get_daily_irrigation_target",
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",

--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -14,10 +14,15 @@ __all__ = [
     "get_crop_coefficient",
     "estimate_irrigation_demand",
     "recommend_irrigation_from_environment",
+    "list_supported_plants",
+    "get_daily_irrigation_target",
 ]
 
 _KC_DATA_FILE = "crop_coefficients.json"
 _KC_DATA = load_dataset(_KC_DATA_FILE)
+
+_IRRIGATION_FILE = "irrigation_guidelines.json"
+_IRRIGATION_DATA: Dict[str, Dict[str, float]] = load_dataset(_IRRIGATION_FILE)
 
 
 def recommend_irrigation_volume(
@@ -141,3 +146,17 @@ def recommend_irrigation_from_environment(
         "volume_ml": volume,
         "metrics": metrics,
     }
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with irrigation guidelines."""
+
+    return sorted(_IRRIGATION_DATA.keys())
+
+
+def get_daily_irrigation_target(plant_type: str, stage: str) -> float:
+    """Return recommended daily irrigation volume in milliliters."""
+
+    plant = _IRRIGATION_DATA.get(normalize_key(plant_type), {})
+    value = plant.get(normalize_key(stage))
+    return float(value) if isinstance(value, (int, float)) else 0.0

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -6,6 +6,8 @@ from plant_engine.irrigation_manager import (
     get_crop_coefficient,
     estimate_irrigation_demand,
     recommend_irrigation_from_environment,
+    get_daily_irrigation_target,
+    list_supported_plants,
 )
 from plant_engine.rootzone_model import RootZone
 from plant_engine.compute_transpiration import compute_transpiration
@@ -91,4 +93,10 @@ def test_recommend_irrigation_from_environment():
     )
     assert result["volume_ml"] == expected
     assert result["metrics"] == metrics
+
+
+def test_daily_irrigation_target_lookup():
+    assert get_daily_irrigation_target("citrus", "vegetative") == 250
+    assert "citrus" in list_supported_plants()
+    assert get_daily_irrigation_target("unknown", "stage") == 0.0
 


### PR DESCRIPTION
## Summary
- integrate new `irrigation_guidelines.json` data file
- expose irrigation guideline helpers in `irrigation_manager`
- re-export utilities via `plant_engine` package
- document dataset and helper in README
- test irrigation lookup functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68803fe2f88c8330a674bb01a5e24263