### PR TITLE
Add crop rotation support and NUE dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Key reference datasets reside in the `data/` directory:
 - `foliar_feed_guidelines.json` – recommended nutrient ppm for foliar sprays
 - `yield/` – per‑plant yield logs created during operation
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations
+- `crop_rotation_guidelines.json` – recommended preceding crops and rotation intervals
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
 - `dataset_catalog.json` – short descriptions of the bundled datasets for quick reference

--- a/data/crop_rotation_guidelines.json
+++ b/data/crop_rotation_guidelines.json
@@ -1,0 +1,14 @@
+{
+  "lettuce": {
+    "preceding": ["beans", "peas"],
+    "interval_months": 12
+  },
+  "tomato": {
+    "preceding": ["lettuce", "brassicas"],
+    "interval_months": 24
+  },
+  "basil": {
+    "preceding": ["lettuce"],
+    "interval_months": 6
+  }
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -3,5 +3,6 @@
   "nutrient_guidelines.json": "Recommended macronutrient ppm levels for each plant stage.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
-  "growth_stages.json": "Expected duration and notes for each growth stage."
+  "growth_stages.json": "Expected duration and notes for each growth stage.",
+  "crop_rotation_guidelines.json": "Recommended preceding crops and rotation intervals."
 }

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -92,6 +92,11 @@ from .micro_manager import (
     calculate_surplus as calculate_micro_surplus,
 )
 from .growth_stage import get_stage_info, list_growth_stages
+from .crop_rotation import (
+    list_supported_plants as list_rotation_plants,
+    get_preceding_crops,
+    get_rotation_interval,
+)
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
 from .report import DailyReport
@@ -270,6 +275,9 @@ __all__ = [
     "list_toxicity_plants",
     "get_toxicity_thresholds",
     "check_toxicities",
+    "list_rotation_plants",
+    "get_preceding_crops",
+    "get_rotation_interval",
     "get_guideline_summary",
     "DailyReport",
     "load_profile",

--- a/plant_engine/crop_rotation.py
+++ b/plant_engine/crop_rotation.py
@@ -1,0 +1,39 @@
+"""Crop rotation helper utilities."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "crop_rotation_guidelines.json"
+
+_DATA: Dict[str, Dict[str, object]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_preceding_crops",
+    "get_rotation_interval",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with crop rotation guidelines."""
+    return list_dataset_entries(_DATA)
+
+
+def get_preceding_crops(plant_type: str) -> list[str]:
+    """Return suitable preceding crops for ``plant_type``."""
+    info = _DATA.get(normalize_key(plant_type), {})
+    crops = info.get("preceding")
+    if isinstance(crops, Iterable):
+        return [str(c) for c in crops]
+    return []
+
+
+def get_rotation_interval(plant_type: str) -> int | None:
+    """Return recommended months between plantings of ``plant_type``."""
+    info = _DATA.get(normalize_key(plant_type), {})
+    val = info.get("interval_months")
+    if isinstance(val, (int, float)):
+        return int(val)
+    return None

--- a/plant_engine/nutrient_efficiency.py
+++ b/plant_engine/nutrient_efficiency.py
@@ -2,6 +2,7 @@
 
 import os
 import json
+from dataclasses import dataclass, asdict
 from typing import Dict
 
 # Default storage locations can be overridden with environment variables. This
@@ -10,11 +11,21 @@ from typing import Dict
 NUTRIENT_DIR = os.getenv("HORTICULTURE_NUTRIENT_DIR", "data/nutrients_applied")
 YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 
-def calculate_nue(plant_id: str) -> Dict:
-    """
-    Calculate Nutrient Use Efficiency (NUE) for all nutrients based on applied nutrients vs yield.
-    Returns NUE per nutrient as g yield per g nutrient applied.
-    """
+@dataclass
+class NUEReport:
+    """Nutrient use efficiency summary."""
+
+    plant_id: str
+    total_yield_g: float
+    nue: Dict[str, float | None]
+
+    def as_dict(self) -> Dict[str, object]:
+        """Return the report as a plain dictionary."""
+        return asdict(self)
+
+
+def calculate_nue(plant_id: str) -> NUEReport:
+    """Return nutrient use efficiency report for ``plant_id``."""
 
     # Load total nutrients applied
     path_nutrients = os.path.join(NUTRIENT_DIR, f"{plant_id}.json")
@@ -45,8 +56,8 @@ def calculate_nue(plant_id: str) -> Dict:
         g_applied = mg / 1000
         nue[nutrient] = round(total_yield_g / g_applied, 2) if g_applied else None
 
-    return {
-        "plant_id": plant_id,
-        "total_yield_g": total_yield_g,
-        "nue": nue
-    }
+    return NUEReport(
+        plant_id=plant_id,
+        total_yield_g=total_yield_g,
+        nue=nue,
+    )

--- a/tests/test_crop_rotation.py
+++ b/tests/test_crop_rotation.py
@@ -1,0 +1,9 @@
+from plant_engine import crop_rotation
+
+
+def test_rotation_lookups():
+    plants = crop_rotation.list_supported_plants()
+    assert "lettuce" in plants
+    assert crop_rotation.get_rotation_interval("tomato") == 24
+    assert crop_rotation.get_preceding_crops("lettuce")[0] == "beans"
+    assert crop_rotation.get_rotation_interval("unknown") is None

--- a/tests/test_nutrient_efficiency_calc.py
+++ b/tests/test_nutrient_efficiency_calc.py
@@ -25,7 +25,8 @@ def test_calculate_nue(tmp_path, monkeypatch):
     monkeypatch.setattr(nutrient_efficiency, "NUTRIENT_DIR", str(nutrient_dir))
     monkeypatch.setattr(nutrient_efficiency, "YIELD_DIR", str(yield_dir))
 
-    result = nutrient_efficiency.calculate_nue("plant")
+    report = nutrient_efficiency.calculate_nue("plant")
+    result = report.as_dict()
     assert result["total_yield_g"] == 1500
     assert result["nue"]["N"] == 1000.0  # 1500g / 1.5g
     assert result["nue"]["K"] == 2000.0  # 1500g / 0.75g


### PR DESCRIPTION
## Summary
- add crop rotation dataset and helper module
- expose crop rotation helpers in `plant_engine`
- refactor nutrient efficiency reporting with `NUEReport` dataclass
- update docs and dataset catalog
- expand tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f004844483309e42ca02ab5d7d51