### PR TITLE
Add pest prevention dataset and utilities

### DIFF
--- a/data/pest_prevention.json
+++ b/data/pest_prevention.json
@@ -1,0 +1,42 @@
+{
+  "citrus": {
+    "aphids": "Encourage beneficial insects and avoid excess nitrogen.",
+    "scale": "Inspect regularly and prune infested branches."
+  },
+  "tomato": {
+    "aphids": "Use row covers early in the season.",
+    "blight": "Provide drip irrigation and avoid overhead watering."
+  },
+  "lettuce": {
+    "aphids": "Use reflective mulch to deter pests.",
+    "leafminers": "Introduce parasitic wasps early."
+  },
+  "strawberry": {
+    "spider mites": "Keep plants hydrated and mulch well.",
+    "slugs": "Remove hiding spots and use copper barriers."
+  },
+  "spinach": {
+    "aphids": "Encourage ladybugs and maintain vigor.",
+    "leaf miners": "Install row covers to exclude flies."
+  },
+  "basil": {
+    "aphids": "Pinch infested tips and attract lacewings.",
+    "leaf miners": "Remove affected foliage promptly."
+  },
+  "cucumber": {
+    "powdery mildew": "Space plants for airflow and avoid wet foliage.",
+    "cucumber beetle": "Use floating row covers until flowering."
+  },
+  "pepper": {
+    "aphids": "Introduce beneficial insects and avoid over fertilization.",
+    "spider mites": "Mist plants to increase humidity and hose off mites."
+  },
+  "arugula": {
+    "flea beetles": "Use row covers and remove nearby weeds.",
+    "aphids": "Encourage predators and avoid water stress."
+  },
+  "blueberry": {
+    "fruitworms": "Prune to improve airflow and remove weeds.",
+    "spotted wing drosophila": "Pick fruit promptly and use traps."
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -24,6 +24,8 @@ from .pest_manager import (
     get_pest_guidelines,
     recommend_treatments as recommend_pest_treatments,
     list_supported_plants as list_pest_plants,
+    get_pest_prevention,
+    recommend_prevention as recommend_pest_prevention,
 )
 from .pest_monitor import (
     get_pest_thresholds,
@@ -147,6 +149,8 @@ __all__ = [
     "list_environment_plants",
     "get_pest_guidelines",
     "recommend_pest_treatments",
+    "get_pest_prevention",
+    "recommend_pest_prevention",
     "list_pest_plants",
     "get_pest_thresholds",
     "assess_pest_pressure",

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -7,12 +7,14 @@ from .utils import load_dataset, normalize_key
 
 DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
+PREVENTION_FILE = "pest_prevention.json"
 
 
 
 # Datasets are cached by ``load_dataset`` so loaded once at import time
 _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
 _BENEFICIALS: Dict[str, List[str]] = load_dataset(BENEFICIAL_FILE)
+_PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -44,10 +46,26 @@ def recommend_beneficials(pests: Iterable[str]) -> Dict[str, List[str]]:
     return {p: get_beneficial_insects(p) for p in pests}
 
 
+def get_pest_prevention(plant_type: str) -> Dict[str, str]:
+    """Return pest prevention guidelines for ``plant_type``."""
+    return _PREVENTION.get(normalize_key(plant_type), {})
+
+
+def recommend_prevention(plant_type: str, pests: Iterable[str]) -> Dict[str, str]:
+    """Return preventative actions for each observed pest."""
+    guide = get_pest_prevention(plant_type)
+    actions: Dict[str, str] = {}
+    for pest in pests:
+        actions[pest] = guide.get(pest, "No guideline available")
+    return actions
+
+
 __all__ = [
     "list_supported_plants",
     "get_pest_guidelines",
     "recommend_treatments",
     "get_beneficial_insects",
     "recommend_beneficials",
+    "get_pest_prevention",
+    "recommend_prevention",
 ]

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -3,6 +3,8 @@ from plant_engine.pest_manager import (
     recommend_treatments,
     get_beneficial_insects,
     recommend_beneficials,
+    get_pest_prevention,
+    recommend_prevention,
 )
 
 
@@ -33,3 +35,15 @@ def test_recommend_beneficials():
     rec = recommend_beneficials(["aphids", "scale"])
     assert "ladybugs" in rec["aphids"]
     assert "parasitic wasps" in rec["scale"]
+
+
+def test_get_pest_prevention():
+    guide = get_pest_prevention("citrus")
+    assert "aphids" in guide
+    assert guide["scale"].startswith("Inspect")
+
+
+def test_recommend_prevention():
+    rec = recommend_prevention("citrus", ["aphids", "unknown"])
+    assert rec["aphids"].startswith("Encourage")
+    assert rec["unknown"] == "No guideline available"


### PR DESCRIPTION
## Summary
- include `pest_prevention.json` dataset for cultural control advice
- extend `pest_manager` with helpers to access pest prevention guidelines
- expose new functions from plant engine package
- test prevention helpers in `test_pest_manager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c6320ee08330b0b049aa1a96b5da