### PR TITLE
Enhance nutrient analysis and dataset catalog

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -3,5 +3,11 @@
   "nutrient_guidelines.json": "Recommended macronutrient ppm levels for each plant stage.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
-  "growth_stages.json": "Expected duration and notes for each growth stage."
+  "growth_stages.json": "Expected duration and notes for each growth stage.",
+  "beneficial_insects.json": "Natural predators for common pests.",
+  "nutrient_deficiency_symptoms.json": "Visual indicators of nutrient deficiencies.",
+  "nutrient_deficiency_treatments.json": "Suggested remedies for nutrient deficiencies.",
+  "nutrient_mobility.json": "Mobile vs immobile nutrient classification.",
+  "pest_prevention.json": "Preventative measures for common pests.",
+  "pest_thresholds.json": "Population thresholds for pest severity."
 }

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -218,6 +218,7 @@ __all__ = [
     "list_nutrient_plants",
     "get_nutrient_weight",
     "score_nutrient_levels",
+    "calculate_deficiency_index",
     "list_micro_plants",
     "get_micro_levels",
     "get_stage_info",

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -10,3 +10,4 @@ def test_list_datasets_contains_known():
 def test_get_dataset_description():
     desc = get_dataset_description("nutrient_guidelines.json")
     assert "macronutrient" in desc
+    assert "pest" in get_dataset_description("beneficial_insects.json")

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -11,6 +11,7 @@ from plant_engine.nutrient_manager import (
     get_npk_ratio,
     get_stage_ratio,
     score_nutrient_levels,
+    calculate_deficiency_index,
 )
 
 
@@ -118,3 +119,12 @@ def test_calculate_all_nutrient_balance():
     assert "N" in ratios and "Fe" in ratios
     assert ratios["N"] > 0
     assert ratios["Fe"] > 0
+
+
+def test_calculate_deficiency_index():
+    guidelines = get_recommended_levels("tomato", "fruiting")
+    current = {key: 0 for key in guidelines}
+    idx = calculate_deficiency_index(current, "tomato", "fruiting")
+    assert idx == 100.0
+    perfect = calculate_deficiency_index(guidelines, "tomato", "fruiting")
+    assert perfect == 0.0


### PR DESCRIPTION
## Summary
- expand dataset catalog with additional horticultural data files
- add `calculate_deficiency_index` to nutrient manager for weighted deficiency scoring
- expose new function from package init
- test new dataset description and deficiency index logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880efecc38c83309c5d4bbd377d7d23