### PR TITLE
Improve environment score weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Key reference datasets reside in the `data/` directory:
 - `photoperiod_guidelines.json` – recommended day length by crop stage
 - `nutrient_toxicity_symptoms.json` – visual cues indicating nutrient excess
 - `nutrient_toxicity_treatments.json` – suggested mitigation steps for toxicity
+- `environment_weights.json` – weighting factors used when scoring environment quality
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `pruning_guidelines.json` – stage-specific pruning recommendations
 - `soil_texture_parameters.json` – default field capacity and MAD values by soil texture
@@ -258,6 +259,7 @@ or incomplete and should only be used as a starting point for your own research.
   quick evaluation.
 - **Environment Score Breakdown**: `score_environment_components` returns
   per-parameter scores so problem areas are easy to identify.
+- **Environment Weighting**: adjust parameter influence using `environment_weights.json`.
 - **Photoperiod Suggestions**: `recommend_photoperiod` returns the daily light
   hours required to hit midpoint DLI targets at the current PPFD.
 - **Light Intensity Suggestions**: `recommend_light_intensity` calculates the

--- a/data/environment_weights.json
+++ b/data/environment_weights.json
@@ -1,0 +1,6 @@
+{
+  "temp_c": 1.0,
+  "humidity_pct": 1.0,
+  "light_ppfd": 1.0,
+  "co2_ppm": 1.0
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from plant_engine.environment_manager import (
@@ -520,3 +521,17 @@ def test_score_environment_series():
 
 def test_score_environment_series_empty():
     assert score_environment_series([], "citrus") == 0.0
+
+
+def test_environment_weight_overlay(tmp_path, monkeypatch):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    weights = {"temp_c": 2.0, "humidity_pct": 0.5}
+    (overlay / "environment_weights.json").write_text(json.dumps(weights))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+    import importlib
+    import plant_engine.environment_manager as em
+    importlib.reload(em)
+    assert em.get_environment_weight("temp_c") == 2.0
+    score = em.score_environment({"temp_c": 22, "humidity_pct": 70}, "citrus", "seedling")
+    assert 0 <= score <= 100


### PR DESCRIPTION
## Summary
- add environment_weights dataset for flexible scoring
- allow environment score weighting via `get_environment_weight`
- compute weighted average in `score_environment`
- document environment weighting in README
- test overlay of new environment weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880efd3f9d48330b9a804df448f6152