### PR TITLE
Refactor engine utilities and add soil moisture metric

### DIFF
--- a/plant_engine/rootzone_model.py
+++ b/plant_engine/rootzone_model.py
@@ -22,6 +22,7 @@ __all__ = [
     "get_default_root_depth",
     "estimate_water_capacity",
     "calculate_remaining_water",
+    "soil_moisture_pct",
     "get_soil_parameters",
     "RootZone",
 ]
@@ -146,4 +147,17 @@ def calculate_remaining_water(
     new_vol = available_ml + irrigation_ml - et_ml
     new_vol = min(new_vol, rootzone.total_available_water_ml)
     return round(max(new_vol, 0.0), 1)
+
+
+def soil_moisture_pct(rootzone: RootZone, available_ml: float) -> float:
+    """Return current soil moisture as a percentage of capacity."""
+
+    if available_ml < 0:
+        raise ValueError("available_ml must be non-negative")
+
+    if rootzone.total_available_water_ml <= 0:
+        return 0.0
+
+    pct = (available_ml / rootzone.total_available_water_ml) * 100
+    return round(min(max(pct, 0.0), 100.0), 1)
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -63,6 +63,28 @@ def test_load_profile(tmp_path, monkeypatch):
     assert data["a"] == 1
 
 
+def test_load_profile_cached(tmp_path, monkeypatch):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    monkeypatch.setattr(engine, "PLANTS_DIR", str(plants_dir))
+    path = plants_dir / "demo.json"
+    path.write_text('{"a":1}')
+
+    calls = 0
+
+    def fake_load(path):
+        nonlocal calls
+        calls += 1
+        return {"a": 1}
+
+    monkeypatch.setattr(engine, "load_json", fake_load)
+    engine.load_profile.cache_clear()
+
+    engine.load_profile("demo")
+    engine.load_profile("demo")
+    assert calls == 1
+
+
 def test_daily_report_as_dict():
     from plant_engine.report import DailyReport
 

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -4,6 +4,7 @@ from plant_engine.rootzone_model import (
     estimate_water_capacity,
     calculate_remaining_water,
     get_soil_parameters,
+    soil_moisture_pct,
     RootZone,
 )
 import pytest
@@ -69,4 +70,11 @@ def test_calculate_remaining_water_negative():
     rz = estimate_water_capacity(10, area_cm2=100)
     with pytest.raises(ValueError):
         calculate_remaining_water(rz, -1.0)
+
+
+def test_soil_moisture_pct():
+    rz = estimate_water_capacity(10, area_cm2=100)
+    assert soil_moisture_pct(rz, 100.0) == 50.0
+    with pytest.raises(ValueError):
+        soil_moisture_pct(rz, -1)
 


### PR DESCRIPTION
## Summary
- cache engine plant profile loading
- simplify engine environment normalization
- expose soil moisture calculation in rootzone model
- test new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f037248c833086100ab8e3ef376a