### PR TITLE
Add yield projection to daily reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ or incomplete and should only be used as a starting point for your own research.
   reports provide an estimated harvest date based on `growth_stages.json`.
 - **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to
   expected totals from `yield_estimates.json`.
+  Daily reports now expose this value under `remaining_yield_g` for quick
+  tracking.
 - **Environment Quality Rating**: `classify_environment_quality` converts the
   numeric score from `score_environment` into `good`, `fair` or `poor` for
   quick evaluation.

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -25,6 +25,7 @@ from plant_engine.utils import load_dataset
 from plant_engine.fertigation import recommend_nutrient_mix
 from plant_engine.nutrient_analysis import analyze_nutrient_profile
 from plant_engine.rootzone_model import estimate_water_capacity
+from plant_engine.yield_prediction import estimate_remaining_yield
 
 
 @dataclass
@@ -50,6 +51,7 @@ class DailyReport:
     irrigation_target_ml: float | None = None
     predicted_harvest_date: str | None = None
     yield_: float | None = None
+    remaining_yield_g: float | None = None
     timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
     def as_dict(self) -> dict:
@@ -260,6 +262,10 @@ def run_daily_cycle(
     if yield_entries:
         last_yield = yield_entries[-1].get("yield_quantity")
         report.yield_ = last_yield
+    # Estimate remaining yield from logged harvests and expectations
+    remaining = estimate_remaining_yield(plant_id, plant_type)
+    if remaining is not None:
+        report.remaining_yield_g = remaining
     # Save the report to a JSON file with today's date
     output_dir = Path(output_path)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_run_daily_cycle_remaining_yield.py
+++ b/tests/test_run_daily_cycle_remaining_yield.py
@@ -1,0 +1,36 @@
+import json
+import importlib
+
+
+def _import_cycle():
+    module = importlib.import_module(
+        "custom_components.horticulture_assistant.engine.run_daily_cycle"
+    )
+    importlib.reload(module)
+    return module.run_daily_cycle
+
+
+def test_run_daily_cycle_remaining_yield(tmp_path, monkeypatch):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    out_dir = tmp_path / "reports"
+
+    (plants_dir / "p.json").write_text(json.dumps({"general": {"plant_type": "tomato", "lifecycle_stage": "vegetative"}}))
+    (plants_dir / "p").mkdir()
+
+    yield_dir = tmp_path / "yield"
+    yield_dir.mkdir()
+    (yield_dir / "p.json").write_text(json.dumps({"harvests": [{"date": "2024-01-01", "yield_grams": 300}]}))
+
+    monkeypatch.setenv("HORTICULTURE_YIELD_DIR", str(yield_dir))
+    import plant_engine.yield_manager as ym
+    import plant_engine.yield_prediction as yp
+    importlib.reload(ym)
+    importlib.reload(yp)
+    run_daily_cycle = _import_cycle()
+    report = run_daily_cycle("p", base_path=str(plants_dir), output_path=str(out_dir))
+
+    assert report["remaining_yield_g"] == 3200.0
+    # Reset cached datasets for subsequent tests
+    import plant_engine.utils as utils
+    importlib.reload(utils)


### PR DESCRIPTION
## Summary
- include remaining yield estimation in `run_daily_cycle`
- document new report field in README
- add regression test for remaining yield calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d95015888330a3c27f2d4569dbfe