### PR TITLE
Add fertilizer mix ppm calculation

### DIFF
--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -210,6 +210,21 @@ def calculate_mix_nutrients(schedule: Mapping[str, float]) -> Dict[str, float]:
     return totals
 
 
+def calculate_mix_ppm(schedule: Mapping[str, float], volume_l: float) -> Dict[str, float]:
+    """Return nutrient concentration (ppm) for ``schedule`` dissolved in ``volume_l``.
+
+    ``volume_l`` is the final solution volume in liters. The returned mapping
+    contains nutrient codes mapped to parts per million. A ``ValueError`` is
+    raised if ``volume_l`` is not positive.
+    """
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    totals = calculate_mix_nutrients(schedule)
+    return {nutrient: round(mg / volume_l, 2) for nutrient, mg in totals.items()}
+
+
 __all__ = [
     "calculate_fertilizer_nutrients",
     "convert_guaranteed_analysis",
@@ -220,6 +235,7 @@ __all__ = [
     "list_products",
     "get_product_info",
     "find_products",
+    "calculate_mix_ppm",
 ]
 
 

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -21,6 +21,7 @@ estimate_mix_cost = fert_mod.estimate_mix_cost
 estimate_cost_breakdown = fert_mod.estimate_cost_breakdown
 find_products = fert_mod.find_products
 calculate_mix_nutrients = fert_mod.calculate_mix_nutrients
+calculate_mix_ppm = fert_mod.calculate_mix_ppm
 
 
 def test_convert_guaranteed_analysis():
@@ -107,4 +108,17 @@ def test_calculate_mix_nutrients():
     )["nutrients"]
 
     assert totals == reference
+
+
+def test_calculate_mix_ppm():
+    mix = {"foxfarm_grow_big": 9.6}
+    ppm = calculate_mix_ppm(mix, 10)
+
+    reference = calculate_mix_nutrients(mix)
+    expected = {k: round(v / 10, 2) for k, v in reference.items()}
+
+    assert ppm == expected
+
+    with pytest.raises(ValueError):
+        calculate_mix_ppm(mix, 0)
 


### PR DESCRIPTION
## Summary
- add `calculate_mix_ppm` helper to fertilizer formulator for ppm output
- test ppm calculation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d62b1a24833087e1b27746544f53