### PR TITLE
Enhance daily cycle reports with prevention guidance

### DIFF
--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -26,6 +26,7 @@ def test_run_daily_cycle_extended(tmp_path):
     report = run_daily_cycle("sample", base_path=str(plants_dir), output_path=str(out_dir))
 
     assert report["beneficial_insects"]["aphids"][0] == "ladybugs"
+    assert report["pest_prevention"]["aphids"].startswith("Use row covers")
     assert report["pest_severity"]["aphids"] == "moderate"
     assert report["predicted_harvest_date"] == "2025-05-01"
     assert "environment_optimization" in report

--- a/tests/test_run_daily_cycle_prevention.py
+++ b/tests/test_run_daily_cycle_prevention.py
@@ -1,0 +1,23 @@
+import json
+from custom_components.horticulture_assistant.engine.run_daily_cycle import run_daily_cycle
+
+
+def test_run_daily_cycle_prevention(tmp_path):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    out_dir = tmp_path / "reports"
+
+    profile = {
+        "general": {
+            "plant_type": "citrus",
+            "lifecycle_stage": "vegetative",
+            "observed_pests": ["aphids"],
+            "observed_diseases": ["root rot"],
+        }
+    }
+    (plants_dir / "c.json").write_text(json.dumps(profile))
+
+    report = run_daily_cycle("c", base_path=str(plants_dir), output_path=str(out_dir))
+
+    assert report["pest_prevention"]["aphids"].startswith("Encourage")
+    assert report["disease_prevention"]["root rot"].startswith("Plant in well-drained")


### PR DESCRIPTION
## Summary
- extend `run_daily_cycle` to include pest and disease prevention guidance
- integrate dataset lookups via `pest_manager` and `disease_manager`
- expose new `pest_prevention` and `disease_prevention` fields in reports
- test prevention recommendations in daily cycle reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880efff50ec8330833bcb25f4a44a39