### PR TITLE
Add EC management module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.data/
+data/pending_thresholds/
+data/water_balance/
+data/reports/

--- a/data/ec_guidelines.json
+++ b/data/ec_guidelines.json
@@ -1,0 +1,14 @@
+{
+  "lettuce": {
+    "seedling": [0.8, 1.2],
+    "harvest": [1.2, 1.8]
+  },
+  "tomato": {
+    "seedling": [1.0, 1.5],
+    "fruiting": [2.0, 3.5]
+  },
+  "citrus": {
+    "vegetative": [1.2, 2.0],
+    "fruiting": [1.8, 2.5]
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -109,6 +109,12 @@ from .water_quality import (
     get_threshold as get_water_threshold,
     interpret_water_profile,
 )
+from .ec_manager import (
+    list_supported_plants as list_ec_plants,
+    get_ec_range,
+    classify_ec_level,
+    recommend_ec_adjustment,
+)
 from .toxicity_manager import (
     list_supported_plants as list_toxicity_plants,
     get_toxicity_thresholds,
@@ -204,6 +210,10 @@ __all__ = [
     "list_water_analytes",
     "get_water_threshold",
     "interpret_water_profile",
+    "list_ec_plants",
+    "get_ec_range",
+    "classify_ec_level",
+    "recommend_ec_adjustment",
     "list_ph_plants",
     "get_ph_range",
     "recommend_ph_adjustment",

--- a/plant_engine/ec_manager.py
+++ b/plant_engine/ec_manager.py
@@ -1,0 +1,66 @@
+"""EC (electrical conductivity) guidelines and helpers."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, Tuple
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "ec_guidelines.json"
+
+# cache dataset load
+@lru_cache(maxsize=None)
+def _data() -> Dict[str, Dict[str, Tuple[float, float]]]:
+    return load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_ec_range",
+    "classify_ec_level",
+    "recommend_ec_adjustment",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with EC guidelines."""
+    return sorted(_data().keys())
+
+
+def get_ec_range(plant_type: str, stage: str | None = None) -> Tuple[float, float] | None:
+    """Return (min, max) EC range for ``plant_type`` and ``stage`` if defined."""
+    plant = _data().get(normalize_key(plant_type))
+    if not plant:
+        return None
+    if stage:
+        stage_key = normalize_key(stage)
+        range_vals = plant.get(stage_key)
+        if isinstance(range_vals, (list, tuple)) and len(range_vals) == 2:
+            return float(range_vals[0]), float(range_vals[1])
+    default = plant.get("default")
+    if isinstance(default, (list, tuple)) and len(default) == 2:
+        return float(default[0]), float(default[1])
+    return None
+
+
+def classify_ec_level(ec_ds_m: float, plant_type: str, stage: str | None = None) -> str:
+    """Return ``'low'``, ``'optimal'`` or ``'high'`` based on guideline range."""
+    rng = get_ec_range(plant_type, stage)
+    if not rng:
+        return "unknown"
+    low, high = rng
+    if ec_ds_m < low:
+        return "low"
+    if ec_ds_m > high:
+        return "high"
+    return "optimal"
+
+
+def recommend_ec_adjustment(ec_ds_m: float, plant_type: str, stage: str | None = None) -> str:
+    """Return adjustment suggestion for an EC reading."""
+    level = classify_ec_level(ec_ds_m, plant_type, stage)
+    if level == "low":
+        return "increase"
+    if level == "high":
+        return "decrease"
+    return "none"
+

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -13,6 +13,7 @@ from . import (
     pest_monitor,
     disease_manager,
     ph_manager,
+    ec_manager,
     growth_stage,
 )
 
@@ -32,6 +33,7 @@ class GuidelineSummary:
     pest_thresholds: Dict[str, int] = dataclass_field(default_factory=dict)
     beneficial_insects: Dict[str, list[str]] = dataclass_field(default_factory=dict)
     ph_range: List[float] = dataclass_field(default_factory=list)
+    ec_range: List[float] = dataclass_field(default_factory=list)
     stage_info: Optional[Dict[str, Any]] = None
     stages: Optional[List[str]] = None
 
@@ -61,6 +63,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         pest_thresholds=thresholds,
         beneficial_insects=beneficial,
         ph_range=ph_manager.get_ph_range(plant_type, stage),
+        ec_range=list(ec_manager.get_ec_range(plant_type, stage) or []),
         stage_info=growth_stage.get_stage_info(plant_type, stage) if stage else None,
         stages=None if stage else growth_stage.list_growth_stages(plant_type),
     )

--- a/tests/test_ec_manager.py
+++ b/tests/test_ec_manager.py
@@ -1,0 +1,24 @@
+from plant_engine import ec_manager
+
+
+def test_list_supported_plants():
+    plants = ec_manager.list_supported_plants()
+    assert "lettuce" in plants
+    assert "tomato" in plants
+
+
+def test_get_ec_range():
+    rng = ec_manager.get_ec_range("lettuce", "seedling")
+    assert rng == (0.8, 1.2)
+
+
+def test_classify_ec_level():
+    assert ec_manager.classify_ec_level(0.7, "lettuce", "seedling") == "low"
+    assert ec_manager.classify_ec_level(1.0, "lettuce", "seedling") == "optimal"
+    assert ec_manager.classify_ec_level(1.3, "lettuce", "seedling") == "high"
+
+
+def test_recommend_ec_adjustment():
+    assert ec_manager.recommend_ec_adjustment(0.7, "lettuce", "seedling") == "increase"
+    assert ec_manager.recommend_ec_adjustment(1.0, "lettuce", "seedling") == "none"
+    assert ec_manager.recommend_ec_adjustment(1.3, "lettuce", "seedling") == "decrease"


### PR DESCRIPTION
## Summary
- ignore output and cache directories
- add dataset for EC ranges
- implement `ec_manager` for EC classification and adjustments
- integrate EC data into guideline summaries
- expose EC helpers in `plant_engine` API
- test EC manager utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d948c2e0833099699efb832d16c8