### PR TITLE
Add environment-based irrigation scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ or incomplete and should only be used as a starting point for your own research.
   based on delivery method using `irrigation_efficiency.json`.
 - **Irrigation Schedule Efficiency**: `generate_irrigation_schedule` accepts a
   `method` parameter to automatically apply those efficiency factors.
+- **Environment Based Scheduling**: `generate_irrigation_schedule_from_environment`
+  calculates ET from daily weather data to produce precise irrigation volumes.
 - **Fertigation Planning**: `generate_fertigation_plan` produces a day-by-day
   fertilizer schedule using those irrigation targets.
 - **Comprehensive Fertigation**: `recommend_precise_fertigation` adjusts for

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -78,6 +78,7 @@ from .irrigation_manager import (
     list_supported_plants as list_irrigation_plants,
     get_daily_irrigation_target,
     generate_irrigation_schedule,
+    generate_irrigation_schedule_from_environment,
 )
 from .nutrient_manager import (
     calculate_deficiencies,
@@ -232,6 +233,7 @@ __all__ = [
     "list_irrigation_plants",
     "get_daily_irrigation_target",
     "generate_irrigation_schedule",
+    "generate_irrigation_schedule_from_environment",
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",


### PR DESCRIPTION
## Summary
- add `generate_irrigation_schedule_from_environment` for ET-driven scheduling
- export new helper from `plant_engine`
- document environment-based scheduling
- cover new function with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ec24db388330b2ff539dee73146f