### PR TITLE
Improve dataset loading with overlay directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ All dataset lookups are case-insensitive and ignore spaces thanks to the
 the same entries.
 
 You can override the default `data/` directory by setting the environment
-variable `HORTICULTURE_DATA_DIR` when running scripts or tests.
+variable `HORTICULTURE_DATA_DIR` when running scripts or tests. An additional
+`HORTICULTURE_OVERLAY_DIR` may contain files that override or extend those
+datasets without copying the entire directory.
 
 The datasets are snapshots compiled from public resources. They may be outdated
 or incomplete and should only be used as a starting point for your own research.

--- a/tests/test_dataset_override.py
+++ b/tests/test_dataset_override.py
@@ -14,3 +14,19 @@ def test_dataset_env_override(tmp_path, monkeypatch):
     importlib.reload(utils)
     result = utils.load_dataset("sample.json")
     assert result == test_data
+
+
+def test_dataset_overlay(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    overlay.mkdir()
+    (base / "sample.json").write_text(json.dumps({"foo": 1, "bar": 2}))
+    (overlay / "sample.json").write_text(json.dumps({"bar": 5, "baz": 7}))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+    importlib.reload(utils)
+
+    result = utils.load_dataset("sample.json")
+    assert result == {"foo": 1, "bar": 5, "baz": 7}


### PR DESCRIPTION
## Summary
- support an optional `HORTICULTURE_OVERLAY_DIR` to override bundled datasets
- document the new overlay directory in README
- test that overlay data merges with base datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dbdf2a2c8330b77fcfd6ce11a5bc