### PR TITLE
Enhance fertigation planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.
+- **Multi-day Fertigation Plans**: `generate_fertigation_plan` returns the total
+  fertilizer mix required for any number of days at a chosen daily volume.
 - **Irrigation Targets**: `get_daily_irrigation_target` returns default
   milliliters per plant based on `irrigation_guidelines.json`.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -47,6 +47,7 @@ __all__ = [
     "recommend_uptake_fertigation",
     "recommend_nutrient_mix_with_cost",
     "recommend_nutrient_mix_with_cost_breakdown",
+    "generate_fertigation_plan",
 ]
 
 
@@ -432,4 +433,55 @@ def recommend_nutrient_mix_with_cost_breakdown(
 
     breakdown = estimate_cost_breakdown(schedule)
     return schedule, total, breakdown
+
+
+def generate_fertigation_plan(
+    plant_type: str,
+    stage: str,
+    days: int,
+    daily_water_ml: float,
+    *,
+    fertilizers: Mapping[str, str] | None = None,
+    purity_overrides: Mapping[str, float] | None = None,
+    include_micro: bool = False,
+    micro_fertilizers: Mapping[str, str] | None = None,
+) -> Dict[str, float]:
+    """Return total fertilizer requirements for a multi-day period.
+
+    Parameters
+    ----------
+    plant_type : str
+        Type of plant used for nutrient guidelines.
+    stage : str
+        Growth stage corresponding to the nutrient targets.
+    days : int
+        Number of days in the fertigation plan. Must be positive.
+    daily_water_ml : float
+        Irrigation volume per day in milliliters. Must be positive.
+    fertilizers : Mapping[str, str] | None, optional
+        Optional mapping of nutrient code to fertilizer IDs.
+    purity_overrides : Mapping[str, float] | None, optional
+        Purity factors overriding defaults from :data:`fertilizer_purity.json`.
+    include_micro : bool, optional
+        Include micronutrients if ``True``.
+    micro_fertilizers : Mapping[str, str] | None, optional
+        Mapping of micronutrient codes to fertilizer IDs.
+    """
+
+    if days <= 0:
+        raise ValueError("days must be positive")
+    if daily_water_ml <= 0:
+        raise ValueError("daily_water_ml must be positive")
+
+    total_volume_l = (daily_water_ml * days) / 1000
+
+    return recommend_nutrient_mix(
+        plant_type,
+        stage,
+        total_volume_l,
+        fertilizers=fertilizers,
+        purity_overrides=purity_overrides,
+        include_micro=include_micro,
+        micro_fertilizers=micro_fertilizers,
+    )
 

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -10,6 +10,7 @@ from plant_engine.fertigation import (
     estimate_daily_nutrient_uptake,
     recommend_nutrient_mix_with_cost,
     recommend_nutrient_mix_with_cost_breakdown,
+    generate_fertigation_plan,
 )
 
 
@@ -172,3 +173,15 @@ def test_recommend_nutrient_mix_with_cost_breakdown():
     assert total >= 0
     assert isinstance(breakdown, dict)
     assert sum(breakdown.values()) == pytest.approx(total, rel=0.1)
+
+
+def test_generate_fertigation_plan():
+    plan = generate_fertigation_plan(
+        "tomato",
+        "vegetative",
+        days=3,
+        daily_water_ml=2000.0,
+    )
+    assert plan["urea"] > 0
+    assert plan["map"] > 0
+    assert plan["kcl"] > 0


### PR DESCRIPTION
## Summary
- add `generate_fertigation_plan` helper for multi-day nutrient calculations
- test multi-day fertigation plans
- document new feature in README

## Testing
- `pytest -q`
- `pytest tests/test_fertigation.py::test_generate_fertigation_plan -q`


------
https://chatgpt.com/codex/tasks/task_e_6880b2a64bac8330b3ae3e2d4df7fcfe