### PR TITLE
Improve root zone water balance

### DIFF
--- a/plant_engine/rootzone_model.py
+++ b/plant_engine/rootzone_model.py
@@ -18,6 +18,7 @@ _SOIL_DATA: Dict[str, Dict[str, Any]] = load_dataset(SOIL_DATA_FILE)
 __all__ = [
     "estimate_rootzone_depth",
     "estimate_water_capacity",
+    "calculate_remaining_water",
     "get_soil_parameters",
     "RootZone",
 ]
@@ -106,3 +107,25 @@ def estimate_water_capacity(
         field_capacity_pct=field_capacity,
         mad_pct=mad_fraction,
     )
+
+
+def calculate_remaining_water(
+    rootzone: RootZone,
+    available_ml: float,
+    *,
+    irrigation_ml: float = 0.0,
+    et_ml: float = 0.0,
+) -> float:
+    """Return updated available water volume within the root zone.
+
+    The result is clipped to the valid range ``0`` to
+    ``rootzone.total_available_water_ml``.
+    """
+
+    if any(x < 0 for x in (available_ml, irrigation_ml, et_ml)):
+        raise ValueError("Volumes must be non-negative")
+
+    new_vol = available_ml + irrigation_ml - et_ml
+    new_vol = min(new_vol, rootzone.total_available_water_ml)
+    return round(max(new_vol, 0.0), 1)
+

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -1,6 +1,7 @@
 from plant_engine.rootzone_model import (
     estimate_rootzone_depth,
     estimate_water_capacity,
+    calculate_remaining_water,
     get_soil_parameters,
     RootZone,
 )
@@ -43,4 +44,16 @@ def test_estimate_water_capacity_texture():
     result = estimate_water_capacity(10, area_cm2=100, texture="loam")
     assert result.total_available_water_ml == 250.0
     assert result.mad_pct == 0.45
+
+
+def test_calculate_remaining_water():
+    rz = estimate_water_capacity(10, area_cm2=100)
+    remaining = calculate_remaining_water(rz, 150.0, irrigation_ml=50.0, et_ml=25.0)
+    assert remaining == 175.0
+
+
+def test_calculate_remaining_water_clamped():
+    rz = estimate_water_capacity(10, area_cm2=100)
+    remaining = calculate_remaining_water(rz, 400.0, irrigation_ml=50.0, et_ml=10.0)
+    assert remaining == rz.total_available_water_ml
 


### PR DESCRIPTION
## Summary
- add `calculate_remaining_water` helper and export
- test new helper in root zone model tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cc450a4083308da842c05bc57a51