### PR TITLE
Add environment series scoring helper

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -119,6 +119,7 @@ __all__ = [
     "get_environmental_targets",
     "recommend_environment_adjustments",
     "score_environment",
+    "score_environment_series",
     "score_environment_components",
     "suggest_environment_setpoints",
     "saturation_vapor_pressure",
@@ -487,6 +488,21 @@ def score_environment(
 
     avg = sum(components.values()) / len(components)
     return round(avg, 1)
+
+
+def score_environment_series(
+    series: Iterable[Mapping[str, float]],
+    plant_type: str,
+    stage: str | None = None,
+) -> float:
+    """Return the average environment score for a sequence of readings."""
+
+    scores = [
+        score_environment(reading, plant_type, stage) for reading in series
+    ]
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 1)
 
 
 def classify_environment_quality(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -29,6 +29,7 @@ from plant_engine.environment_manager import (
     evaluate_humidity_stress,
     evaluate_stress_conditions,
     score_environment,
+    score_environment_series,
     score_environment_components,
     optimize_environment,
     calculate_environment_metrics,
@@ -473,3 +474,16 @@ def test_calculate_vpd_series():
 
     with pytest.raises(ValueError):
         calculate_vpd_series([20], [-1])
+
+
+def test_score_environment_series():
+    series = [
+        {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450},
+        {"temp_c": 24, "humidity_pct": 75, "light_ppfd": 260, "co2_ppm": 460},
+    ]
+    score = score_environment_series(series, "citrus", "seedling")
+    assert 90 <= score <= 100
+
+
+def test_score_environment_series_empty():
+    assert score_environment_series([], "citrus") == 0.0


### PR DESCRIPTION
## Summary
- add `score_environment_series` for averaging quality readings
- test scoring helper for single and empty series

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880df731f008330bf6abad6ef4dde01