### PR TITLE
Add water quality summary to environment reporting

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, asdict
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
 from .utils import load_dataset, normalize_key
-from . import ph_manager
+from . import ph_manager, water_quality
 
 DATA_FILE = "environment_guidelines.json"
 DLI_DATA_FILE = "light_dli_guidelines.json"
@@ -86,6 +86,7 @@ __all__ = [
     "EnvironmentMetrics",
     "EnvironmentOptimization",
     "StressFlags",
+    "WaterQualityInfo",
     "normalize_environment_readings",
     "compare_environment",
     "generate_environment_alerts",
@@ -212,6 +213,17 @@ class StressFlags:
 
 
 @dataclass
+class WaterQualityInfo:
+    """Simple rating and score for irrigation water."""
+
+    rating: str
+    score: float
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
 class EnvironmentSummary:
     """High level summary of current environmental conditions."""
 
@@ -220,6 +232,7 @@ class EnvironmentSummary:
     metrics: EnvironmentMetrics
     score: float
     stress: StressFlags
+    water_quality: WaterQualityInfo | None = None
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -228,6 +241,7 @@ class EnvironmentSummary:
             "metrics": self.metrics.as_dict(),
             "score": self.score,
             "stress": self.stress.as_dict(),
+            "water_quality": self.water_quality.as_dict() if self.water_quality else None,
         }
 
 
@@ -776,9 +790,12 @@ def optimize_environment(
 
 
 def summarize_environment(
-    current: Mapping[str, float], plant_type: str, stage: str | None = None
+    current: Mapping[str, float],
+    plant_type: str,
+    stage: str | None = None,
+    water_test: Mapping[str, float] | None = None,
 ) -> Dict[str, Any]:
-    """Return combined quality rating, adjustments, metrics and stress."""
+    """Return combined quality rating, adjustments, metrics, stress and water quality."""
 
     readings = normalize_environment_readings(current)
 
@@ -793,11 +810,18 @@ def summarize_environment(
         stage,
     )
 
+    water_info = None
+    if water_test is not None:
+        rating = water_quality.classify_water_quality(water_test)
+        score = water_quality.score_water_quality(water_test)
+        water_info = WaterQualityInfo(rating=rating, score=score)
+
     summary = EnvironmentSummary(
         quality=classify_environment_quality(readings, plant_type, stage),
         adjustments=recommend_environment_adjustments(readings, plant_type, stage),
         metrics=metrics,
         score=score_environment(readings, plant_type, stage),
         stress=stress,
+        water_quality=water_info,
     )
     return summary.as_dict()

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -363,6 +363,17 @@ def test_summarize_environment():
     assert "stress" in summary
 
 
+def test_summarize_environment_with_water_quality():
+    summary = summarize_environment(
+        {"temperature": 22, "humidity": 70},
+        "citrus",
+        "vegetative",
+        water_test={"Na": 60, "Cl": 50},
+    )
+    assert summary["water_quality"]["rating"] == "fair"
+    assert "score" in summary["water_quality"]
+
+
 def test_evaluate_light_stress():
     assert evaluate_light_stress(8, "lettuce", "seedling") == "low"
     assert evaluate_light_stress(14, "lettuce", "seedling") == "high"


### PR DESCRIPTION
## Summary
- integrate water quality classification/score into environment summaries
- expose new `WaterQualityInfo` dataclass
- extend tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cc3465c88330a8c613e8255039a9