### PR TITLE
Add stage-based nutrient factor dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Key reference datasets reside in the `data/` directory:
 - `environment_guidelines.json` – optimal temperature, humidity and light by crop
 - `nutrient_guidelines.json` – recommended N‑P‑K levels across stages
 - `micronutrient_guidelines.json` – Fe/Mn/Zn/B/Cu/Mo levels across stages
+- `nutrient_stage_factors.json` – multipliers for adjusting nutrient targets by stage
 - `disease_guidelines.json` and `pest_guidelines.json` – treatment references
 - `disease_prevention.json` – cultural practices to prevent common diseases
 - `pest_thresholds.json` – action thresholds for common pests

--- a/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
@@ -14,17 +14,12 @@ except ImportError:
 
 from custom_components.horticulture_assistant.utils.plant_profile_loader import load_profile
 from plant_engine.nutrient_manager import get_recommended_levels
+from plant_engine.stage_factors import get_stage_factor
 from plant_engine.utils import load_json
 
 _LOGGER = logging.getLogger(__name__)
 
-# Default multipliers for nutrient targets by lifecycle stage
-STAGE_MULTIPLIERS = {
-    "seedling": 0.5,
-    "vegetative": 1.0,
-    "flowering": 1.2,
-    "fruiting": 1.1,
-}
+# Stage nutrient multipliers now loaded from dataset
 
 # Map common stage shorthand to formal stage names
 STAGE_SYNONYMS = {
@@ -141,11 +136,9 @@ def schedule_nutrients(plant_id: str, hass: HomeAssistant = None) -> dict:
                         _LOGGER.warning("Invalid nutrient factor in profile for stage '%s'; defaulting to 1.0", stage_key)
                     break
     if stage_multiplier == 1.0:
-        if stage_key in STAGE_MULTIPLIERS:
-            stage_multiplier = STAGE_MULTIPLIERS[stage_key]
-        else:
-            if stage_key not in ("unknown", ""):
-                _LOGGER.info("No predefined nutrient multiplier for stage '%s'; using 1.0", stage_key)
+        stage_multiplier = get_stage_factor(stage_key)
+        if stage_multiplier == 1.0 and stage_key not in ("unknown", ""):
+            _LOGGER.info("No predefined nutrient multiplier for stage '%s'; using 1.0", stage_key)
     # Log stage-based adjustment
     if stage_multiplier != 1.0:
         _LOGGER.info("Applying stage multiplier for '%s': %sx to all nutrient targets", stage_key, stage_multiplier)

--- a/data/nutrient_stage_factors.json
+++ b/data/nutrient_stage_factors.json
@@ -1,0 +1,6 @@
+{
+  "seedling": 0.5,
+  "vegetative": 1.0,
+  "flowering": 1.2,
+  "fruiting": 1.1
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -71,6 +71,7 @@ from .micro_manager import (
     calculate_surplus as calculate_micro_surplus,
 )
 from .growth_stage import get_stage_info, list_growth_stages
+from .stage_factors import get_stage_factor, list_stages as list_stage_factors
 from .guidelines import get_guideline_summary
 from .report import DailyReport
 from .engine import load_profile
@@ -179,6 +180,8 @@ __all__ = [
     "get_micro_levels",
     "get_stage_info",
     "list_growth_stages",
+    "get_stage_factor",
+    "list_stage_factors",
     "estimate_rootzone_depth",
     "estimate_water_capacity",
     "get_soil_parameters",

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -18,6 +18,7 @@ from plant_engine.environment_manager import (
 from plant_engine.nutrient_manager import get_recommended_levels
 from plant_engine.pest_manager import recommend_treatments as recommend_pest_treatments
 from plant_engine.disease_manager import recommend_treatments as recommend_disease_treatments
+from plant_engine.stage_factors import get_stage_factor
 from plant_engine.growth_stage import get_stage_info
 from plant_engine.report import DailyReport
 
@@ -58,13 +59,6 @@ def _normalize_env(env: Mapping[str, Any]) -> Dict[str, float]:
         mapped["photoperiod_hours"] = env["photoperiod_hours"]
     return mapped
 
-# Basic multipliers to scale nutrient recommendations by growth stage
-STAGE_MULTIPLIERS = {
-    "seedling": 0.5,
-    "vegetative": 1.0,
-    "flowering": 1.2,
-    "fruiting": 1.1,
-}
 
 def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
     """Run a full daily processing cycle for a plant profile."""
@@ -121,7 +115,7 @@ def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
     )
 
     stage_name = str(profile.get("stage", "")).lower()
-    stage_mult = STAGE_MULTIPLIERS.get(stage_name, 1.0)
+    stage_mult = get_stage_factor(stage_name)
     nutrient_targets = {
         n: round(v * stage_mult, 2) for n, v in guidelines.items()
     } if guidelines else {}

--- a/plant_engine/stage_factors.py
+++ b/plant_engine/stage_factors.py
@@ -1,0 +1,27 @@
+"""Stage-based nutrient adjustment factors."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "nutrient_stage_factors.json"
+
+_FACTORS: Dict[str, float] = load_dataset(DATA_FILE)
+
+__all__ = ["get_stage_factor", "list_stages"]
+
+
+def list_stages() -> list[str]:
+    """Return stages with defined nutrient factors."""
+    return sorted(_FACTORS.keys())
+
+
+@lru_cache(maxsize=None)
+def get_stage_factor(stage: str) -> float:
+    """Return nutrient multiplier for ``stage``.
+
+    If no factor is defined a value of ``1.0`` is returned.
+    """
+    return float(_FACTORS.get(normalize_key(stage), 1.0))

--- a/tests/test_stage_factors.py
+++ b/tests/test_stage_factors.py
@@ -1,0 +1,11 @@
+from plant_engine.stage_factors import get_stage_factor, list_stages
+
+
+def test_get_stage_factor():
+    assert get_stage_factor("fruiting") == 1.1
+    assert get_stage_factor("unknown") == 1.0
+
+
+def test_list_stages():
+    stages = list_stages()
+    assert "vegetative" in stages


### PR DESCRIPTION
## Summary
- support stage-specific nutrient factors via new data file
- refactor engine and scheduler to use `get_stage_factor`
- document new dataset in README
- add unit tests for stage factors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d61f9590833084351190bea5e53b