### PR TITLE
Improve automation cycle utilities

### DIFF
--- a/custom_components/horticulture_assistant/automation/helpers.py
+++ b/custom_components/horticulture_assistant/automation/helpers.py
@@ -1,0 +1,39 @@
+"""Utility helpers for automation scripts."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+
+def iter_profiles(base_path: str) -> Iterable[Tuple[str, Dict]]:
+    """Yield ``(plant_id, profile_data)`` from ``base_path`` JSON files."""
+    path = Path(base_path)
+    if not path.is_dir():
+        return
+    for file in path.glob("*.json"):
+        try:
+            with open(file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            plant_id = data.get("plant_id") or file.stem
+            yield plant_id, data
+        except Exception:
+            continue
+
+
+def append_json_log(log_path: Path, entry: Dict) -> None:
+    """Append ``entry`` to a JSON list stored at ``log_path``."""
+    log_path.parent.mkdir(exist_ok=True)
+    log_entries = []
+    if log_path.is_file():
+        try:
+            with open(log_path, "r", encoding="utf-8") as f:
+                val = json.load(f)
+            if isinstance(val, list):
+                log_entries = val
+        except json.JSONDecodeError:
+            pass
+    log_entries.append(entry)
+    with open(log_path, "w", encoding="utf-8") as f:
+        json.dump(log_entries, f, indent=2)
+

--- a/tests/test_automation_cycles.py
+++ b/tests/test_automation_cycles.py
@@ -1,0 +1,62 @@
+import json
+from custom_components.horticulture_assistant.automation import run_automation_cycle, run_fertilizer_cycle
+from custom_components.horticulture_assistant.automation import irrigation_actuator, fertilizer_actuator
+
+
+def test_run_automation_cycle(tmp_path, monkeypatch):
+    plant_dir = tmp_path
+    profile = {
+        "plant_id": "plant1",
+        "thresholds": {"soil_moisture": 30},
+        "general": {"latest_env": {"soil_moisture": 20}},
+        "actuators": {"irrigation": "switch.irrigate"},
+    }
+    (plant_dir / "plant1.json").write_text(json.dumps(profile))
+
+    monkeypatch.setattr(run_automation_cycle, "ENABLE_AUTOMATION", True)
+    called = {}
+
+    def fake_trigger(plant_id: str, trigger: bool, base_path: str, hass=None):
+        called["plant"] = plant_id
+        called["trigger"] = trigger
+        called["base"] = base_path
+
+    monkeypatch.setattr(irrigation_actuator, "trigger_irrigation_actuator", fake_trigger)
+
+    run_automation_cycle.run_automation_cycle(str(plant_dir))
+
+    assert called["plant"] == "plant1"
+    log = plant_dir / "plant1" / "irrigation_log.json"
+    assert log.exists()
+    data = json.loads(log.read_text())
+    assert data and data[0]["triggered"] is True
+
+
+def test_run_fertilizer_cycle(tmp_path, monkeypatch):
+    plant_dir = tmp_path
+    profile = {
+        "plant_id": "p2",
+        "thresholds": {"N": 20},
+        "general": {"latest_env": {"N": 10}},
+        "actuators": {"fertilizer": "switch.fert"},
+    }
+    (plant_dir / "p2.json").write_text(json.dumps(profile))
+
+    monkeypatch.setattr(run_fertilizer_cycle, "ENABLE_AUTOMATION", True)
+    called = {}
+
+    def fake_trigger(plant_id: str, trigger: bool, base_path: str, hass=None):
+        called["plant"] = plant_id
+        called["trigger"] = trigger
+        called["base"] = base_path
+
+    monkeypatch.setattr(fertilizer_actuator, "trigger_fertilizer_actuator", fake_trigger)
+
+    run_fertilizer_cycle.run_fertilizer_cycle(str(plant_dir))
+
+    assert called["plant"] == "p2"
+    log = plant_dir / "p2" / "nutrient_application_log.json"
+    assert log.exists()
+    data = json.loads(log.read_text())
+    assert data and data[0]["triggered"] is True
+


### PR DESCRIPTION
## Summary
- refactor run_automation_cycle and run_fertilizer_cycle to share helpers
- add reusable automation helper module
- create unit tests for automation cycle scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880bba9c9b88330a4f1bd9963f8a9ce