### PR TITLE
Refactor environment range handling

### DIFF
--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -35,6 +35,8 @@ from plant_engine.environment_manager import (
     optimize_environment,
     calculate_environment_metrics,
     compare_environment,
+    classify_value_range,
+    _check_range,
     generate_environment_alerts,
     classify_environment_quality,
     normalize_environment_readings,
@@ -335,6 +337,16 @@ def test_compare_environment():
     result2 = compare_environment(off, targets)
     assert result2["temp_c"] == "above range"
     assert result2["humidity_pct"] == "below range"
+
+
+def test_classify_value_range_and_check_range():
+    assert classify_value_range(10, (5, 15)) == "within range"
+    assert classify_value_range(2, (5, 15)) == "below range"
+    assert classify_value_range(20, (5, 15)) == "above range"
+
+    assert _check_range(10, (5, 15)) is None
+    assert _check_range(2, (5, 15)) == "increase"
+    assert _check_range(20, (5, 15)) == "decrease"
 
 
 def test_generate_environment_alerts():


### PR DESCRIPTION
## Summary
- add `classify_value_range` helper to centralize range comparisons
- simplify `_check_range` and `compare_environment` using new helper
- export new helper in `__all__`
- test classification logic alongside private `_check_range`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ec118e28833080351dfe0e0273b2