### PR TITLE
Refactor environment manager

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, asdict
+from functools import lru_cache
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
 from .utils import load_dataset, normalize_key
@@ -43,6 +44,52 @@ _ALIAS_MAP: Dict[str, str] = {
 }
 
 
+def _parse_range(value: Iterable[float]) -> Tuple[float, float] | None:
+    """Return a normalized (min, max) tuple or ``None`` if invalid."""
+    try:
+        low, high = value
+        low = float(low)
+        high = float(high)
+    except (TypeError, ValueError, Exception):
+        return None
+    return (low, high)
+
+
+@dataclass(frozen=True)
+class EnvironmentGuidelines:
+    """Environmental target ranges for a plant stage."""
+
+    temp_c: Tuple[float, float] | None = None
+    humidity_pct: Tuple[float, float] | None = None
+    light_ppfd: Tuple[float, float] | None = None
+    co2_ppm: Tuple[float, float] | None = None
+
+    def as_dict(self) -> Dict[str, list[float]]:
+        """Return guidelines as a dictionary with list values."""
+        result: Dict[str, list[float]] = {}
+        for k, v in asdict(self).items():
+            if v is not None:
+                result[k] = [float(v[0]), float(v[1])]
+        return result
+
+
+@lru_cache(maxsize=None)
+def get_environment_guidelines(
+    plant_type: str, stage: str | None = None
+) -> EnvironmentGuidelines:
+    """Return :class:`EnvironmentGuidelines` for the given plant stage."""
+
+    data = _lookup_stage_data(_DATA, plant_type, stage)
+    if not isinstance(data, Mapping):
+        data = {}
+    return EnvironmentGuidelines(
+        temp_c=_parse_range(data.get("temp_c")),
+        humidity_pct=_parse_range(data.get("humidity_pct")),
+        light_ppfd=_parse_range(data.get("light_ppfd")),
+        co2_ppm=_parse_range(data.get("co2_ppm")),
+    )
+
+
 def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, float]:
     """Return ``readings`` with keys mapped to canonical environment names."""
 
@@ -58,6 +105,7 @@ def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, f
 
 __all__ = [
     "list_supported_plants",
+    "get_environment_guidelines",
     "get_environmental_targets",
     "recommend_environment_adjustments",
     "score_environment",
@@ -85,6 +133,7 @@ __all__ = [
     "calculate_environment_metrics",
     "EnvironmentMetrics",
     "EnvironmentOptimization",
+    "EnvironmentGuidelines",
     "StressFlags",
     "normalize_environment_readings",
     "compare_environment",
@@ -240,7 +289,7 @@ def get_environmental_targets(
     plant_type: str, stage: str | None = None
 ) -> Dict[str, Any]:
     """Return recommended environmental ranges for a plant type and stage."""
-    return _lookup_stage_data(_DATA, plant_type, stage)
+    return get_environment_guidelines(plant_type, stage).as_dict()
 
 
 def _check_range(value: float, bounds: Tuple[float, float]) -> str | None:

--- a/tests/test_environment_guidelines.py
+++ b/tests/test_environment_guidelines.py
@@ -1,0 +1,15 @@
+from plant_engine.environment_manager import get_environment_guidelines, get_environmental_targets
+
+
+def test_get_environment_guidelines_dataclass():
+    guide = get_environment_guidelines("citrus", "seedling")
+    assert guide.temp_c == (22.0, 26.0)
+    assert guide.humidity_pct == (60.0, 80.0)
+    assert guide.light_ppfd == (150.0, 300.0)
+    assert guide.co2_ppm == (400.0, 600.0)
+
+
+def test_get_environmental_targets_matches_dataclass():
+    guide_dict = get_environmental_targets("citrus", "seedling")
+    guide = get_environment_guidelines("citrus", "seedling")
+    assert guide_dict == guide.as_dict()


### PR DESCRIPTION
## Summary
- refactor environment manager with `EnvironmentGuidelines` dataclass
- expose helper for retrieving guidelines
- update targets helper to use the dataclass
- add tests for the new dataclass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cc3c9e3883308f141fca9a31cf49