### PR TITLE
Add next stage prediction helper

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -24,6 +24,7 @@ __all__ = [
     "predict_harvest_date",
     "stage_progress",
     "days_until_harvest",
+    "predict_next_stage_date",
 ]
 
 
@@ -115,3 +116,29 @@ def days_until_harvest(
         return None
     remaining = (harvest - current_date).days
     return max(0, remaining)
+
+
+def predict_next_stage_date(
+    plant_type: str, current_stage: str, stage_start: date
+) -> date | None:
+    """Return the estimated start date of the stage following ``current_stage``.
+
+    Parameters
+    ----------
+    plant_type : str
+        Plant type used to look up stage durations.
+    current_stage : str
+        Name of the current stage in the growth cycle.
+    stage_start : date
+        Date when ``current_stage`` began.
+
+    Returns
+    -------
+    date | None
+        The expected date of the next stage transition or ``None`` if unknown.
+    """
+
+    duration = get_stage_duration(plant_type, current_stage)
+    if duration is None:
+        return None
+    return stage_start + timedelta(days=duration)

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -8,6 +8,7 @@ from plant_engine.growth_stage import (
     predict_harvest_date,
     stage_progress,
     days_until_harvest,
+    predict_next_stage_date,
 )
 
 
@@ -66,4 +67,14 @@ def test_days_until_harvest():
     today = date(2025, 2, 1)
     assert days_until_harvest("tomato", start, today) == 89
     assert days_until_harvest("unknown", start, today) is None
+
+
+def test_predict_next_stage_date():
+    stage_start = date(2025, 1, 1)
+    next_date = predict_next_stage_date("tomato", "seedling", stage_start)
+    assert next_date == date(2025, 1, 31)
+
+    assert (
+        predict_next_stage_date("unknown", "seedling", stage_start) is None
+    )
 


### PR DESCRIPTION
## Summary
- add `predict_next_stage_date` helper to `growth_stage`
- test new growth stage helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880df6acf7c833085dc97e01beb7e13