### PR TITLE
Improve plant profile loader

### DIFF
--- a/custom_components/horticulture_assistant/utils/load_plant_profile.py
+++ b/custom_components/horticulture_assistant/utils/load_plant_profile.py
@@ -4,12 +4,18 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
-def load_plant_profile(plant_id: str, base_path: str = None) -> dict:
+def load_plant_profile(
+    plant_id: str,
+    base_path: str | None = None,
+    *,
+    include_validation_files: bool = False,
+) -> dict:
     """
     Load a plant's profile by reading all JSON files in the plant's directory.
 
     Scans the directory `plants/<plant_id>/` (or under the given base_path) for JSON files,
-    except for 'profile_index.json' and any files intended for validation only.
+    except for ``profile_index.json`` and, by default, any files intended for
+    validation only.
     Parses each JSON file into a dictionary and aggregates them into a single profile structure.
 
     Returns a dictionary with the structure:
@@ -25,7 +31,10 @@ def load_plant_profile(plant_id: str, base_path: str = None) -> dict:
     Logs an info-level summary with the total number of profile modules successfully loaded.
 
     :param plant_id: Identifier for the plant (also the directory name under the base path).
-    :param base_path: Optional base directory for plant profiles (defaults to "plants/" in current working directory).
+    :param base_path: Optional base directory for plant profiles (defaults to
+        ``plants/`` in the current working directory).
+    :param include_validation_files: If ``True``, also load files whose name
+        contains ``validate`` or ``validation``.
     :return: A dictionary containing the plant_id and loaded profile_data sections, or an empty dict on error.
     """
     # Determine the base directory and plant profile directory
@@ -49,7 +58,9 @@ def load_plant_profile(plant_id: str, base_path: str = None) -> dict:
             # Skip the profile index file and any validation-only JSON files
             if filename == "profile_index.json":
                 continue
-            if "validation" in filename.lower() or "validate" in filename.lower():
+            if not include_validation_files and (
+                "validation" in filename.lower() or "validate" in filename.lower()
+            ):
                 _LOGGER.debug("Skipping validation-only file: %s", file_path)
                 continue
             # Attempt to load and parse the JSON file

--- a/tests/test_load_plant_profile.py
+++ b/tests/test_load_plant_profile.py
@@ -1,0 +1,36 @@
+import json
+from custom_components.horticulture_assistant.utils.load_plant_profile import load_plant_profile
+
+
+def test_load_profile_basic(tmp_path):
+    plant_dir = tmp_path / "plants" / "demo"
+    plant_dir.mkdir(parents=True)
+    (plant_dir / "general.json").write_text(json.dumps({"name": "demo"}))
+    (plant_dir / "thresholds.json").write_text("{}")
+    (plant_dir / "profile_index.json").write_text("{}")
+    data = load_plant_profile("demo", base_path=tmp_path / "plants")
+    assert data["plant_id"] == "demo"
+    assert "general" in data["profile_data"]
+    assert "profile_index" not in data["profile_data"]
+
+
+def test_load_profile_with_validation_files(tmp_path):
+    plant_dir = tmp_path / "plants" / "demo"
+    plant_dir.mkdir(parents=True)
+    (plant_dir / "general.json").write_text("{}")
+    (plant_dir / "validate_extra.json").write_text("{}")
+
+    result = load_plant_profile("demo", base_path=tmp_path / "plants")
+    assert "validate_extra" not in result["profile_data"]
+
+    result = load_plant_profile(
+        "demo",
+        base_path=tmp_path / "plants",
+        include_validation_files=True,
+    )
+    assert "validate_extra" in result["profile_data"]
+
+
+def test_load_profile_missing_dir(tmp_path):
+    result = load_plant_profile("missing", base_path=tmp_path / "plants")
+    assert result == {}


### PR DESCRIPTION
## Summary
- expand `load_plant_profile` to optionally read validation files
- test new loader behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880df675a10833086de78b25221ec57