### PR TITLE
Enhance nutrient uptake utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Key reference datasets reside in the `data/` directory:
 - `water_quality_actions.json` – recommended treatments when limits are exceeded
 - `fertilizer_purity.json` – default purity factors for common fertilizers
 - `fertilizer_solubility.json` – maximum solubility (g/L) for fertilizers
+- `nutrient_uptake.json` – typical daily N‑P‑K demand per plant stage
 - `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress
 - `wind_stress_thresholds.json` – maximum safe wind speed before damage

--- a/data/nutrient_uptake.json
+++ b/data/nutrient_uptake.json
@@ -7,4 +7,25 @@
     "vegetative": {"N": 80, "P": 25, "K": 90},
     "fruiting": {"N": 100, "P": 30, "K": 120}
   }
+  ,
+  "citrus": {
+    "vegetative": {"N": 50, "P": 15, "K": 60},
+    "fruiting": {"N": 70, "P": 20, "K": 90}
+  },
+  "cucumber": {
+    "vegetative": {"N": 60, "P": 20, "K": 80},
+    "fruiting": {"N": 70, "P": 25, "K": 110}
+  },
+  "pepper": {
+    "vegetative": {"N": 60, "P": 20, "K": 70},
+    "fruiting": {"N": 80, "P": 30, "K": 100}
+  },
+  "strawberry": {
+    "vegetative": {"N": 40, "P": 20, "K": 50},
+    "fruiting": {"N": 50, "P": 30, "K": 80}
+  },
+  "blueberry": {
+    "vegetative": {"N": 30, "P": 10, "K": 40},
+    "fruiting": {"N": 20, "P": 15, "K": 60}
+  }
 }

--- a/plant_engine/nutrient_uptake.py
+++ b/plant_engine/nutrient_uptake.py
@@ -14,6 +14,7 @@ __all__ = [
     "get_daily_uptake",
     "estimate_stage_totals",
     "estimate_total_uptake",
+    "get_uptake_ratio",
 ]
 
 
@@ -28,6 +29,26 @@ def get_daily_uptake(plant_type: str, stage: str) -> Dict[str, float]:
     if not plant:
         return {}
     return plant.get(stage.lower(), {})
+
+
+def get_uptake_ratio(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return normalized N:P:K ratio from daily uptake data.
+
+    The values sum to 1.0. Unknown plants or stages return an empty mapping.
+    """
+
+    daily = get_daily_uptake(plant_type, stage)
+    n = daily.get("N", 0.0)
+    p = daily.get("P", 0.0)
+    k = daily.get("K", 0.0)
+    total = n + p + k
+    if total <= 0:
+        return {}
+    return {
+        "N": round(n / total, 2),
+        "P": round(p / total, 2),
+        "K": round(k / total, 2),
+    }
 
 
 def estimate_stage_totals(plant_type: str, stage: str) -> Dict[str, float]:

--- a/tests/test_nutrient_uptake.py
+++ b/tests/test_nutrient_uptake.py
@@ -1,6 +1,10 @@
 import pytest
 
-from plant_engine.nutrient_uptake import list_supported_plants, get_daily_uptake
+from plant_engine.nutrient_uptake import (
+    list_supported_plants,
+    get_daily_uptake,
+    get_uptake_ratio,
+)
 from plant_engine.fertigation import recommend_uptake_fertigation
 
 
@@ -13,6 +17,8 @@ def test_get_daily_uptake():
 def test_list_supported_plants():
     plants = list_supported_plants()
     assert "lettuce" in plants
+    assert "citrus" in plants
+    assert "pepper" in plants
 
 
 def test_recommend_uptake_fertigation():
@@ -20,3 +26,8 @@ def test_recommend_uptake_fertigation():
     assert schedule["urea"] == pytest.approx((60*2)/1000/0.46, rel=1e-2)
     assert schedule["map"] == pytest.approx((20*2)/1000/0.22, rel=1e-2)
     assert schedule["kcl"] == pytest.approx((80*2)/1000/0.5, rel=1e-2)
+
+
+def test_get_uptake_ratio():
+    ratio = get_uptake_ratio("citrus", "vegetative")
+    assert ratio == {"N": 0.4, "P": 0.12, "K": 0.48}


### PR DESCRIPTION
## Summary
- expand `nutrient_uptake.json` with additional crops
- document `nutrient_uptake.json` dataset
- expose and implement `get_uptake_ratio` utility
- test uptake ratio and new crops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ec187c7c83308114ca3f95cd1328