### PR TITLE
Refactor fertigation plan with dataclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ or incomplete and should only be used as a starting point for your own research.
   the entire crop cycle.
 - **Irrigation Targets**: `get_daily_irrigation_target` returns default
   milliliters per plant based on `irrigation_guidelines.json`.
-- **Fertigation Planning**: `generate_fertigation_plan` produces a day-by-day
-  fertilizer schedule using those irrigation targets.
+- **Fertigation Planning**: `generate_fertigation_plan` now returns a
+  `FertigationPlan` dataclass providing a day-by-day fertilizer schedule via
+  `plan.as_dict()` and the per-day irrigation target.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and
   micro guidelines with interaction checks to summarize deficiencies and
   surpluses at once.

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -45,6 +45,8 @@ from .fertigation import (
     recommend_correction_schedule,
     get_fertilizer_purity,
     recommend_nutrient_mix_with_cost_breakdown,
+    FertigationDay,
+    FertigationPlan,
     generate_fertigation_plan,
 )
 from .rootzone_model import (
@@ -166,6 +168,8 @@ __all__ = [
     "recommend_correction_schedule",
     "get_fertilizer_purity",
     "recommend_nutrient_mix_with_cost_breakdown",
+    "FertigationDay",
+    "FertigationPlan",
     "generate_fertigation_plan",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -11,6 +11,7 @@ from plant_engine.fertigation import (
     recommend_nutrient_mix_with_cost,
     recommend_nutrient_mix_with_cost_breakdown,
     generate_fertigation_plan,
+    FertigationDay,
 )
 
 
@@ -177,7 +178,16 @@ def test_recommend_nutrient_mix_with_cost_breakdown():
 
 def test_generate_fertigation_plan():
     plan = generate_fertigation_plan("lettuce", "seedling", 3)
-    assert len(plan) == 3
-    day1 = plan[1]
+    plan_dict = plan.as_dict()
+    assert len(plan_dict) == 3
+    day1 = plan_dict[1]
     assert day1["N"] > 0
-    assert day1 == plan[2] == plan[3]
+    assert day1 == plan_dict[2] == plan_dict[3]
+
+
+def test_fertigation_plan_dataclass():
+    plan = generate_fertigation_plan("citrus", "seedling", 2)
+    assert plan.plant_type == "citrus"
+    assert plan.stage == "seedling"
+    assert len(plan.days) == 2
+    assert all(isinstance(day, FertigationDay) for day in plan.days)


### PR DESCRIPTION
## Summary
- return fertigation plans as dataclasses for clarity
- export new classes from package
- document dataclass usage in README
- expand tests for fertigation plan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d61a4a848330b07a394f32d6a5bc