### PR TITLE
Add disease monitoring utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ or incomplete and should only be used as a starting point for your own research.
   beneficial insects to deploy when pest thresholds are exceeded.
 - **Pest Monitoring Report**: `generate_pest_report` combines severity,
   treatment, biological control and prevention advice for observed pests.
+- **Disease Monitoring Report**: `generate_disease_report` now provides
+  severity and treatment guidance based on new `disease_thresholds.json`.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily
   reports provide an estimated harvest date based on `growth_stages.json`.
 - **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to

--- a/data/disease_thresholds.json
+++ b/data/disease_thresholds.json
@@ -1,0 +1,14 @@
+{
+  "citrus": {
+    "citrus greening": 1,
+    "root rot": 2
+  },
+  "tomato": {
+    "blight": 1,
+    "powdery mildew": 3
+  },
+  "lettuce": {
+    "downy mildew": 2,
+    "tipburn": 3
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -34,6 +34,13 @@ from .pest_monitor import (
     assess_pest_pressure,
     recommend_threshold_actions,
 )
+from .disease_monitor import (
+    get_disease_thresholds,
+    assess_disease_pressure,
+    classify_disease_severity,
+    recommend_threshold_actions as recommend_disease_threshold_actions,
+    generate_disease_report,
+)
 from .disease_manager import (
     get_disease_guidelines,
     recommend_treatments as recommend_disease_treatments,
@@ -166,6 +173,11 @@ __all__ = [
     "get_disease_prevention",
     "recommend_disease_prevention",
     "list_disease_plants",
+    "get_disease_thresholds",
+    "assess_disease_pressure",
+    "classify_disease_severity",
+    "recommend_disease_threshold_actions",
+    "generate_disease_report",
     "recommend_fertigation_schedule",
     "recommend_correction_schedule",
     "get_fertilizer_purity",

--- a/plant_engine/disease_monitor.py
+++ b/plant_engine/disease_monitor.py
@@ -1,0 +1,103 @@
+"""Disease threshold monitoring utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Dict, Iterable, Mapping
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+from .disease_manager import recommend_treatments, recommend_prevention
+
+DATA_FILE = "disease_thresholds.json"
+
+# Cached dataset
+_THRESHOLDS: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_disease_thresholds",
+    "assess_disease_pressure",
+    "classify_disease_severity",
+    "recommend_threshold_actions",
+    "generate_disease_report",
+    "DiseaseReport",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with disease threshold data."""
+    return list_dataset_entries(_THRESHOLDS)
+
+
+def get_disease_thresholds(plant_type: str) -> Dict[str, int]:
+    """Return disease count thresholds for ``plant_type`` with normalized keys."""
+    raw = _THRESHOLDS.get(normalize_key(plant_type), {})
+    return {normalize_key(k): int(v) for k, v in raw.items()}
+
+
+def assess_disease_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:
+    """Return mapping of diseases to ``True`` if counts exceed thresholds."""
+    thresholds = get_disease_thresholds(plant_type)
+    pressure: Dict[str, bool] = {}
+    for name, count in observations.items():
+        key = normalize_key(name)
+        thresh = thresholds.get(key)
+        if thresh is None:
+            continue
+        pressure[key] = count >= thresh
+    return pressure
+
+
+def classify_disease_severity(plant_type: str, observations: Mapping[str, int]) -> Dict[str, str]:
+    """Return ``low``, ``moderate`` or ``severe`` classifications."""
+    thresholds = get_disease_thresholds(plant_type)
+    severity: Dict[str, str] = {}
+    for name, count in observations.items():
+        key = normalize_key(name)
+        thresh = thresholds.get(key)
+        if thresh is None:
+            continue
+        if count < thresh:
+            level = "low"
+        elif count < thresh * 2:
+            level = "moderate"
+        else:
+            level = "severe"
+        severity[key] = level
+    return severity
+
+
+def recommend_threshold_actions(plant_type: str, observations: Mapping[str, int]) -> Dict[str, str]:
+    """Return treatment actions for diseases exceeding thresholds."""
+    pressure = assess_disease_pressure(plant_type, observations)
+    exceeded = [name for name in observations if pressure.get(normalize_key(name))]
+    if not exceeded:
+        return {}
+    return recommend_treatments(plant_type, exceeded)
+
+
+@dataclass
+class DiseaseReport:
+    """Consolidated disease monitoring report."""
+
+    severity: Dict[str, str]
+    thresholds_exceeded: Dict[str, bool]
+    treatments: Dict[str, str]
+    prevention: Dict[str, str]
+
+    def as_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def generate_disease_report(plant_type: str, observations: Mapping[str, int]) -> Dict[str, object]:
+    """Return severity, treatment and prevention recommendations."""
+    severity = classify_disease_severity(plant_type, observations)
+    thresholds = assess_disease_pressure(plant_type, observations)
+    treatments = recommend_threshold_actions(plant_type, observations)
+    prevention = recommend_prevention(plant_type, observations.keys())
+    report = DiseaseReport(
+        severity=severity,
+        thresholds_exceeded=thresholds,
+        treatments=treatments,
+        prevention=prevention,
+    )
+    return report.as_dict()

--- a/tests/test_disease_monitor.py
+++ b/tests/test_disease_monitor.py
@@ -1,0 +1,42 @@
+from plant_engine.disease_monitor import (
+    list_supported_plants,
+    get_disease_thresholds,
+    assess_disease_pressure,
+    classify_disease_severity,
+    recommend_threshold_actions,
+    generate_disease_report,
+)
+
+
+def test_get_disease_thresholds():
+    thresholds = get_disease_thresholds("citrus")
+    assert thresholds["citrus_greening"] == 1
+    assert thresholds["root_rot"] == 2
+
+
+def test_assess_disease_pressure():
+    obs = {"citrus greening": 2, "root rot": 1}
+    result = assess_disease_pressure("citrus", obs)
+    assert result == {"citrus_greening": True, "root_rot": False}
+
+
+def test_classify_disease_severity():
+    obs = {"citrus greening": 1, "root rot": 3}
+    result = classify_disease_severity("citrus", obs)
+    assert result["citrus_greening"] == "moderate"
+    assert result["root_rot"] == "moderate"
+
+
+def test_recommend_threshold_actions():
+    obs = {"citrus greening": 2}
+    actions = recommend_threshold_actions("citrus", obs)
+    assert "citrus greening" in actions
+
+
+def test_generate_disease_report():
+    obs = {"citrus greening": 2, "root rot": 0}
+    report = generate_disease_report("citrus", obs)
+    assert report["severity"]["citrus_greening"] == "severe"
+    assert report["thresholds_exceeded"]["citrus_greening"] is True
+    assert "citrus greening" in report["treatments"]
+    assert "root rot" in report["prevention"]


### PR DESCRIPTION
## Summary
- add new `disease_monitor` module with severity and treatment helpers
- integrate disease monitor functions into package API
- include dataset `disease_thresholds.json`
- document new disease report feature
- test disease monitoring utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d97d46cc83308def6058f0db68a7