### PR TITLE
Improve environment scoring with weights

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -4,6 +4,7 @@
   "micronutrient_guidelines.json": "Recommended micronutrient ppm levels for each plant stage.",
   "nutrient_ratio_guidelines.json": "Optimal NPK ratios by stage for balanced fertilization.",
   "nutrient_weights.json": "Relative importance weighting for nutrient scoring.",
+  "environment_score_weights.json": "Weights for environment quality metrics.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",

--- a/data/environment_score_weights.json
+++ b/data/environment_score_weights.json
@@ -1,0 +1,6 @@
+{
+  "temp_c": 0.4,
+  "humidity_pct": 0.3,
+  "light_ppfd": 0.2,
+  "co2_ppm": 0.1
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -283,6 +283,15 @@ def test_score_environment():
     assert low_score < score
 
 
+def test_weighted_score_environment():
+    base = {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450}
+    bad_temp = {**base, "temp_c": 10}
+    bad_hum = {**base, "humidity_pct": 40}
+    score_temp = score_environment(bad_temp, "citrus", "seedling")
+    score_hum = score_environment(bad_hum, "citrus", "seedling")
+    assert score_temp < score_hum
+
+
 def test_get_target_dli():
     assert get_target_dli("lettuce", "seedling") == (10, 12)
     assert get_target_dli("unknown") is None


### PR DESCRIPTION
## Summary
- support weighting of environment quality metrics
- add `get_score_weight` utility
- use weighted average for environment scoring
- document dataset in catalog
- add environment score weights dataset
- test weighted scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f6889d2083308dfc946462098c92