### PR TITLE
Enhance daily report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ or incomplete and should only be used as a starting point for your own research.
   returns a 0‑100 rating based on toxicity thresholds.
 - **Guideline Summary**: `get_guideline_summary` consolidates environment,
   nutrient and pest guidance for quick reference.
+- **Environment Targets in Reports**: Daily report files now include the
+  recommended temperature, humidity, light and CO₂ ranges for the plant's
+  current stage.
 
 
 ### Automation Blueprint Guide

--- a/tests/test_daily_report_builder.py
+++ b/tests/test_daily_report_builder.py
@@ -1,0 +1,55 @@
+import json
+import types
+import sys
+from pathlib import Path
+
+ha = types.ModuleType("homeassistant")
+ha.core = types.ModuleType("homeassistant.core")
+ha.core.HomeAssistant = object
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.core", ha.core)
+
+from custom_components.horticulture_assistant.utils import daily_report_builder as drb
+
+class DummyConfig:
+    def __init__(self, base: Path):
+        self._base = Path(base)
+    def path(self, *parts):
+        return str(self._base.joinpath(*parts))
+
+class DummyStates:
+    def __init__(self):
+        self._data = {}
+    def get(self, entity_id):
+        val = self._data.get(entity_id)
+        return types.SimpleNamespace(state=str(val)) if val is not None else None
+
+class DummyHass:
+    def __init__(self, base: Path):
+        self.config = DummyConfig(base)
+        self.states = DummyStates()
+
+
+def test_build_daily_report(tmp_path):
+    plants = tmp_path / "plants"
+    plants.mkdir()
+    profile = {
+        "general": {
+            "plant_type": "citrus",
+            "lifecycle_stage": "fruiting",
+            "sensor_entities": {"temperature": "sensor.p1_temp"},
+        },
+        "thresholds": {"light": 100},
+        "nutrients": {"N": 120},
+    }
+    (plants / "plant1.json").write_text(json.dumps(profile))
+
+    registry = {"plant1": {"plant_type": "citrus"}}
+    (tmp_path / "plant_registry.json").write_text(json.dumps(registry))
+
+    hass = DummyHass(tmp_path)
+    hass.states._data["sensor.p1_temp"] = "25"
+
+    report = drb.build_daily_report(hass, "plant1")
+    assert report.temperature == 25.0
+    assert report.environment_targets["temp_c"] == [18, 28]


### PR DESCRIPTION
## Summary
- refactor daily report builder to use dataclass
- include environment targets in daily reports
- document new functionality in README
- add regression test for daily report builder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880cc2ef5e88330a7bc8e9091338e8f