### PR TITLE
Improve dataset merging logic and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ the same entries.
 You can override the default `data/` directory by setting the environment
 variable `HORTICULTURE_DATA_DIR` when running scripts or tests. An additional
 `HORTICULTURE_OVERLAY_DIR` may contain files that override or extend those
-datasets without copying the entire directory.
+datasets without copying the entire directory. Overlay files are merged
+recursively so nested keys can be customized without redefining the entire
+structure.
 
 The datasets are snapshots compiled from public resources. They may be outdated
 or incomplete and should only be used as a starting point for your own research.

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -14,6 +14,7 @@ __all__ = [
     "load_dataset",
     "normalize_key",
     "list_dataset_entries",
+    "deep_update",
 ]
 
 
@@ -28,6 +29,21 @@ def save_json(path: str, data: Dict[str, Any]) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
+
+
+def deep_update(base: Dict[str, Any], other: Mapping[str, Any]) -> Dict[str, Any]:
+    """Recursively merge ``other`` into ``base`` and return ``base``."""
+
+    for key, value in other.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, Mapping)
+        ):
+            deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
 
 
 # Default data directory is the repository ``data`` folder. It can be
@@ -63,7 +79,7 @@ def load_dataset(filename: str) -> Dict[str, Any]:
         if overlay_path.exists():
             extra = load_json(str(overlay_path))
             if isinstance(extra, dict) and isinstance(data, dict):
-                data.update(extra)
+                deep_update(data, extra)
             else:
                 data = extra
 

--- a/tests/test_dataset_override.py
+++ b/tests/test_dataset_override.py
@@ -29,3 +29,23 @@ def test_dataset_overlay(tmp_path, monkeypatch):
 
     result = utils.load_dataset("sample.json")
     assert result == {"foo": 1, "bar": 5, "baz": 7}
+
+
+def test_dataset_overlay_deep(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    overlay.mkdir()
+    (base / "sample.json").write_text(
+        json.dumps({"foo": {"a": 1, "b": 2}, "bar": 2})
+    )
+    (overlay / "sample.json").write_text(
+        json.dumps({"foo": {"b": 5, "c": 9}})
+    )
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+    importlib.reload(utils)
+
+    result = utils.load_dataset("sample.json")
+    assert result == {"foo": {"a": 1, "b": 5, "c": 9}, "bar": 2}


### PR DESCRIPTION
## Summary
- support deep merging for dataset overlays
- document recursive overlay behavior in README
- add test coverage for nested dataset overlays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e96c572c8330bc1f1fde4ad7f2e9