### PR TITLE
Add dataset catalog utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ Key reference datasets reside in the `data/` directory:
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
+- `dataset_catalog.json` – short descriptions of the bundled datasets for quick reference
+  Use `plant_engine.datasets.list_datasets()` to list available files and
+  `get_dataset_description()` to read these summaries programmatically.
 
 All dataset lookups are case-insensitive and ignore spaces thanks to the
 `normalize_key` helper, so references such as `"Citrus"` and `"citrus"` map to

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -1,0 +1,7 @@
+{
+  "environment_guidelines.json": "Temperature, humidity, light and CO2 ranges for each plant stage.",
+  "nutrient_guidelines.json": "Recommended macronutrient ppm levels for each plant stage.",
+  "pest_guidelines.json": "Common pest control recommendations per crop.",
+  "disease_guidelines.json": "Treatment guidance for common plant diseases.",
+  "growth_stages.json": "Expected duration and notes for each growth stage."
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -1,6 +1,7 @@
 """Plant engine package utilities."""
 
 from .utils import load_json, save_json
+from .datasets import list_datasets, get_dataset_description
 from .environment_manager import (
     get_environmental_targets,
     recommend_environment_adjustments,
@@ -159,6 +160,8 @@ from .compute_transpiration import TranspirationMetrics
 __all__ = [
     "load_json",
     "save_json",
+    "list_datasets",
+    "get_dataset_description",
     "get_environmental_targets",
     "recommend_environment_adjustments",
     "optimize_environment",

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -1,0 +1,34 @@
+"""Helpers for discovering and describing bundled datasets."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+CATALOG_FILE = DATA_DIR / "dataset_catalog.json"
+
+__all__ = ["list_datasets", "get_dataset_description"]
+
+
+def list_datasets() -> List[str]:
+    """Return the names of available JSON datasets."""
+    return sorted(
+        p.name for p in DATA_DIR.glob("*.json") if p.name != CATALOG_FILE.name
+    )
+
+
+@lru_cache(maxsize=None)
+def _load_catalog() -> Dict[str, str]:
+    if CATALOG_FILE.exists():
+        with open(CATALOG_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                return {str(k): str(v) for k, v in data.items()}
+    return {}
+
+
+def get_dataset_description(name: str) -> str | None:
+    """Return the human readable description for ``name`` if known."""
+    return _load_catalog().get(name)

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -1,0 +1,12 @@
+from plant_engine.datasets import list_datasets, get_dataset_description
+
+
+def test_list_datasets_contains_known():
+    datasets = list_datasets()
+    assert "nutrient_guidelines.json" in datasets
+    assert "dataset_catalog.json" not in datasets
+
+
+def test_get_dataset_description():
+    desc = get_dataset_description("nutrient_guidelines.json")
+    assert "macronutrient" in desc


### PR DESCRIPTION
## Summary
- document dataset catalog in README
- add dataset catalog file listing dataset descriptions
- add helper functions to inspect dataset files
- export dataset helpers in `plant_engine`
- test dataset catalog helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ec0b5b548330b091eb8540fec5b1