### PR TITLE
Improve daily report generation

### DIFF
--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -11,9 +11,14 @@ Repo: horticulture-assistant
 
 import logging
 
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import ConfigType
+try:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.helpers.typing import ConfigType
+except ModuleNotFoundError:  # pragma: no cover - allow running tests without HA
+    HomeAssistant = object  # type: ignore
+    ConfigEntry = object  # type: ignore
+    ConfigType = dict
 
 from .const import DOMAIN, PLATFORMS
 import asyncio

--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -26,4 +26,6 @@ def test_run_daily_cycle_extended(tmp_path):
 
     assert report["beneficial_insects"]["aphids"][0] == "ladybugs"
     assert report["predicted_harvest_date"] == "2025-05-01"
+    assert "environment_optimization" in report
+    assert "fertigation_schedule" in report
     assert (out_dir / f"sample_{report['timestamp'][:10]}.json").exists()


### PR DESCRIPTION
## Summary
- refactor run_daily_cycle with new `DailyReport` dataclass
- add environment optimization, fertigation and irrigation targets
- write daily report via dataclass helper
- allow tests to run without Home Assistant installed
- check new features in extended daily cycle test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a01885708330ab7e235b36c41182