### PR TITLE
Enhance fertigation utils and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Total Uptake Estimation**: `estimate_stage_totals` multiplies daily uptake by
   growth stage duration while `estimate_total_uptake` sums these values across
   the entire crop cycle.
+- **Uptake Cost Estimation**: `estimate_stage_cost` and `estimate_cycle_cost`
+  convert those totals into fertilizer costs using price data.
 - **Irrigation Targets**: `get_daily_irrigation_target` returns default
   milliliters per plant based on `irrigation_guidelines.json`.
 - **Fertigation Planning**: `generate_fertigation_plan` produces a day-by-day

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -48,6 +48,8 @@ from .fertigation import (
     recommend_nutrient_mix_with_cost_breakdown,
     generate_fertigation_plan,
     calculate_mix_nutrients,
+    estimate_stage_cost,
+    estimate_cycle_cost,
 )
 from .rootzone_model import (
     estimate_rootzone_depth,
@@ -172,6 +174,8 @@ __all__ = [
     "recommend_nutrient_mix_with_cost_breakdown",
     "generate_fertigation_plan",
     "calculate_mix_nutrients",
+    "estimate_stage_cost",
+    "estimate_cycle_cost",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",

--- a/plant_engine/approval_queue.py
+++ b/plant_engine/approval_queue.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from datetime import datetime
 from typing import Dict
 
 from .utils import load_json, save_json
+
+_LOGGER = logging.getLogger(__name__)
 
 PENDING_DIR = "data/pending_thresholds"
 
@@ -28,7 +31,9 @@ def queue_threshold_updates(plant_id: str, old: Dict, new: Dict) -> str:
 
     save_json(pending_file, record)
 
-    print(f"📝 Queued {len(record['changes'])} threshold changes for {plant_id}")
+    _LOGGER.info(
+        "Queued %d threshold changes for %s", len(record["changes"]), plant_id
+    )
     return pending_file
 
 def apply_approved_thresholds(plant_path: str, pending_file: str) -> int:
@@ -48,6 +53,8 @@ def apply_approved_thresholds(plant_path: str, pending_file: str) -> int:
     plant["thresholds"] = updated
     save_json(plant_path, plant)
 
-    print(f"✅ Applied {applied} approved changes for {pending['plant_id']}")
+    _LOGGER.info(
+        "Applied %d approved changes for %s", applied, pending.get("plant_id")
+    )
     return applied
 

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Dict, Mapping, Any
 from plant_engine.utils import load_json, save_json
 from plant_engine.ai_model import analyze
@@ -33,6 +34,8 @@ DEFAULT_ENV = {
     "par_w_m2": 350,
     "wind_speed_m_s": 1.2,
 }
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def load_profile(plant_id: str) -> Dict[str, Any]:
@@ -162,7 +165,9 @@ def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
     if profile.get("auto_approve_all", False):
         profile["thresholds"] = recommendations
         save_json(plant_file, profile)
-        print(f"✅ Auto-applied AI threshold updates for {plant_id}")
+        _LOGGER.info(
+            "Auto-applied AI threshold updates for %s", plant_id
+        )
     else:
         queue_threshold_updates(plant_id, profile["thresholds"], recommendations)
 
@@ -170,6 +175,6 @@ def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     out_path = os.path.join(OUTPUT_DIR, f"{plant_id}.json")
     save_json(out_path, report)
-    print(f"📄 Daily report saved for {plant_id}")
+    _LOGGER.info("Daily report saved for %s", plant_id)
 
     return report

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -200,3 +200,27 @@ def test_recommend_uptake_fertigation_invalid():
 
     with pytest.raises(ValueError):
         recommend_uptake_fertigation("lettuce", "vegetative", num_plants=0)
+
+
+def test_estimate_stage_and_cycle_cost():
+    from plant_engine.fertigation import estimate_stage_cost, estimate_cycle_cost
+
+    stage_cost = estimate_stage_cost(
+        "lettuce",
+        "vegetative",
+        fertilizers={
+            "N": "foxfarm_grow_big",
+            "P": "foxfarm_grow_big",
+            "K": "intrepid_granular_potash_0_0_60",
+        },
+    )
+    cycle_cost = estimate_cycle_cost(
+        "lettuce",
+        fertilizers={
+            "N": "foxfarm_grow_big",
+            "P": "foxfarm_grow_big",
+            "K": "intrepid_granular_potash_0_0_60",
+        },
+    )
+    assert stage_cost >= 0
+    assert cycle_cost >= stage_cost


### PR DESCRIPTION
## Summary
- swap print statements for logging in approval and engine modules
- add helpers to estimate fertilizer costs from uptake totals
- re-export new functions
- test stage and cycle cost estimators
- document cost estimation helpers in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880d96bdd808330b25f27cd53e1d994