### PR TITLE
Add irrigation schedule generator

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -58,6 +58,7 @@ from .irrigation_manager import (
     recommend_irrigation_interval,
     list_supported_plants as list_irrigation_plants,
     get_daily_irrigation_target,
+    generate_irrigation_schedule,
 )
 from .nutrient_manager import (
     calculate_deficiencies,
@@ -187,6 +188,7 @@ __all__ = [
     "recommend_irrigation_interval",
     "list_irrigation_plants",
     "get_daily_irrigation_target",
+    "generate_irrigation_schedule",
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -8,6 +8,7 @@ from plant_engine.irrigation_manager import (
     recommend_irrigation_from_environment,
     get_daily_irrigation_target,
     list_supported_plants,
+    generate_irrigation_schedule,
 )
 from plant_engine.rootzone_model import RootZone
 from plant_engine.compute_transpiration import compute_transpiration
@@ -112,4 +113,15 @@ def test_daily_irrigation_target_lookup():
     assert get_daily_irrigation_target("citrus", "vegetative") == 250
     assert "citrus" in list_supported_plants()
     assert get_daily_irrigation_target("unknown", "stage") == 0.0
+
+
+def test_generate_irrigation_schedule():
+    zone = RootZone(
+        root_depth_cm=10,
+        root_volume_cm3=1000,
+        total_available_water_ml=200.0,
+        readily_available_water_ml=100.0,
+    )
+    schedule = generate_irrigation_schedule(zone, 150.0, [30.0, 30.0, 30.0])
+    assert schedule == {1: 0.0, 2: 80.0, 3: 0.0}
 


### PR DESCRIPTION
## Summary
- export irrigation scheduler from irrigation_manager
- generate irrigation schedule from ET data
- cover schedule generator in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d625501883309b9805266920e7e6