### PR TITLE
Refactor product catalog & add tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/product_catalog.py
+++ b/custom_components/horticulture_assistant/utils/product_catalog.py
@@ -1,82 +1,62 @@
+from dataclasses import dataclass, field, asdict
 from typing import Dict, List
 
 
+@dataclass
 class ProductPackaging:
-    def __init__(
-        self,
-        volume: float,
-        unit: str,
-        distributor: str,
-        price: float,
-        sku: str,
-        msrp: float = None,
-        link: str = None,
-    ):
-        self.volume = volume  # e.g., 1.0
-        self.unit = unit  # e.g., 'L', 'kg'
-        self.distributor = distributor
-        self.price = price  # price paid or listed price
-        self.sku = sku
-        self.msrp = msrp
-        self.link = link
+    """Packaging information for a fertilizer product."""
+
+    volume: float
+    unit: str
+    distributor: str
+    price: float
+    sku: str
+    msrp: float | None = None
+    link: str | None = None
 
     def cost_per_unit(self) -> float:
+        """Return price normalized to a single unit."""
         return self.price / self.volume if self.volume else 0.0
 
     def describe(self) -> Dict:
-        return {
-            "sku": self.sku,
-            "volume": self.volume,
-            "unit": self.unit,
-            "distributor": self.distributor,
-            "price": self.price,
-            "msrp": self.msrp,
-            "link": self.link,
-            "cost_per_unit": self.cost_per_unit(),
-        }
+        """Return a serialisable representation including unit cost."""
+        data = asdict(self)
+        data["cost_per_unit"] = self.cost_per_unit()
+        return data
 
 
+@dataclass
 class FertilizerProduct:
-    def __init__(
-        self,
-        name: str,
-        manufacturer: str,
-        form: str,  # e.g., 'liquid', 'granular'
-        derived_from: List[str],
-        base_composition: Dict[str, float],  # e.g., {'N': 5.0, 'Ca': 3.0}
-        density_kg_per_L: float = None,
-        bio_based: bool = False,
-    ):
-        self.name = name
-        self.manufacturer = manufacturer
-        self.form = form
-        self.derived_from = derived_from
-        self.base_composition = base_composition
-        self.packaging_options: List[ProductPackaging] = []
-        self.density_kg_per_L = density_kg_per_L
-        self.bio_based = bio_based
+    """Representation of a fertilizer product and pricing options."""
 
-    def add_packaging(self, packaging: ProductPackaging):
+    name: str
+    manufacturer: str
+    form: str
+    derived_from: List[str]
+    base_composition: Dict[str, float]
+    density_kg_per_L: float | None = None
+    bio_based: bool = False
+    packaging_options: List[ProductPackaging] = field(default_factory=list)
+
+    def add_packaging(self, packaging: ProductPackaging) -> None:
+        """Register an available package size."""
         self.packaging_options.append(packaging)
 
-    def get_best_price_per_unit(self, unit_preference: str = "kg") -> float:
-        best_price = float("inf")
-        for pkg in self.packaging_options:
-            if pkg.unit.lower() == unit_preference.lower():
-                price = pkg.cost_per_unit()
-                if price < best_price:
-                    best_price = price
-        return best_price if best_price != float("inf") else None
+    def get_best_price_per_unit(self, unit_preference: str = "kg") -> float | None:
+        """Return the lowest unit price for the preferred unit if available."""
+        prices = [
+            pkg.cost_per_unit()
+            for pkg in self.packaging_options
+            if pkg.unit.lower() == unit_preference.lower()
+        ]
+        return min(prices) if prices else None
 
     def describe(self) -> Dict:
-        return {
-            "product_name": self.name,
-            "manufacturer": self.manufacturer,
-            "form": self.form,
-            "bio_based": self.bio_based,
-            "derived_from": self.derived_from,
-            "base_composition": self.base_composition,
-            "density_kg_per_L": self.density_kg_per_L,
-            "best_price_per_unit": self.get_best_price_per_unit(),
-            "packaging_options": [pkg.describe() for pkg in self.packaging_options],
-        }
+        """Return a serialisable summary including best unit price."""
+        data = asdict(self)
+        data["best_price_per_unit"] = self.get_best_price_per_unit()
+        data["packaging_options"] = [pkg.describe() for pkg in self.packaging_options]
+        return data
+
+
+__all__ = ["ProductPackaging", "FertilizerProduct"]

--- a/tests/test_product_catalog.py
+++ b/tests/test_product_catalog.py
@@ -1,0 +1,29 @@
+from custom_components.horticulture_assistant.utils.product_catalog import (
+    ProductPackaging,
+    FertilizerProduct,
+)
+
+
+def test_product_catalog_basic():
+    pkg1 = ProductPackaging(volume=1.0, unit="L", distributor="A", price=10.0, sku="X")
+    pkg2 = ProductPackaging(volume=5.0, unit="L", distributor="B", price=45.0, sku="Y")
+
+    product = FertilizerProduct(
+        name="Grow",
+        manufacturer="FF",
+        form="liquid",
+        derived_from=["compost"],
+        base_composition={"N": 3.0},
+        density_kg_per_L=1.0,
+        bio_based=True,
+    )
+    product.add_packaging(pkg1)
+    product.add_packaging(pkg2)
+
+    assert pkg1.cost_per_unit() == 10.0
+    assert product.get_best_price_per_unit("L") == 9.0
+
+    desc = product.describe()
+    assert desc["name"] == "Grow"
+    assert desc["best_price_per_unit"] is None  # default unit is kg
+    assert len(desc["packaging_options"]) == 2


### PR DESCRIPTION
## Summary
- refactor `product_catalog` module to use dataclasses
- expose serialization helpers and cleanup docs
- add unit tests for the new dataclass based catalog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e970573083308d300b827702c74b