### PR TITLE
Add pest scouting interval helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Key reference datasets reside in the `data/` directory:
 - `disease_prevention.json` – cultural practices to prevent common diseases
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
+- `pest_monitoring_intervals.json` – recommended scouting frequency by stage
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `water_quality_actions.json` – recommended treatments when limits are exceeded
 - `fertilizer_purity.json` – default purity factors for common fertilizers
@@ -238,6 +239,7 @@ or incomplete and should only be used as a starting point for your own research.
   beneficial insects to deploy when pest thresholds are exceeded.
 - **Pest Monitoring Report**: `generate_pest_report` combines severity,
   treatment, biological control, severity actions and prevention advice for observed pests using `pest_severity_actions.json`.
+- **Pest Scouting Intervals**: `get_pest_monitoring_interval` returns recommended days between checks using `pest_monitoring_intervals.json`.
 - **Disease Monitoring Report**: `generate_disease_report` now provides
   severity and treatment guidance based on new `disease_thresholds.json`.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily

--- a/data/pest_monitoring_intervals.json
+++ b/data/pest_monitoring_intervals.json
@@ -1,0 +1,18 @@
+{
+  "citrus": {
+    "seedling": 7,
+    "vegetative": 5,
+    "fruiting": 3,
+    "optimal": 5
+  },
+  "lettuce": {
+    "seedling": 6,
+    "harvest": 2,
+    "optimal": 4
+  },
+  "tomato": {
+    "seedling": 7,
+    "fruiting": 3,
+    "optimal": 5
+  }
+}

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -13,11 +13,14 @@ from .pest_manager import recommend_treatments, recommend_beneficials
 DATA_FILE = "pest_thresholds.json"
 RISK_DATA_FILE = "pest_risk_factors.json"
 SEVERITY_ACTIONS_FILE = "pest_severity_actions.json"
+# Recommended days between scouting events
+MONITOR_INTERVAL_FILE = "pest_monitoring_intervals.json"
 
 # Load once with caching
 _THRESHOLDS: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
 _RISK_FACTORS: Dict[str, Dict[str, Dict[str, list]]] = load_dataset(RISK_DATA_FILE)
 _SEVERITY_ACTIONS: Dict[str, str] = load_dataset(SEVERITY_ACTIONS_FILE)
+_MONITOR_INTERVALS: Dict[str, Dict[str, int]] = load_dataset(MONITOR_INTERVAL_FILE)
 
 __all__ = [
     "list_supported_plants",
@@ -29,6 +32,7 @@ __all__ = [
     "estimate_pest_risk",
     "generate_pest_report",
     "get_severity_action",
+    "get_monitoring_interval",
     "PestReport",
 ]
 
@@ -47,6 +51,20 @@ def list_supported_plants() -> list[str]:
     """Return plant types with pest threshold definitions."""
 
     return list_dataset_entries(_THRESHOLDS)
+
+
+def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | None:
+    """Return recommended days between scouting events for a plant stage."""
+
+    data = _MONITOR_INTERVALS.get(normalize_key(plant_type), {})
+    if stage:
+        value = data.get(normalize_key(stage))
+        if isinstance(value, (int, float)):
+            return int(value)
+    value = data.get("optimal")
+    if isinstance(value, (int, float)):
+        return int(value)
+    return None
 
 
 def get_severity_action(level: str) -> str:

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -6,6 +6,7 @@ from plant_engine.pest_monitor import (
     recommend_biological_controls,
     classify_pest_severity,
     generate_pest_report,
+    get_monitoring_interval,
 )
 
 
@@ -64,4 +65,10 @@ def test_generate_pest_report():
     assert "aphids" in report["treatments"]
     assert "aphids" in report["beneficial_insects"]
     assert report["severity_actions"]["aphids"]
+
+
+def test_get_monitoring_interval():
+    assert get_monitoring_interval("citrus", "fruiting") == 3
+    assert get_monitoring_interval("CITRUS") == 5
+    assert get_monitoring_interval("unknown") is None
 


### PR DESCRIPTION
## Summary
- introduce `pest_monitoring_intervals.json` dataset
- add `get_monitoring_interval` helper in `pest_monitor`
- document new dataset and helper in README
- cover new helper with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ec03dbc8833098582f95464c7582