### PR TITLE
Add growth stage schedule planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ or incomplete and should only be used as a starting point for your own research.
   severity and treatment guidance based on new `disease_thresholds.json`.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily
   reports provide an estimated harvest date based on `growth_stages.json`.
+- **Stage Schedule Planner**: `build_stage_schedule` returns the expected start
+  and end date of each growth stage when given a planting date.
 - **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to
   expected totals from `yield_estimates.json`.
 - **Environment Quality Rating**: `classify_environment_quality` converts the

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -83,6 +83,7 @@ from .micro_manager import (
     calculate_surplus as calculate_micro_surplus,
 )
 from .growth_stage import get_stage_info, list_growth_stages
+from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
 from .report import DailyReport
 from .engine import load_profile
@@ -206,6 +207,7 @@ __all__ = [
     "get_micro_levels",
     "get_stage_info",
     "list_growth_stages",
+    "build_stage_schedule",
     "estimate_rootzone_depth",
     "estimate_water_capacity",
     "get_soil_parameters",

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -34,7 +34,8 @@ def get_stage_info(plant_type: str, stage: str) -> Dict[str, Any]:
 
 def list_growth_stages(plant_type: str) -> list[str]:
     """Return all defined growth stages for a plant type."""
-    return sorted(_DATA.get(normalize_key(plant_type), {}).keys())
+    stages = _DATA.get(normalize_key(plant_type), {})
+    return list(stages.keys())
 
 
 def get_stage_duration(plant_type: str, stage: str) -> int | None:

--- a/plant_engine/harvest_planner.py
+++ b/plant_engine/harvest_planner.py
@@ -1,0 +1,43 @@
+"""Utilities for planning growth stage schedules."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Dict, List
+
+from .growth_stage import list_growth_stages, get_stage_duration
+
+__all__ = ["build_stage_schedule"]
+
+
+def build_stage_schedule(plant_type: str, start_date: date) -> List[Dict[str, object]]:
+    """Return an ordered schedule of growth stages with dates.
+
+    Parameters
+    ----------
+    plant_type : str
+        Crop type defined in ``growth_stages.json``.
+    start_date : date
+        Planting or germination date.
+
+    Returns
+    -------
+    List[dict]
+        Each dictionary contains ``stage``, ``start_date``, ``end_date`` and
+        ``duration_days`` keys. ``end_date`` is exclusive.
+    """
+    stages = list_growth_stages(plant_type)
+    schedule: List[Dict[str, object]] = []
+    current = start_date
+    for stage in stages:
+        duration = get_stage_duration(plant_type, stage) or 0
+        end = current + timedelta(days=duration)
+        schedule.append(
+            {
+                "stage": stage,
+                "start_date": current,
+                "end_date": end,
+                "duration_days": duration,
+            }
+        )
+        current = end
+    return schedule

--- a/tests/test_harvest_planner.py
+++ b/tests/test_harvest_planner.py
@@ -1,0 +1,15 @@
+from datetime import date
+
+from plant_engine.harvest_planner import build_stage_schedule
+
+
+def test_build_stage_schedule():
+    start = date(2025, 1, 1)
+    schedule = build_stage_schedule("tomato", start)
+    assert schedule[0]["stage"] == "seedling"
+    assert schedule[0]["start_date"] == start
+    assert schedule[-1]["stage"] == "fruiting"
+    assert schedule[-1]["end_date"].isoformat() == "2025-05-01"
+    # ensure durations sum to 120 days from dataset
+    total = sum(entry["duration_days"] for entry in schedule)
+    assert total == 120


### PR DESCRIPTION
## Summary
- add new `harvest_planner` module for building growth stage schedules
- export `build_stage_schedule` via `plant_engine` package
- keep growth stages in dataset order
- document new helper in README
- test `build_stage_schedule`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dbb709b8833084dddadcc725c247