### PR TITLE
Enhance environment scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Environment Quality Rating**: `classify_environment_quality` converts the
   numeric score from `score_environment` into `good`, `fair` or `poor` for
   quick evaluation.
+- **Environment Score Breakdown**: `score_environment_components` returns
+  per-parameter scores so problem areas are easy to identify.
 - **Photoperiod Suggestions**: `recommend_photoperiod` returns the daily light
   hours required to hit midpoint DLI targets at the current PPFD.
 - **Photoperiod Guidelines**: `get_target_photoperiod` looks up recommended day lengths from `photoperiod_guidelines.json`.

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -118,6 +118,7 @@ __all__ = [
     "get_environmental_targets",
     "recommend_environment_adjustments",
     "score_environment",
+    "score_environment_components",
     "suggest_environment_setpoints",
     "saturation_vapor_pressure",
     "actual_vapor_pressure",
@@ -435,17 +436,19 @@ def generate_environment_alerts(
     return alerts
 
 
-def score_environment(
-    current: Mapping[str, float], plant_type: str, stage: str | None = None
-) -> float:
-    """Return a 0-100 score representing how close ``current`` is to targets."""
+def score_environment_components(
+    current: Mapping[str, float],
+    plant_type: str,
+    stage: str | None = None,
+) -> Dict[str, float]:
+    """Return per-parameter environment scores on a 0-100 scale."""
+
     targets = get_environmental_targets(plant_type, stage)
     if not targets:
-        return 0.0
+        return {}
 
     readings = normalize_environment_readings(current)
-    score = 0.0
-    count = 0
+    scores: Dict[str, float] = {}
     for key, bounds in targets.items():
         if key not in readings or not isinstance(bounds, (list, tuple)):
             continue
@@ -455,16 +458,27 @@ def score_environment(
         if width <= 0:
             continue
         if low <= val <= high:
-            score += 1
+            comp = 1.0
         elif val < low:
-            score += max(0.0, 1 - (low - val) / width)
+            comp = max(0.0, 1 - (low - val) / width)
         else:
-            score += max(0.0, 1 - (val - high) / width)
-        count += 1
+            comp = max(0.0, 1 - (val - high) / width)
+        scores[key] = round(comp * 100, 1)
 
-    if count == 0:
+    return scores
+
+
+def score_environment(
+    current: Mapping[str, float], plant_type: str, stage: str | None = None
+) -> float:
+    """Return a 0-100 score representing overall environment quality."""
+
+    components = score_environment_components(current, plant_type, stage)
+    if not components:
         return 0.0
-    return round((score / count) * 100, 1)
+
+    avg = sum(components.values()) / len(components)
+    return round(avg, 1)
 
 
 def classify_environment_quality(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -26,6 +26,7 @@ from plant_engine.environment_manager import (
     evaluate_wind_stress,
     evaluate_stress_conditions,
     score_environment,
+    score_environment_components,
     optimize_environment,
     calculate_environment_metrics,
     compare_environment,
@@ -420,6 +421,12 @@ def test_evaluate_stress_conditions():
 
     stress_none = evaluate_stress_conditions(None, None, None, None, "citrus")
     assert stress_none.heat is None
+
+
+def test_score_environment_components():
+    scores = score_environment_components({"temp_c": 24, "humidity_pct": 70}, "citrus", "seedling")
+    assert scores["temp_c"] == 100.0
+    assert scores["humidity_pct"] == 100.0
 
 
 def test_calculate_vpd_series():


### PR DESCRIPTION
## Summary
- add `score_environment_components` helper in environment manager
- refactor `score_environment` to use component scores
- document new function in README
- test new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dbaaf6708330a41df967bdae922a