### PR TITLE
Add CO2 range helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ or incomplete and should only be used as a starting point for your own research.
 - **Light Intensity Suggestions**: `recommend_light_intensity` calculates the
   PPFD needed to achieve midpoint DLI targets for a given photoperiod.
 - **Photoperiod Guidelines**: `get_target_photoperiod` looks up recommended day lengths from `photoperiod_guidelines.json`.
+- **CO₂ Guidelines**: `get_target_co2` returns recommended enrichment ranges for each stage.
 - **Environment Summary**: `summarize_environment` returns the quality rating
   alongside recommended adjustments and calculated metrics in one step.
 - **Water Quality Scoring**: `score_water_quality` evaluates irrigation water and

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -137,6 +137,7 @@ __all__ = [
     "get_target_dli",
     "get_target_vpd",
     "get_target_photoperiod",
+    "get_target_co2",
     "humidity_for_target_vpd",
     "recommend_light_intensity",
     "recommend_photoperiod",
@@ -245,6 +246,7 @@ class EnvironmentOptimization:
     target_dli: tuple[float, float] | None = None
     target_vpd: tuple[float, float] | None = None
     target_photoperiod: tuple[float, float] | None = None
+    target_co2: tuple[float, float] | None = None
     photoperiod_hours: float | None = None
     heat_stress: bool | None = None
     cold_stress: bool | None = None
@@ -266,6 +268,7 @@ class EnvironmentOptimization:
             "target_dli": self.target_dli,
             "target_vpd": self.target_vpd,
             "target_photoperiod": self.target_photoperiod,
+            "target_co2": self.target_co2,
             "photoperiod_hours": self.photoperiod_hours,
             "heat_stress": self.heat_stress,
             "cold_stress": self.cold_stress,
@@ -885,6 +888,14 @@ def get_target_photoperiod(
     return _lookup_range(_PHOTOPERIOD_DATA, plant_type, stage)
 
 
+def get_target_co2(
+    plant_type: str, stage: str | None = None
+) -> tuple[float, float] | None:
+    """Return recommended CO₂ range in ppm for a plant stage."""
+    guide = get_environment_guidelines(plant_type, stage)
+    return guide.co2_ppm
+
+
 def calculate_environment_metrics(
     temp_c: float | None, humidity_pct: float | None
 ) -> EnvironmentMetrics:
@@ -934,6 +945,7 @@ def optimize_environment(
     target_dli = get_target_dli(plant_type, stage)
     target_vpd = get_target_vpd(plant_type, stage)
     target_photoperiod = get_target_photoperiod(plant_type, stage)
+    target_co2 = get_target_co2(plant_type, stage)
     photoperiod_hours = None
     if target_dli and "light_ppfd" in readings:
         mid_target = sum(target_dli) / 2
@@ -971,6 +983,7 @@ def optimize_environment(
         target_dli=target_dli,
         target_vpd=target_vpd,
         target_photoperiod=target_photoperiod,
+        target_co2=target_co2,
         photoperiod_hours=photoperiod_hours,
         heat_stress=stress.heat,
         cold_stress=stress.cold,

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -19,6 +19,7 @@ from plant_engine.environment_manager import (
     get_target_dli,
     get_target_vpd,
     get_target_photoperiod,
+    get_target_co2,
     humidity_for_target_vpd,
     recommend_photoperiod,
     recommend_light_intensity,
@@ -158,6 +159,7 @@ def test_optimize_environment():
     assert result["target_dli"] is None
     assert result["photoperiod_hours"] is None
     assert result["target_photoperiod"] == (16, 18)
+    assert result["target_co2"] == (400, 600)
 
     result2 = optimize_environment(
         {"temp_c": 18, "humidity_pct": 90, "ph": 7.2},
@@ -169,6 +171,7 @@ def test_optimize_environment():
     assert result2["target_dli"] is None
     assert result2["photoperiod_hours"] is None
     assert result2["target_vpd"] == (0.6, 0.8)
+    assert result2["target_co2"] == (400, 600)
 
 
 def test_optimize_environment_with_dli():
@@ -182,6 +185,7 @@ def test_optimize_environment_with_dli():
     expected_hours = photoperiod_for_target_dli(mid, 500)
     assert result["photoperiod_hours"] == expected_hours
     assert result["target_photoperiod"] == (18, 20)
+    assert result["target_co2"] == (400, 600)
 
 
 def test_optimize_environment_aliases():
@@ -295,6 +299,11 @@ def test_get_target_vpd():
 def test_get_target_photoperiod():
     assert get_target_photoperiod("lettuce", "seedling") == (16, 18)
     assert get_target_photoperiod("unknown") is None
+
+
+def test_get_target_co2():
+    assert get_target_co2("citrus", "seedling") == (400, 600)
+    assert get_target_co2("unknown") is None
 
 
 def test_calculate_absolute_humidity():


### PR DESCRIPTION
## Summary
- expose `get_target_co2` for environment CO₂ recommendations
- include CO₂ targets in optimization output
- document CO₂ helper in README
- test new helper and environment data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e95caf6883309d42cf86476e9072