### PR TITLE
Add fertilizer solubility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Key reference datasets reside in the `data/` directory:
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `fertilizer_purity.json` – default purity factors for common fertilizers
+- `fertilizer_solubility.json` – maximum solubility (g/L) for fertilizers
 - `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress
 - `wind_stress_thresholds.json` – maximum safe wind speed before damage
@@ -198,6 +199,8 @@ or incomplete and should only be used as a starting point for your own research.
   schedule along with an estimated dollar cost based on fertilizer prices.
 - **Mix Nutrient Totals**: `calculate_mix_nutrients` reports the elemental
   nutrient amounts contributed by each fertilizer mix in milligrams.
+- **Solubility Check**: `check_solubility_limits` warns when a fertilizer mix
+  exceeds the maximum grams per liter defined in `fertilizer_solubility.json`.
 - **Daily Uptake Estimation**: Use `estimate_daily_nutrient_uptake` to convert
   ppm guidelines and irrigation volume into milligrams of nutrients consumed
   each day.

--- a/data/fertilizer_solubility.json
+++ b/data/fertilizer_solubility.json
@@ -1,0 +1,5 @@
+{
+  "foxfarm_grow_big": 300,
+  "magriculture": 800,
+  "intrepid_granular_potash_0_0_60": 340
+}

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -23,6 +23,7 @@ find_products = fert_mod.find_products
 calculate_mix_nutrients = fert_mod.calculate_mix_nutrients
 calculate_mix_ppm = fert_mod.calculate_mix_ppm
 calculate_mix_density = fert_mod.calculate_mix_density
+check_solubility_limits = fert_mod.check_solubility_limits
 
 
 def test_convert_guaranteed_analysis():
@@ -133,4 +134,16 @@ def test_calculate_mix_density():
 
     with pytest.raises(KeyError):
         calculate_mix_density({"unknown": 10})
+
+
+def test_check_solubility_limits():
+    schedule = {"foxfarm_grow_big": 400}
+    warnings = check_solubility_limits(schedule, 1)
+    assert warnings["foxfarm_grow_big"] > 0
+
+    ok = check_solubility_limits({"foxfarm_grow_big": 100}, 1)
+    assert ok == {}
+
+    with pytest.raises(ValueError):
+        check_solubility_limits(schedule, 0)
 


### PR DESCRIPTION
## Summary
- provide solubility limits dataset
- expose solubility check helper in fertilizer_formulator
- document dataset and helper in README
- test new check_solubility_limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880df813bd48330bb3543219debdaec