### PR TITLE
Add VPD series calculation

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -72,6 +72,7 @@ __all__ = [
     "calculate_dli",
     "photoperiod_for_target_dli",
     "calculate_dli_series",
+    "calculate_vpd_series",
     "get_target_dli",
     "get_target_vpd",
     "humidity_for_target_vpd",
@@ -643,6 +644,24 @@ def calculate_dli_series(
             raise ValueError("PPFD values must be non-negative")
         total += val * 3600 * interval_hours
     return round(total / 1_000_000, 2)
+
+
+def calculate_vpd_series(
+    temp_values: Iterable[float], humidity_values: Iterable[float]
+) -> float:
+    """Return average VPD from paired temperature and humidity readings."""
+
+    temps = list(temp_values)
+    hums = list(humidity_values)
+    if len(temps) != len(hums):
+        raise ValueError("temperature and humidity readings must have the same length")
+    if not temps:
+        return 0.0
+
+    total = 0.0
+    for t, h in zip(temps, hums):
+        total += calculate_vpd(t, h)
+    return round(total / len(temps), 3)
 
 
 def get_target_dli(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -13,6 +13,7 @@ from plant_engine.environment_manager import (
     calculate_absolute_humidity,
     calculate_dli,
     calculate_dli_series,
+    calculate_vpd_series,
     photoperiod_for_target_dli,
     get_target_dli,
     get_target_vpd,
@@ -380,3 +381,16 @@ def test_evaluate_stress_conditions():
 
     stress_none = evaluate_stress_conditions(None, None, None, "citrus")
     assert stress_none.heat is None
+
+
+def test_calculate_vpd_series():
+    temps = [20, 22, 24]
+    humidity = [70, 65, 60]
+    expected = sum(calculate_vpd(t, h) for t, h in zip(temps, humidity)) / 3
+    assert calculate_vpd_series(temps, humidity) == round(expected, 3)
+
+    with pytest.raises(ValueError):
+        calculate_vpd_series([20], [60, 70])
+
+    with pytest.raises(ValueError):
+        calculate_vpd_series([20], [-1])


### PR DESCRIPTION
## Summary
- add `calculate_vpd_series` helper for environment analysis
- expose new helper through environment manager API
- test average VPD computation with validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b2ac88248330937457d1a1c0a3f4