### PR TITLE
Add light stress evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ applying it to your plants.
 - Disease and pest treatment recommendations
 - Environment optimization suggestions with pH guidance
 - Heat stress warnings using heat index thresholds
+- Light stress detection using DLI ranges
 - Stage-adjusted nutrient targets
 - Example crop profiles for strawberries, basil, spinach and more
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -20,6 +20,7 @@ from plant_engine.environment_manager import (
     recommend_photoperiod,
     evaluate_heat_stress,
     evaluate_cold_stress,
+    evaluate_light_stress,
     score_environment,
     optimize_environment,
     calculate_environment_metrics,
@@ -356,3 +357,15 @@ def test_summarize_environment():
     assert summary["adjustments"]["temperature"] == "increase"
     assert summary["adjustments"]["humidity"] == "decrease"
     assert "vpd" in summary["metrics"]
+
+
+def test_evaluate_light_stress():
+    assert evaluate_light_stress(8, "lettuce", "seedling") == "low"
+    assert evaluate_light_stress(14, "lettuce", "seedling") == "high"
+    assert evaluate_light_stress(11, "lettuce", "seedling") is None
+    assert evaluate_light_stress(10, "unknown") is None
+
+
+def test_optimize_environment_light_stress():
+    result = optimize_environment({"dli": 8}, "lettuce", "seedling")
+    assert result["light_stress"] == "low"


### PR DESCRIPTION
## Summary
- add a light stress check using DLI ranges
- expose light stress in the optimization API
- extend environment tests for the new logic
- document light stress detection in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804452db1c8330893bbede071b73c4