### PR TITLE
Handle Fahrenheit environment readings

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -28,7 +28,9 @@ ACTION_LABELS = {
 # ``compare_environment`` to match sensor names like ``temperature`` or
 # ``rh`` against dataset keys such as ``temp_c`` or ``humidity_pct``.
 ENV_ALIASES = {
-    "temp_c": ["temp_c", "temperature", "temp"],
+    "temp_c": ["temp_c", "temperature", "temp", "temperature_c"],
+    # Fahrenheit readings are converted to Celsius during normalization
+    "temp_f": ["temp_f", "temperature_f", "temp_fahrenheit"],
     "humidity_pct": ["humidity_pct", "humidity", "rh", "rh_pct"],
     "light_ppfd": ["light_ppfd", "light", "par", "par_w_m2"],
     "co2_ppm": ["co2_ppm", "co2"],
@@ -50,9 +52,13 @@ def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, f
     for key, value in readings.items():
         canonical = _ALIAS_MAP.get(key, key)
         try:
-            normalized[canonical] = float(value)
+            val = float(value)
         except (TypeError, ValueError):
             continue
+        if canonical == "temp_f":
+            val = (val - 32) * 5 / 9
+            canonical = "temp_c"
+        normalized[canonical] = val
     return normalized
 
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -347,6 +347,11 @@ def test_normalize_environment_readings_aliases():
         "ec": 1.2,
     }
 
+def test_normalize_environment_readings_temp_fahrenheit():
+    data = {"temperature_f": 86}
+    result = normalize_environment_readings(data)
+    assert result == {"temp_c": 30.0}
+
 
 def test_normalize_environment_readings_unknown_key():
     result = normalize_environment_readings({"foo": 1})


### PR DESCRIPTION
## Summary
- expand environment alias mapping to recognize Fahrenheit keys
- convert Fahrenheit inputs to Celsius in `normalize_environment_readings`
- test Fahrenheit normalization logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cc410b388330bac5c559c382e83c