### PR TITLE
Add cycle fertigation planning

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -57,6 +57,7 @@ from .fertigation import (
     calculate_mix_nutrients,
     estimate_stage_cost,
     estimate_cycle_cost,
+    generate_cycle_fertigation_plan,
 )
 from .rootzone_model import (
     estimate_rootzone_depth,
@@ -196,6 +197,7 @@ __all__ = [
     "calculate_mix_nutrients",
     "estimate_stage_cost",
     "estimate_cycle_cost",
+    "generate_cycle_fertigation_plan",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -84,6 +84,7 @@ __all__ = [
     "calculate_mix_nutrients",
     "estimate_stage_cost",
     "estimate_cycle_cost",
+    "generate_cycle_fertigation_plan",
     "recommend_precise_fertigation",
 ]
 
@@ -675,6 +676,31 @@ def estimate_cycle_cost(
         totals, num_plants, fertilizers, purity_overrides
     )
     return estimate_mix_cost(schedule)
+
+
+def generate_cycle_fertigation_plan(
+    plant_type: str,
+    purity: Mapping[str, float] | None = None,
+    *,
+    product: str | None = None,
+) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """Return fertigation plan for each stage of the crop cycle."""
+
+    from .growth_stage import list_growth_stages, get_stage_duration
+
+    cycle_plan: Dict[str, Dict[int, Dict[str, float]]] = {}
+    for stage in list_growth_stages(plant_type):
+        days = get_stage_duration(plant_type, stage)
+        if not days:
+            continue
+        cycle_plan[stage] = generate_fertigation_plan(
+            plant_type,
+            stage,
+            days,
+            purity,
+            product=product,
+        )
+    return cycle_plan
 
 
 

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -246,3 +246,15 @@ def test_recommend_precise_fertigation():
     assert total >= 0
     assert breakdown
     assert warnings == {}
+
+
+def test_generate_cycle_fertigation_plan():
+    from plant_engine.fertigation import generate_cycle_fertigation_plan
+
+    plan = generate_cycle_fertigation_plan("lettuce")
+    assert set(plan.keys()) == {"seedling", "vegetative", "harvest"}
+    assert len(plan["seedling"]) == 25
+    assert len(plan["vegetative"]) == 35
+    assert len(plan["harvest"]) == 30
+    first_day = plan["seedling"][1]
+    assert first_day["N"] > 0


### PR DESCRIPTION
## Summary
- expose fertigation cycle planner in plant_engine
- add `generate_cycle_fertigation_plan` helper
- test cycle fertigation planning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e951767483308d4b8888d1fcf536