### PR TITLE
Enhance environment summary with stress metrics

### DIFF
--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -359,6 +359,8 @@ def test_summarize_environment():
     assert summary["adjustments"]["temperature"] == "increase"
     assert summary["adjustments"]["humidity"] == "decrease"
     assert "vpd" in summary["metrics"]
+    assert "score" in summary
+    assert "stress" in summary
 
 
 def test_evaluate_light_stress():


### PR DESCRIPTION
## Summary
- track environment score and stress flags in EnvironmentSummary
- improve calculate_dli_series implementation
- extend tests for the updated summarize_environment helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c649313c8330884524de3432b565