### PR TITLE
Enhance fertilizer utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ or incomplete and should only be used as a starting point for your own research.
   micronutrients using the new `micronutrient_guidelines.json` dataset.
 - **Mix Cost Estimation**: `recommend_nutrient_mix_with_cost` returns the same
   schedule along with an estimated dollar cost based on fertilizer prices.
+- **Mix Nutrient Totals**: `calculate_mix_nutrients` reports the elemental
+  nutrient amounts contributed by each fertilizer mix in milligrams.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.

--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -187,12 +187,36 @@ def estimate_cost_breakdown(schedule: Mapping[str, float]) -> Dict[str, float]:
     return breakdown
 
 
+def calculate_mix_nutrients(schedule: Mapping[str, float]) -> Dict[str, float]:
+    """Return nutrient totals (mg) for a fertilizer mix."""
+
+    inventory = _inventory()
+    totals: Dict[str, float] = {}
+
+    for fert_id, grams in schedule.items():
+        if grams <= 0:
+            continue
+        if fert_id not in inventory:
+            raise KeyError(f"Unknown fertilizer '{fert_id}'")
+
+        ga = convert_guaranteed_analysis(
+            inventory[fert_id].guaranteed_analysis
+        )
+        for nutrient, pct in ga.items():
+            totals[nutrient] = round(
+                totals.get(nutrient, 0.0) + grams * pct * 1000, 2
+            )
+
+    return totals
+
+
 __all__ = [
     "calculate_fertilizer_nutrients",
     "convert_guaranteed_analysis",
     "calculate_fertilizer_cost",
     "estimate_mix_cost",
     "estimate_cost_breakdown",
+    "calculate_mix_nutrients",
     "list_products",
     "get_product_info",
     "find_products",

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -20,6 +20,7 @@ calculate_fertilizer_cost = fert_mod.calculate_fertilizer_cost
 estimate_mix_cost = fert_mod.estimate_mix_cost
 estimate_cost_breakdown = fert_mod.estimate_cost_breakdown
 find_products = fert_mod.find_products
+calculate_mix_nutrients = fert_mod.calculate_mix_nutrients
 
 
 def test_convert_guaranteed_analysis():
@@ -95,4 +96,15 @@ def test_list_products_sorted_by_name():
     ids = list_products()
     names = [get_product_info(pid).product_name or pid for pid in ids]
     assert names == sorted(names)
+
+
+def test_calculate_mix_nutrients():
+    mix = {"foxfarm_grow_big": 9.6}
+    totals = calculate_mix_nutrients(mix)
+
+    reference = calculate_fertilizer_nutrients(
+        "plant", "foxfarm_grow_big", 10
+    )["nutrients"]
+
+    assert totals == reference
 


### PR DESCRIPTION
## Summary
- add `calculate_mix_nutrients` to compute elemental totals for a fertilizer mix
- document new helper in README
- test mix nutrient calculations

## Testing
- `pytest tests/test_fertilizer_formulator.py::test_calculate_mix_nutrients -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c64132948330a545065231b38d85