### PR TITLE
Improve fertigation utilities

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -46,6 +46,7 @@ from .fertigation import (
     get_fertilizer_purity,
     recommend_nutrient_mix_with_cost_breakdown,
     generate_fertigation_plan,
+    calculate_mix_nutrients,
 )
 from .rootzone_model import (
     estimate_rootzone_depth,
@@ -167,6 +168,7 @@ __all__ = [
     "get_fertilizer_purity",
     "recommend_nutrient_mix_with_cost_breakdown",
     "generate_fertigation_plan",
+    "calculate_mix_nutrients",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -11,6 +11,7 @@ from plant_engine.fertigation import (
     recommend_nutrient_mix_with_cost,
     recommend_nutrient_mix_with_cost_breakdown,
     generate_fertigation_plan,
+    calculate_mix_nutrients,
 )
 
 
@@ -181,3 +182,21 @@ def test_generate_fertigation_plan():
     day1 = plan[1]
     assert day1["N"] > 0
     assert day1 == plan[2] == plan[3]
+
+
+def test_calculate_mix_nutrients_wrapper():
+    mix = {"foxfarm_grow_big": 9.6}
+    totals = calculate_mix_nutrients(mix)
+    assert totals["N"] > 0
+
+
+def test_estimate_daily_nutrient_uptake_invalid():
+    with pytest.raises(ValueError):
+        estimate_daily_nutrient_uptake("tomato", "vegetative", daily_water_ml=-1)
+
+
+def test_recommend_uptake_fertigation_invalid():
+    from plant_engine.fertigation import recommend_uptake_fertigation
+
+    with pytest.raises(ValueError):
+        recommend_uptake_fertigation("lettuce", "vegetative", num_plants=0)


### PR DESCRIPTION
## Summary
- refactor fertigation calculations to use a helper for ppm→grams
- add `calculate_mix_nutrients` wrapper and export via package init
- update tests for new helper behavior and extra edge cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d633a654833099f788eaccce1f7e