### PR TITLE
Add water quality scoring helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ or incomplete and should only be used as a starting point for your own research.
   hours required to hit midpoint DLI targets at the current PPFD.
 - **Environment Summary**: `summarize_environment` returns the quality rating
   alongside recommended adjustments and calculated metrics in one step.
+- **Water Quality Scoring**: `score_water_quality` evaluates irrigation water and
+  returns a 0‑100 rating based on toxicity thresholds.
 - **Guideline Summary**: `get_guideline_summary` consolidates environment,
   nutrient and pest guidance for quick reference.
 

--- a/plant_engine/water_quality.py
+++ b/plant_engine/water_quality.py
@@ -16,6 +16,7 @@ __all__ = [
     "get_threshold",
     "interpret_water_profile",
     "classify_water_quality",
+    "score_water_quality",
 ]
 
 
@@ -61,3 +62,18 @@ def classify_water_quality(water_test: Dict[str, float]) -> str:
     if count <= 2:
         return "fair"
     return "poor"
+
+
+def score_water_quality(water_test: Dict[str, float]) -> float:
+    """Return a 0-100 score based on threshold exceedances."""
+    score = 100.0
+    for ion, limit in _THRESHOLDS.items():
+        if ion not in water_test:
+            continue
+        value = water_test[ion]
+        if value <= limit:
+            continue
+        exceed_ratio = (value - limit) / limit
+        penalty = min(exceed_ratio, 1.0) * 25
+        score -= penalty
+    return round(max(score, 0.0), 1)

--- a/tests/test_water_quality.py
+++ b/tests/test_water_quality.py
@@ -27,3 +27,12 @@ def test_classify_water_quality():
     assert rating_fair == "fair"
     rating_poor = water_quality.classify_water_quality({"Na": 60, "Cl": 120, "B": 2.0})
     assert rating_poor == "poor"
+
+
+def test_score_water_quality():
+    assert water_quality.score_water_quality({"Na": 40}) == 100.0
+    # Exceeding by 20% deducts 5 points
+    score = water_quality.score_water_quality({"Na": 60})
+    assert 94.0 <= score <= 95.0
+    low_score = water_quality.score_water_quality({"Na": 120, "Cl": 120})
+    assert low_score < score


### PR DESCRIPTION
## Summary
- add `score_water_quality` helper
- document water quality scoring in README
- test new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b29dda888330a3f1e48f8879e79f