### PR TITLE
Refactor common constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ horticulture-assistant/
 ├── blueprints/                                # automation blueprints
 ├── data/                                      # reference datasets
 ├── plant_engine/                              # nutrient and disease modules
+│   └── constants.py                           # shared constants
 ├── scripts/                                   # helper scripts
 ├── plants/                                    # example plant profiles
 ├── plant_registry.json
@@ -183,6 +184,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Custom Plant Profiles**: Drop JSON profiles in `plants/` for per‑plant settings.
 - **Auto Approval**: Toggle `input_boolean.auto_approve_all` to apply AI recommendations automatically.
 - **Data Logging**: Set `state_class: measurement` on sensors for proper history recording.
+- **Customization**: Edit `plant_engine/constants.py` to tweak default environment
+  readings or nutrient multipliers when profiles omit them.
 - **Dynamic Tags**: Tag plants (e.g. `"blueberry"`, `"fruiting"`) to generate grouped dashboards.
 - **Nutrient Mix Helper**: The `recommend_nutrient_mix` function computes exact
   fertilizer grams needed to hit N/P/K targets and can optionally include

--- a/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
@@ -16,16 +16,9 @@ except ImportError:
 from custom_components.horticulture_assistant.utils.plant_profile_loader import load_profile
 from plant_engine.nutrient_manager import get_recommended_levels
 from plant_engine.utils import load_json, save_json
+from plant_engine.constants import STAGE_MULTIPLIERS
 
 _LOGGER = logging.getLogger(__name__)
-
-# Default multipliers for nutrient targets by lifecycle stage
-STAGE_MULTIPLIERS = {
-    "seedling": 0.5,
-    "vegetative": 1.0,
-    "flowering": 1.2,
-    "fruiting": 1.1,
-}
 
 # Map common stage shorthand to formal stage names
 STAGE_SYNONYMS = {

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -107,6 +107,7 @@ from .yield_prediction import (
     get_estimated_yield,
     estimate_remaining_yield,
 )
+from .constants import STAGE_MULTIPLIERS, DEFAULT_ENV
 from .pruning_manager import (
     list_supported_plants as list_pruning_plants,
     list_stages as list_pruning_stages,
@@ -252,4 +253,6 @@ __all__ = [
     "DailyReport",
     "load_profile",
     "TranspirationMetrics",
+    "STAGE_MULTIPLIERS",
+    "DEFAULT_ENV",
 ]

--- a/plant_engine/constants.py
+++ b/plant_engine/constants.py
@@ -1,0 +1,21 @@
+"""Central constants used across the plant engine."""
+
+from __future__ import annotations
+
+# Multipliers used to scale nutrient recommendations based on lifecycle stage.
+STAGE_MULTIPLIERS: dict[str, float] = {
+    "seedling": 0.5,
+    "vegetative": 1.0,
+    "flowering": 1.2,
+    "fruiting": 1.1,
+}
+
+# Default environment readings applied when a plant profile lacks recent data.
+DEFAULT_ENV: dict[str, float] = {
+    "temp_c": 26,
+    "temp_c_max": 30,
+    "temp_c_min": 22,
+    "rh_pct": 65,
+    "par_w_m2": 350,
+    "wind_speed_m_s": 1.2,
+}

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from typing import Dict, Mapping, Any
+
 from plant_engine.utils import load_json, save_json
 from plant_engine.ai_model import analyze
 from plant_engine.compute_transpiration import compute_transpiration
@@ -17,23 +18,18 @@ from plant_engine.environment_manager import (
     optimize_environment,
 )
 from plant_engine.nutrient_manager import get_recommended_levels
-from plant_engine.pest_manager import recommend_treatments as recommend_pest_treatments
-from plant_engine.disease_manager import recommend_treatments as recommend_disease_treatments
+from plant_engine.pest_manager import (
+    recommend_treatments as recommend_pest_treatments,
+)
+from plant_engine.disease_manager import (
+    recommend_treatments as recommend_disease_treatments,
+)
 from plant_engine.growth_stage import get_stage_info
 from plant_engine.report import DailyReport
+from plant_engine.constants import STAGE_MULTIPLIERS, DEFAULT_ENV
 
 PLANTS_DIR = "plants"
 OUTPUT_DIR = "data/reports"
-
-# Default environment readings used when a profile lacks recent data
-DEFAULT_ENV = {
-    "temp_c": 26,
-    "temp_c_max": 30,
-    "temp_c_min": 22,
-    "rh_pct": 65,
-    "par_w_m2": 350,
-    "wind_speed_m_s": 1.2,
-}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,16 +57,15 @@ def _normalize_env(env: Mapping[str, Any]) -> Dict[str, float]:
         mapped["photoperiod_hours"] = env["photoperiod_hours"]
     return mapped
 
-# Basic multipliers to scale nutrient recommendations by growth stage
-STAGE_MULTIPLIERS = {
-    "seedling": 0.5,
-    "vegetative": 1.0,
-    "flowering": 1.2,
-    "fruiting": 1.1,
-}
 
 def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
-    """Run a full daily processing cycle for a plant profile."""
+    """Return a consolidated daily report for ``plant_id``.
+
+    The function orchestrates all processing steps including transpiration
+    calculation, environment optimization, nutrient recommendations and
+    optional AI analysis. Results are written to ``data/reports`` and also
+    returned as a dictionary.
+    """
     profile = load_profile(plant_id)
     plant_file = os.path.join(PLANTS_DIR, f"{plant_id}.json")
 


### PR DESCRIPTION
## Summary
- centralize environment defaults and stage multipliers
- import new constants module in engine and nutrient scheduler
- expose constants from package `__init__`
- document constants in README
- expand `run_daily_cycle` docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dbaed0588330b56ca9b5b2841f37