### PR TITLE
Add environment scoring weights

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -4,4 +4,5 @@
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "growth_stages.json": "Expected duration and notes for each growth stage."
+  ,"environment_weights.json": "Importance weights for environment score calculation."
 }

--- a/data/environment_weights.json
+++ b/data/environment_weights.json
@@ -1,0 +1,6 @@
+{
+  "temp_c": 1.0,
+  "humidity_pct": 1.0,
+  "light_ppfd": 1.0,
+  "co2_ppm": 1.0
+}


### PR DESCRIPTION
## Summary
- allow environment scoring to use configurable weights
- document the new dataset in dataset catalog
- add default environment weight data
- test weight customization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f009413c8330803c704b894493ae