### PR TITLE
Enhance nutrient reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and
   micro guidelines with interaction checks to summarize deficiencies and
   surpluses at once.
+- **Daily Nutrient Report**: `run_daily_cycle` now embeds this analysis under
+  `nutrient_analysis` to highlight imbalances in recent applications.
 - **Pruning Recommendations**: Call `get_pruning_instructions` for stage-specific
   pruning tips loaded from `pruning_guidelines.json`.
 - **Beneficial Insect Suggestions**: Daily reports list natural predators for

--- a/tests/test_run_daily_cycle_nutrient_analysis.py
+++ b/tests/test_run_daily_cycle_nutrient_analysis.py
@@ -1,0 +1,25 @@
+import json
+from datetime import datetime
+from custom_components.horticulture_assistant.engine.run_daily_cycle import run_daily_cycle
+
+
+def test_run_daily_cycle_nutrient_analysis(tmp_path):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    out_dir = tmp_path / "reports"
+
+    (plants_dir / "plant1.json").write_text(json.dumps({"general": {"plant_type": "citrus", "lifecycle_stage": "vegetative"}}))
+    plant_dir = plants_dir / "plant1"
+    plant_dir.mkdir()
+    log = [
+        {
+            "timestamp": datetime.utcnow().isoformat(),
+            "nutrient_formulation": {"N": 50, "P": 20, "K": 40}
+        }
+    ]
+    (plant_dir / "nutrient_application_log.json").write_text(json.dumps(log))
+
+    report = run_daily_cycle("plant1", base_path=str(plants_dir), output_path=str(out_dir))
+
+    assert "nutrient_analysis" in report
+    assert report["nutrient_analysis"]["recommended"]["N"] == 80


### PR DESCRIPTION
## Summary
- extend `run_daily_cycle` with a nutrient analysis section
- add helper `_load_recent_entries` for efficient log parsing
- document new daily nutrient reporting capability
- add regression test for nutrient analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880cc26730c8330b6d257a8f69719f4