### PR TITLE
Add root depth dataset and integrate with rootzone model

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Key reference datasets reside in the `data/` directory:
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `pruning_guidelines.json` – stage-specific pruning recommendations
 - `soil_texture_parameters.json` – default field capacity and MAD values by soil texture
+- `root_depth_guidelines.json` – typical maximum root depth (cm) for common crops
 - `irrigation_guidelines.json` – default daily irrigation volume per plant stage
 - `yield/` – per‑plant yield logs created during operation
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations

--- a/data/root_depth_guidelines.json
+++ b/data/root_depth_guidelines.json
@@ -1,0 +1,7 @@
+{
+  "tomato": 60,
+  "lettuce": 20,
+  "cucumber": 40,
+  "strawberry": 30,
+  "pepper": 50
+}

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -1,5 +1,6 @@
 from plant_engine.rootzone_model import (
     estimate_rootzone_depth,
+    get_default_root_depth,
     estimate_water_capacity,
     calculate_remaining_water,
     get_soil_parameters,
@@ -39,6 +40,11 @@ def test_get_soil_parameters():
     params = get_soil_parameters("loam")
     assert params["field_capacity"] == 0.25
     assert params["mad_fraction"] == 0.45
+
+
+def test_get_default_root_depth():
+    assert get_default_root_depth("tomato") == 60
+    assert get_default_root_depth("unknown") == 30.0
 
 
 def test_estimate_water_capacity_texture():


### PR DESCRIPTION
## Summary
- add `root_depth_guidelines.json` dataset
- load default root depth in `rootzone_model`
- expose `get_default_root_depth`
- document new dataset in README
- test default root depth helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d9590834833085ecdbd329e987aa