### PR TITLE
Add consolidated stress evaluation helper

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -16,6 +16,8 @@ from .environment_manager import (
     recommend_photoperiod,
     EnvironmentMetrics,
     EnvironmentOptimization,
+    StressFlags,
+    evaluate_stress_conditions,
     list_supported_plants as list_environment_plants,
 )
 from .pest_manager import (
@@ -137,6 +139,8 @@ __all__ = [
     "recommend_photoperiod",
     "EnvironmentMetrics",
     "EnvironmentOptimization",
+    "StressFlags",
+    "evaluate_stress_conditions",
     "list_environment_plants",
     "get_pest_guidelines",
     "recommend_pest_treatments",

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -21,6 +21,7 @@ from plant_engine.environment_manager import (
     evaluate_heat_stress,
     evaluate_cold_stress,
     evaluate_light_stress,
+    evaluate_stress_conditions,
     score_environment,
     optimize_environment,
     calculate_environment_metrics,
@@ -369,3 +370,13 @@ def test_evaluate_light_stress():
 def test_optimize_environment_light_stress():
     result = optimize_environment({"dli": 8}, "lettuce", "seedling")
     assert result["light_stress"] == "low"
+
+
+def test_evaluate_stress_conditions():
+    stress = evaluate_stress_conditions(32, 70, 8, "lettuce", "seedling")
+    assert stress.heat is True
+    assert stress.cold is False
+    assert stress.light == "low"
+
+    stress_none = evaluate_stress_conditions(None, None, None, "citrus")
+    assert stress_none.heat is None


### PR DESCRIPTION
## Summary
- add `StressFlags` dataclass and `evaluate_stress_conditions` helper
- expose new utilities from `environment_manager` and package root
- use new helper inside `optimize_environment`
- cover stress evaluation via new unit test

## Testing
- `pytest -q`
- `pytest --maxfail=1 --disable-warnings --cov=plant_engine -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a027f4d483308d224002ab470823