### PR TITLE
Add target ranges to environment summary

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -986,8 +986,26 @@ def summarize_environment(
     plant_type: str,
     stage: str | None = None,
     water_test: Mapping[str, float] | None = None,
+    *,
+    include_targets: bool = False,
 ) -> Dict[str, Any]:
-    """Return combined quality rating, adjustments, metrics, stress and water quality."""
+    """Return a consolidated environment summary for a plant stage.
+
+    Parameters
+    ----------
+    current : Mapping[str, float]
+        Current environment readings which may use any of the supported
+        aliases in :data:`ENV_ALIASES`.
+    plant_type : str
+        Plant type used to look up guideline ranges.
+    stage : str, optional
+        Growth stage for stage specific guidelines.
+    water_test : Mapping[str, float], optional
+        Water quality metrics to include in the summary.
+    include_targets : bool, optional
+        If ``True`` the returned dictionary contains the recommended target
+        ranges under the ``"targets"`` key.
+    """
 
     readings = normalize_environment_readings(current)
 
@@ -1017,4 +1035,7 @@ def summarize_environment(
         stress=stress,
         water_quality=water_info,
     )
-    return summary.as_dict()
+    data = summary.as_dict()
+    if include_targets:
+        data["targets"] = get_environmental_targets(plant_type, stage)
+    return data

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -390,13 +390,14 @@ def test_normalize_environment_readings_unknown_key():
 
 
 def test_summarize_environment():
-    summary = summarize_environment({"temperature": 18, "humidity": 90}, "citrus", "seedling")
+    summary = summarize_environment({"temperature": 18, "humidity": 90}, "citrus", "seedling", include_targets=True)
     assert summary["quality"] == "poor"
     assert summary["adjustments"]["temperature"] == "increase"
     assert summary["adjustments"]["humidity"] == "decrease"
     assert "vpd" in summary["metrics"]
     assert "score" in summary
     assert "stress" in summary
+    assert "targets" in summary
 
 
 def test_summarize_environment_with_water_quality():
@@ -405,6 +406,7 @@ def test_summarize_environment_with_water_quality():
         "citrus",
         "vegetative",
         water_test={"Na": 60, "Cl": 50},
+        include_targets=True,
     )
     assert summary["water_quality"]["rating"] == "fair"
     assert "score" in summary["water_quality"]


### PR DESCRIPTION
## Summary
- extend `summarize_environment` to optionally include target ranges
- document new argument and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e9568338833095d12a6066948c8e