### PR TITLE
Improve daily report structure and engine helpers

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -66,6 +66,8 @@ from .micro_manager import (
 )
 from .growth_stage import get_stage_info, list_growth_stages
 from .guidelines import get_guideline_summary
+from .report import DailyReport
+from .engine import load_profile
 from .health_report import generate_health_report
 from .deficiency_manager import (
     get_deficiency_treatment,
@@ -203,5 +205,7 @@ __all__ = [
     "get_toxicity_thresholds",
     "check_toxicities",
     "get_guideline_summary",
+    "DailyReport",
+    "load_profile",
     "TranspirationMetrics",
 ]

--- a/plant_engine/report.py
+++ b/plant_engine/report.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List
+
+__all__ = ["DailyReport"]
+
+@dataclass
+class DailyReport:
+    """Container for daily plant processing results."""
+
+    plant_id: str
+    thresholds: Dict[str, Any]
+    growth: Dict[str, Any]
+    transpiration: Dict[str, Any]
+    water_deficit: Dict[str, Any]
+    rootzone: Dict[str, Any]
+    nue: Dict[str, Any]
+    guidelines: Dict[str, Any]
+    nutrient_targets: Dict[str, Any]
+    environment_actions: Dict[str, Any]
+    environment_optimization: Dict[str, Any]
+    pest_actions: Dict[str, Any]
+    disease_actions: Dict[str, Any]
+    lifecycle_stage: str
+    stage_info: Dict[str, Any]
+    tags: List[str]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return the dataclass as a serializable dictionary."""
+        return asdict(self)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -52,3 +52,40 @@ def test_run_daily_cycle_with_rootzone(tmp_path, monkeypatch):
     assert report["environment_optimization"]["setpoints"]["temp_c"] == 24
     assert "nutrient_targets" in report
 
+
+def test_load_profile(tmp_path, monkeypatch):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    monkeypatch.setattr(engine, "PLANTS_DIR", str(plants_dir))
+    path = plants_dir / "demo.json"
+    path.write_text('{"a":1}')
+    data = engine.load_profile("demo")
+    assert data["a"] == 1
+
+
+def test_daily_report_as_dict():
+    from plant_engine.report import DailyReport
+
+    report = DailyReport(
+        plant_id="x",
+        thresholds={},
+        growth={},
+        transpiration={},
+        water_deficit={},
+        rootzone={},
+        nue={},
+        guidelines={},
+        nutrient_targets={},
+        environment_actions={},
+        environment_optimization={},
+        pest_actions={},
+        disease_actions={},
+        lifecycle_stage="seedling",
+        stage_info={},
+        tags=[],
+    )
+
+    d = report.as_dict()
+    assert d["plant_id"] == "x"
+    assert d["lifecycle_stage"] == "seedling"
+


### PR DESCRIPTION
## Summary
- refactor `engine.run_daily_cycle` for clarity
- add `DailyReport` dataclass and helper functions
- expose `load_profile` and `DailyReport` at package level
- test new helpers and dataclass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a01dbb3c8330b8a82dc098b1c210