### PR TITLE
Improve helper utilities and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,13 @@ python scripts/generate_plant_sensors.py <plant_id>
 ```
 The generated YAML is written to `templates/generated/` for easy import.
 
+`export_all_growth_yield.py` aggregates growth and yield data from the
+`analytics/` directory into a single JSON file:
+
+```bash
+python -m custom_components.horticulture_assistant.analytics.export_all_growth_yield
+```
+
 ## Troubleshooting
 - **Sensors show `unavailable`**: verify the entity IDs and that the devices are reporting to Home Assistant.
 - **Config flow fails**: check the logs for JSON errors in your plant profiles or missing permissions.

--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -1,9 +1,9 @@
 """
-Horticulture Assistant: 
-Custom integration init module.
+Horticulture Assistant integration entry module.
 
-This is the main initialization file for the Horticulture Assistant custom component
-for Home Assistant. It handles core setup and registration.
+This file sets up the custom component within Home Assistant and forwards the
+configuration entry to the supported platforms. It is intentionally minimal as
+all heavy lifting happens in the individual platform modules.
 
 Author: Traverse Jurcisin & ChatGPT (GPT-4o)
 Repo: horticulture-assistant
@@ -11,28 +11,37 @@ Repo: horticulture-assistant
 
 import logging
 
+import asyncio
+
 try:
     from homeassistant.core import HomeAssistant
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.typing import ConfigType
-except ModuleNotFoundError:  # pragma: no cover - allow running tests without HA
+except ModuleNotFoundError:  # pragma: no cover
+    # Allow running tests without Home Assistant installed
     HomeAssistant = object  # type: ignore
     ConfigEntry = object  # type: ignore
     ConfigType = dict
 
 from .const import DOMAIN, PLATFORMS
-import asyncio
+
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Horticulture Assistant integration via YAML (if used)."""
-    _LOGGER.debug("async_setup (YAML) called, but this integration uses UI config flows.")
+    _LOGGER.debug(
+        "async_setup (YAML) called, but this integration uses UI config flows."
+    )
     return True
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Horticulture Assistant from a config entry."""
-    _LOGGER.info("Setting up Horticulture Assistant from config entry: %s", entry.entry_id)
+    _LOGGER.info(
+        "Initializing Horticulture Assistant from entry: %s", entry.entry_id
+    )
 
     # Forward config entry to all supported platforms
     for platform in PLATFORMS:
@@ -45,9 +54,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return True
 
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    _LOGGER.info("Unloading Horticulture Assistant config entry: %s", entry.entry_id)
+    _LOGGER.info(
+        "Unloading Horticulture Assistant config entry: %s", entry.entry_id
+    )
     unload_results = await asyncio.gather(
         *[
             hass.config_entries.async_forward_entry_unload(entry, platform)

--- a/custom_components/horticulture_assistant/analytics/export_all_growth_yield.py
+++ b/custom_components/horticulture_assistant/analytics/export_all_growth_yield.py
@@ -1,22 +1,24 @@
-import os
+"""Helper to combine growth and yield logs for multiple plants."""
+
+from __future__ import annotations
+
 import json
 import logging
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
-def export_all_growth_yield():
-    """
-    Aggregate growth and yield data for all plants into a single JSON.
-    Scans the 'analytics/' directory for '*_growth_yield.json' files
-    and combines them into one dictionary with plant_id as keys.
-    """
-    base_dir = Path(os.getcwd()) / "analytics"
-    if not base_dir.is_dir():
-        base_dir = Path(__file__).parent
+
+def export_all_growth_yield(base_dir: Path | None = None) -> dict[str, list]:
+    """Return consolidated growth/yield logs from ``base_dir``."""
+
+    if base_dir is None:
+        base_dir = Path.cwd() / "analytics"
         if not base_dir.is_dir():
-            _LOGGER.error("Analytics directory not found: %s", base_dir)
-            return {}
+            base_dir = Path(__file__).parent
+    if not base_dir.is_dir():
+        _LOGGER.error("Analytics directory not found: %s", base_dir)
+        return {}
     results = {}
     for file_path in base_dir.glob("*_growth_yield.json"):
         plant_id = file_path.name.replace("_growth_yield.json", "")

--- a/tests/test_export_all_growth_yield.py
+++ b/tests/test_export_all_growth_yield.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from custom_components.horticulture_assistant.analytics.export_all_growth_yield import (
+    export_all_growth_yield,
+)
+
+
+def test_export_all_growth_yield(tmp_path: Path):
+    base = tmp_path / "analytics"
+    base.mkdir()
+    (base / "plant1_growth_yield.json").write_text(json.dumps([{"date": "2024-01-01", "yield": 10}]))
+    (base / "plant2_growth_yield.json").write_text(json.dumps([{"date": "2024-01-02", "yield": 5}]))
+
+    result = export_all_growth_yield(base)
+    assert set(result.keys()) == {"plant1", "plant2"}
+    assert result["plant1"][0]["date"] == "2024-01-01"


### PR DESCRIPTION
## Summary
- refine Home Assistant integration setup code
- add growth/yield log aggregator helper
- document new helper in the README
- test export_all_growth_yield

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f69ce05c83309aa27b96b461eaff