### PR TITLE
Improve fertigation planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ or incomplete and should only be used as a starting point for your own research.
   the entire crop cycle.
 - **Irrigation Targets**: `get_daily_irrigation_target` returns default
   milliliters per plant based on `irrigation_guidelines.json`.
+- **Fertigation Planning**: `generate_fertigation_plan` produces a day-by-day
+  fertilizer schedule using those irrigation targets.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and
   micro guidelines with interaction checks to summarize deficiencies and
   surpluses at once.

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -42,6 +42,7 @@ from .fertigation import (
     recommend_correction_schedule,
     get_fertilizer_purity,
     recommend_nutrient_mix_with_cost_breakdown,
+    generate_fertigation_plan,
 )
 from .rootzone_model import (
     estimate_rootzone_depth,
@@ -159,6 +160,7 @@ __all__ = [
     "recommend_correction_schedule",
     "get_fertilizer_purity",
     "recommend_nutrient_mix_with_cost_breakdown",
+    "generate_fertigation_plan",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -10,6 +10,7 @@ from plant_engine.fertigation import (
     estimate_daily_nutrient_uptake,
     recommend_nutrient_mix_with_cost,
     recommend_nutrient_mix_with_cost_breakdown,
+    generate_fertigation_plan,
 )
 
 
@@ -172,3 +173,11 @@ def test_recommend_nutrient_mix_with_cost_breakdown():
     assert total >= 0
     assert isinstance(breakdown, dict)
     assert sum(breakdown.values()) == pytest.approx(total, rel=0.1)
+
+
+def test_generate_fertigation_plan():
+    plan = generate_fertigation_plan("lettuce", "seedling", 3)
+    assert len(plan) == 3
+    day1 = plan[1]
+    assert day1["N"] > 0
+    assert day1 == plan[2] == plan[3]


### PR DESCRIPTION
## Summary
- extend fertigation helper module with `generate_fertigation_plan`
- expose new helper from package
- document fertigation planning helper
- add unit test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880bba36508833082daea92dbb010c4