### PR TITLE
Enhance toxicity utilities with symptoms/treatments

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Key reference datasets reside in the `data/` directory:
 - `nutrient_surplus_actions.json` – steps to mitigate excess nutrient levels
 - `nutrient_interactions.json` – warning ratios for antagonistic nutrients
 - `nutrient_toxicity_thresholds.json` – upper limits to flag potential toxicity
+- `nutrient_toxicity_symptoms.json` – visual cues indicating nutrient excess
+- `nutrient_toxicity_treatments.json` – suggested mitigation steps for toxicity
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `pruning_guidelines.json` – stage-specific pruning recommendations
 - `soil_texture_parameters.json` – default field capacity and MAD values by soil texture

--- a/data/nutrient_toxicity_symptoms.json
+++ b/data/nutrient_toxicity_symptoms.json
@@ -1,0 +1,8 @@
+{
+  "N": "Leaf tips may burn and foliage turns dark green",
+  "P": "Excess phosphorus can cause micronutrient deficiencies",
+  "K": "High potassium can lead to calcium and magnesium deficiencies",
+  "Ca": "Leaf edges may brown and new growth can be stunted",
+  "Mg": "Older leaves may develop dark spots and dry edges",
+  "Fe": "Bronzing of leaves or dark spots on young foliage"
+}

--- a/data/nutrient_toxicity_treatments.json
+++ b/data/nutrient_toxicity_treatments.json
@@ -1,0 +1,8 @@
+{
+  "N": "Flush growing medium with clean water and reduce nitrogen inputs",
+  "P": "Reduce phosphorus fertilization and monitor micronutrient availability",
+  "K": "Leach soil with water and limit potassium fertilizers",
+  "Ca": "Leach excess with clean water and check pH",
+  "Mg": "Leach with water and avoid high magnesium fertilizers",
+  "Fe": "Reduce iron applications and adjust pH if needed"
+}

--- a/tests/test_toxicity_manager.py
+++ b/tests/test_toxicity_manager.py
@@ -2,6 +2,11 @@ from plant_engine.toxicity_manager import (
     list_supported_plants,
     get_toxicity_thresholds,
     check_toxicities,
+    list_known_nutrients,
+    get_toxicity_symptom,
+    diagnose_toxicities,
+    get_toxicity_treatment,
+    recommend_toxicity_treatments,
 )
 
 
@@ -9,6 +14,11 @@ def test_list_supported_plants():
     plants = list_supported_plants()
     assert "tomato" in plants
     assert "lettuce" in plants
+
+
+def test_list_known_nutrients():
+    nutrients = list_known_nutrients()
+    assert "N" in nutrients
 
 
 def test_get_toxicity_thresholds():
@@ -24,3 +34,16 @@ def test_check_toxicities():
     assert excess["N"] == 10
     assert "K" not in excess
     assert "Fe" not in excess
+
+
+def test_toxicity_symptom_and_treatment():
+    assert "burn" in get_toxicity_symptom("N").lower()
+    assert get_toxicity_treatment("P")
+
+
+def test_diagnose_and_recommend_treatments():
+    current = {"N": 260, "K": 400}
+    symptoms = diagnose_toxicities(current, "tomato")
+    actions = recommend_toxicity_treatments(current, "tomato")
+    assert "N" in symptoms and "burn" in symptoms["N"].lower()
+    assert "K" in actions and actions["K"]


### PR DESCRIPTION
## Summary
- load new datasets for nutrient toxicity symptoms and treatments
- extend `toxicity_manager` with helpers to expose that data
- document datasets in README
- test toxicity symptom and treatment helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880bb9bc0dc8330a5c4c0569a43d223