### PR TITLE
Improve dataset utilities and add test

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, asdict
 from functools import lru_cache
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 from . import ph_manager, water_quality
 
 DATA_FILE = "environment_guidelines.json"
@@ -307,7 +307,7 @@ class EnvironmentSummary:
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with available environment data."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_environmental_targets(

--- a/plant_engine/micro_manager.py
+++ b/plant_engine/micro_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Mapping
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "micronutrient_guidelines.json"
 
@@ -20,7 +20,7 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return plants with micronutrient guidelines."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "nutrient_guidelines.json"
 RATIO_DATA_FILE = "nutrient_ratio_guidelines.json"
@@ -30,7 +30,7 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with nutrient guidelines."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Dict, Mapping
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 from .pest_manager import recommend_treatments, recommend_beneficials
 
 DATA_FILE = "pest_thresholds.json"
@@ -38,7 +38,7 @@ def get_pest_thresholds(plant_type: str) -> Dict[str, int]:
 def list_supported_plants() -> list[str]:
     """Return plant types with pest threshold definitions."""
 
-    return sorted(_THRESHOLDS.keys())
+    return list_dataset_entries(_THRESHOLDS)
 
 
 def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -6,9 +6,15 @@ import json
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
-__all__ = ["load_json", "save_json", "load_dataset", "normalize_key"]
+__all__ = [
+    "load_json",
+    "save_json",
+    "load_dataset",
+    "normalize_key",
+    "list_dataset_entries",
+]
 
 
 def load_json(path: str) -> Dict[str, Any]:
@@ -47,3 +53,9 @@ def load_dataset(filename: str) -> Dict[str, Any]:
 def normalize_key(key: str) -> str:
     """Return ``key`` normalized for case-insensitive dataset lookups."""
     return str(key).lower().replace(" ", "_")
+
+
+def list_dataset_entries(dataset: Mapping[str, Any]) -> list[str]:
+    """Return sorted top-level keys from a dataset mapping."""
+
+    return sorted(str(k) for k in dataset.keys())

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -5,6 +5,7 @@ from plant_engine.rootzone_model import (
     get_soil_parameters,
     RootZone,
 )
+import pytest
 
 
 def test_estimate_rootzone_depth():
@@ -56,4 +57,10 @@ def test_calculate_remaining_water_clamped():
     rz = estimate_water_capacity(10, area_cm2=100)
     remaining = calculate_remaining_water(rz, 400.0, irrigation_ml=50.0, et_ml=10.0)
     assert remaining == rz.total_available_water_ml
+
+
+def test_calculate_remaining_water_negative():
+    rz = estimate_water_capacity(10, area_cm2=100)
+    with pytest.raises(ValueError):
+        calculate_remaining_water(rz, -1.0)
 


### PR DESCRIPTION
## Summary
- refactor dataset listing logic into new `list_dataset_entries` helper
- use helper across managers
- test negative values in `calculate_remaining_water`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d6144c588330a54d0b635deb46b3