### PR TITLE
Improve environment manager with CO₂ injection calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ or incomplete and should only be used as a starting point for your own research.
   PPFD needed to achieve midpoint DLI targets for a given photoperiod.
 - **Photoperiod Guidelines**: `get_target_photoperiod` looks up recommended day lengths from `photoperiod_guidelines.json`.
 - **CO₂ Guidelines**: `get_target_co2` returns recommended enrichment ranges for each stage.
+- **CO₂ Injection Calculator**: `calculate_co2_injection` estimates the grams of CO₂ needed to hit the target range based on greenhouse volume.
 - **Environment Summary**: `summarize_environment` returns the quality rating
   alongside recommended adjustments and calculated metrics in one step.
 - **Water Quality Scoring**: `score_water_quality` evaluates irrigation water and

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -138,6 +138,8 @@ __all__ = [
     "get_target_vpd",
     "get_target_photoperiod",
     "get_target_co2",
+    "calculate_co2_injection",
+    "CO2_MG_PER_M3_PER_PPM",
     "humidity_for_target_vpd",
     "recommend_light_intensity",
     "recommend_photoperiod",
@@ -894,6 +896,28 @@ def get_target_co2(
     """Return recommended CO₂ range in ppm for a plant stage."""
     guide = get_environment_guidelines(plant_type, stage)
     return guide.co2_ppm
+
+
+# Approximate mass of CO₂ in milligrams required per m³ to raise
+# concentration by 1 ppm at 25°C. Used for enrichment calculations.
+CO2_MG_PER_M3_PER_PPM = 1.98
+
+
+def calculate_co2_injection(
+    current_ppm: float, target_ppm: tuple[float, float], volume_m3: float
+) -> float:
+    """Return grams of CO₂ needed to reach the midpoint of ``target_ppm``.
+
+    If ``current_ppm`` is already above the midpoint, ``0.0`` is returned.
+    ``volume_m3`` must be positive.
+    """
+
+    if volume_m3 <= 0:
+        raise ValueError("volume_m3 must be positive")
+    midpoint = (target_ppm[0] + target_ppm[1]) / 2
+    delta = max(0.0, midpoint - current_ppm)
+    grams = delta * CO2_MG_PER_M3_PER_PPM * volume_m3 / 1000
+    return round(grams, 2)
 
 
 def calculate_environment_metrics(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -20,6 +20,7 @@ from plant_engine.environment_manager import (
     get_target_vpd,
     get_target_photoperiod,
     get_target_co2,
+    calculate_co2_injection,
     humidity_for_target_vpd,
     recommend_photoperiod,
     recommend_light_intensity,
@@ -304,6 +305,15 @@ def test_get_target_photoperiod():
 def test_get_target_co2():
     assert get_target_co2("citrus", "seedling") == (400, 600)
     assert get_target_co2("unknown") is None
+
+
+def test_calculate_co2_injection():
+    target = get_target_co2("citrus", "seedling")
+    grams = calculate_co2_injection(300, target, 100.0)
+    assert grams > 0
+    assert calculate_co2_injection(700, target, 100.0) == 0.0
+    with pytest.raises(ValueError):
+        calculate_co2_injection(300, target, -1)
 
 
 def test_calculate_absolute_humidity():


### PR DESCRIPTION
## Summary
- add CO₂ injection calculator and constant
- expose the helper in `environment_manager` API
- document new capability in README
- test CO₂ injection calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ec1c53e483308f7a38d98d98f198