### PR TITLE
Refactor nutrient tracker and extend tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/nutrient_tracker.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_tracker.py
@@ -1,23 +1,34 @@
+"""Simple utilities for logging nutrient applications."""
+
 from dataclasses import dataclass, field
-from typing import Dict, Optional, List
-from datetime import datetime
+from typing import Dict, Optional, List, Iterable
+from datetime import datetime, timedelta
+from collections import defaultdict
 
 @dataclass
 class NutrientEntry:
+    """Mapping of an element to its concentration in a product."""
+
     element: str
     value_mg_per_kg: float
     source_compound: Optional[str] = None
 
 @dataclass
 class ProductNutrientProfile:
+    """Profile describing nutrient concentrations for a product."""
+
     product_id: str
     nutrient_map: Dict[str, NutrientEntry] = field(default_factory=dict)
 
-    def add_element(self, element: str, value: float, source: Optional[str] = None):
+    def add_element(self, element: str, value: float, source: Optional[str] = None) -> None:
+        """Register a nutrient value in ``mg/kg`` for the product."""
+
         self.nutrient_map[element] = NutrientEntry(element, value, source)
 
     def get_ppm_from_dose(self, dose_g: float, solution_kg: float = 1.0) -> Dict[str, float]:
-        ppm_map = {}
+        """Return delivered ppm for ``dose_g`` grams in ``solution_kg`` kilograms."""
+
+        ppm_map: Dict[str, float] = {}
         for nutrient in self.nutrient_map.values():
             total_mg = dose_g * (nutrient.value_mg_per_kg / 1000)
             ppm = total_mg / solution_kg
@@ -26,6 +37,8 @@ class ProductNutrientProfile:
 
 @dataclass
 class NutrientDeliveryRecord:
+    """Record describing a single nutrient application."""
+
     plant_id: str
     batch_id: str
     timestamp: datetime
@@ -34,70 +47,84 @@ class NutrientDeliveryRecord:
 
 @dataclass
 class NutrientTracker:
+    """Track nutrient deliveries and summarize totals."""
+
     product_profiles: Dict[str, ProductNutrientProfile] = field(default_factory=dict)
     delivery_log: List[NutrientDeliveryRecord] = field(default_factory=list)
 
-    def register_product(self, profile: ProductNutrientProfile):
+    def register_product(self, profile: ProductNutrientProfile) -> None:
+        """Register a nutrient profile so it can be referenced by ``log_delivery``."""
+
         self.product_profiles[profile.product_id] = profile
 
-    def log_delivery(self, plant_id: str, batch_id: str, product_id: str, dose_g: float, volume_l: float):
+    def log_delivery(self, plant_id: str, batch_id: str, product_id: str, dose_g: float, volume_l: float) -> None:
+        """Log a nutrient application for ``plant_id``."""
+
         if product_id not in self.product_profiles:
             raise ValueError(f"Unknown product_id {product_id}")
+
         profile = self.product_profiles[product_id]
         ppm_map = profile.get_ppm_from_dose(dose_g, volume_l)
+
         record = NutrientDeliveryRecord(
             plant_id=plant_id,
             batch_id=batch_id,
             timestamp=datetime.now(),
             ppm_delivered=ppm_map,
-            volume_l=volume_l
+            volume_l=volume_l,
         )
         self.delivery_log.append(record)
 
     def summarize_nutrients(self, plant_id: Optional[str] = None) -> Dict[str, float]:
-        summary = {}
+        """Return total ppm delivered across all logged applications."""
+
+        summary: Dict[str, float] = defaultdict(float)
         for record in self.delivery_log:
             if plant_id and record.plant_id != plant_id:
                 continue
             for element, ppm in record.ppm_delivered.items():
-                summary[element] = summary.get(element, 0) + ppm
-        return summary
+                summary[element] += ppm
+        return dict(summary)
 
-    def summarize_mg_for_day(
-        self, date: datetime, plant_id: Optional[str] = None
-    ) -> Dict[str, float]:
+    def summarize_mg_for_day(self, date: datetime, plant_id: Optional[str] = None) -> Dict[str, float]:
         """Return total milligrams delivered on ``date``."""
 
-        summary: Dict[str, float] = {}
+        summary: Dict[str, float] = defaultdict(float)
         for record in self.delivery_log:
             if plant_id and record.plant_id != plant_id:
                 continue
             if record.timestamp.date() != date.date():
                 continue
             for element, ppm in record.ppm_delivered.items():
-                mg = ppm * record.volume_l
-                summary[element] = summary.get(element, 0.0) + mg
-        return summary
+                summary[element] += ppm * record.volume_l
+        return dict(summary)
 
     def summarize_mg_for_period(
-        self,
-        start: datetime,
-        end: datetime,
-        plant_id: Optional[str] = None,
+        self, start: datetime, end: datetime, plant_id: Optional[str] = None
     ) -> Dict[str, float]:
         """Return milligrams delivered between ``start`` and ``end`` (inclusive)."""
 
         if start > end:
             raise ValueError("start must not be after end")
 
-        summary: Dict[str, float] = {}
+        summary: Dict[str, float] = defaultdict(float)
         for record in self.delivery_log:
             if plant_id and record.plant_id != plant_id:
                 continue
-            date_val = record.timestamp
-            if date_val < start or date_val > end:
+            if not (start <= record.timestamp <= end):
                 continue
             for element, ppm in record.ppm_delivered.items():
-                mg = ppm * record.volume_l
-                summary[element] = summary.get(element, 0.0) + mg
-        return summary
+                summary[element] += ppm * record.volume_l
+        return dict(summary)
+
+    def summarize_mg_since(
+        self, days: int, plant_id: Optional[str] = None, *, now: Optional[datetime] = None
+    ) -> Dict[str, float]:
+        """Return milligrams delivered in the last ``days`` days."""
+
+        if days < 0:
+            raise ValueError("days must be non-negative")
+
+        ref = now or datetime.now()
+        start = ref - timedelta(days=days)
+        return self.summarize_mg_for_period(start, ref, plant_id)

--- a/tests/test_nutrient_tracker.py
+++ b/tests/test_nutrient_tracker.py
@@ -26,3 +26,21 @@ def test_summarize_mg_for_period_invalid_range():
     now = datetime.now()
     with pytest.raises(ValueError):
         tracker.summarize_mg_for_period(now, now - timedelta(days=1))
+
+
+def test_summarize_mg_since():
+    tracker = NutrientTracker()
+    now = datetime.now()
+    tracker.delivery_log.extend(
+        [
+            NutrientDeliveryRecord("p", "b1", now - timedelta(days=3), {"N": 10}, 1.0),
+            NutrientDeliveryRecord("p", "b2", now - timedelta(days=1), {"N": 20}, 1.0),
+            NutrientDeliveryRecord("p", "b3", now, {"N": 30}, 1.0),
+        ]
+    )
+
+    summary = tracker.summarize_mg_since(2, "p", now=now)
+    assert summary["N"] == 50.0
+
+    with pytest.raises(ValueError):
+        tracker.summarize_mg_since(-1)


### PR DESCRIPTION
## Summary
- document nutrient tracker classes
- use `defaultdict` for nutrient summarization
- add `summarize_mg_since` helper
- test new summarization logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880efdd0d7c833096b1282478f09c42