### PR TITLE
Add optimal EC helper

### DIFF
--- a/plant_engine/ec_manager.py
+++ b/plant_engine/ec_manager.py
@@ -16,6 +16,7 @@ def _data() -> Dict[str, Dict[str, Tuple[float, float]]]:
 __all__ = [
     "list_supported_plants",
     "get_ec_range",
+    "get_optimal_ec",
     "classify_ec_level",
     "recommend_ec_adjustment",
 ]
@@ -40,6 +41,16 @@ def get_ec_range(plant_type: str, stage: str | None = None) -> Tuple[float, floa
     if isinstance(default, (list, tuple)) and len(default) == 2:
         return float(default[0]), float(default[1])
     return None
+
+
+def get_optimal_ec(plant_type: str, stage: str | None = None) -> float | None:
+    """Return midpoint EC target for a plant stage if available."""
+
+    rng = get_ec_range(plant_type, stage)
+    if not rng:
+        return None
+    low, high = rng
+    return round((low + high) / 2, 2)
 
 
 def classify_ec_level(ec_ds_m: float, plant_type: str, stage: str | None = None) -> str:

--- a/tests/test_ec_manager.py
+++ b/tests/test_ec_manager.py
@@ -12,6 +12,11 @@ def test_get_ec_range():
     assert rng == (0.8, 1.2)
 
 
+def test_get_optimal_ec():
+    assert ec_manager.get_optimal_ec("lettuce", "seedling") == 1.0
+    assert ec_manager.get_optimal_ec("tomato", "fruiting") == 2.75
+
+
 def test_classify_ec_level():
     assert ec_manager.classify_ec_level(0.7, "lettuce", "seedling") == "low"
     assert ec_manager.classify_ec_level(1.0, "lettuce", "seedling") == "optimal"


### PR DESCRIPTION
## Summary
- support quickly retrieving the midpoint EC value for a plant stage
- test helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dbb2f17483309433a3e57a533df4