### PR TITLE
Improve env normalization

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -89,3 +89,23 @@ def test_daily_report_as_dict():
     assert d["plant_id"] == "x"
     assert d["lifecycle_stage"] == "seedling"
 
+
+def test_normalize_env_aliases():
+    env = {
+        "temperature": 25,
+        "humidity": 55,
+        "light": 400,
+        "co2": 800,
+        "dli": 20,
+        "photoperiod_hours": 16,
+    }
+    result = engine._normalize_env(env)
+    assert result == {
+        "temp_c": 25,
+        "humidity_pct": 55,
+        "light_ppfd": 400,
+        "co2_ppm": 800,
+        "dli": 20,
+        "photoperiod_hours": 16,
+    }
+


### PR DESCRIPTION
## Summary
- normalize environment inputs with alias mapping
- test environment normalization with aliases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880df7a6824833092d9e36e0ad7c89d