### PR TITLE
Add next_monitor_date helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Pest Monitoring Report**: `generate_pest_report` combines severity,
   treatment, biological control, severity actions and prevention advice for observed pests using `pest_severity_actions.json`.
 - **Pest Scouting Intervals**: `get_pest_monitoring_interval` returns recommended days between checks using `pest_monitoring_intervals.json`.
+- **Next Scouting Date**: `next_monitor_date` adds ``timedelta`` days to the last
+  scouting date based on these intervals.
 - **Disease Monitoring Report**: `generate_disease_report` now provides
   severity and treatment guidance based on new `disease_thresholds.json`.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -6,6 +6,7 @@
   "nutrient_weights.json": "Relative importance weighting for nutrient scoring.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",
+  "pest_monitoring_intervals.json": "Recommended days between pest scouting events.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from datetime import date, timedelta
 from typing import Dict, Mapping
 
 from . import environment_manager
@@ -33,6 +34,7 @@ __all__ = [
     "generate_pest_report",
     "get_severity_action",
     "get_monitoring_interval",
+    "next_monitor_date",
     "PestReport",
 ]
 
@@ -65,6 +67,17 @@ def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | 
     if isinstance(value, (int, float)):
         return int(value)
     return None
+
+
+def next_monitor_date(
+    plant_type: str, stage: str | None, last_date: date
+) -> date | None:
+    """Return the next pest scouting date based on interval guidelines."""
+
+    interval = get_monitoring_interval(plant_type, stage)
+    if interval is None:
+        return None
+    return last_date + timedelta(days=interval)
 
 
 def get_severity_action(level: str) -> str:
@@ -210,3 +223,4 @@ def generate_pest_report(
         severity_actions=severity_actions,
     )
     return report.as_dict()
+

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -1,3 +1,4 @@
+from datetime import date
 from plant_engine.pest_monitor import (
     list_supported_plants,
     get_pest_thresholds,
@@ -7,6 +8,7 @@ from plant_engine.pest_monitor import (
     classify_pest_severity,
     generate_pest_report,
     get_monitoring_interval,
+    next_monitor_date,
 )
 
 
@@ -71,4 +73,11 @@ def test_get_monitoring_interval():
     assert get_monitoring_interval("citrus", "fruiting") == 3
     assert get_monitoring_interval("CITRUS") == 5
     assert get_monitoring_interval("unknown") is None
+
+
+def test_next_monitor_date():
+    last = date(2023, 1, 1)
+    expected = date(2023, 1, 4)
+    assert next_monitor_date("tomato", "fruiting", last) == expected
+    assert next_monitor_date("unknown", None, last) is None
 


### PR DESCRIPTION
## Summary
- add next_monitor_date helper for pest monitoring
- document new dataset in catalog
- mention next_monitor_date in README advanced topics
- test pest_monitor.next_monitor_date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f68dc85c8330a33ef0281053a6b8