### PR TITLE
Add nutrient uptake totals helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.
+- **Total Uptake Estimation**: `estimate_stage_totals` multiplies daily uptake by
+  growth stage duration while `estimate_total_uptake` sums these values across
+  the entire crop cycle.
 - **Irrigation Targets**: `get_daily_irrigation_target` returns default
   milliliters per plant based on `irrigation_guidelines.json`.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and

--- a/tests/test_nutrient_uptake_totals.py
+++ b/tests/test_nutrient_uptake_totals.py
@@ -1,0 +1,14 @@
+from plant_engine.nutrient_uptake import estimate_stage_totals, estimate_total_uptake
+
+
+def test_estimate_stage_totals():
+    totals = estimate_stage_totals("lettuce", "vegetative")
+    assert totals["N"] == 60 * 35
+    assert totals["K"] == 80 * 35
+
+
+def test_estimate_total_uptake():
+    totals = estimate_total_uptake("lettuce")
+    assert totals["N"] == 60 * 35 + 50 * 30
+    assert totals["P"] == 20 * 35 + 15 * 30
+    assert totals["K"] == 80 * 35 + 70 * 30


### PR DESCRIPTION
## Summary
- estimate total nutrient uptake for individual stages and overall growth cycle
- test new nutrient uptake helpers
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b29a092483308ae51ca1277484d2