### PR TITLE
Add rain-aware irrigation scheduling

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -16,6 +16,7 @@
   "photoperiod_guidelines.json": "Recommended photoperiod ranges for growth stages.",
   "irrigation_guidelines.json": "Daily irrigation volume guidelines by stage.",
   "irrigation_efficiency.json": "Efficiency factors for irrigation methods.",
+  "rain_capture_efficiency.json": "Fraction of rainfall captured by different ground covers.",
   "water_quality_thresholds.json": "Maximum safe levels of common water analytes.",
   "water_quality_actions.json": "Recommended remediation steps for poor water quality.",
   "leaf_tissue_targets.json": "Optimal nutrient ranges for leaf tissue analysis.",

--- a/data/rain_capture_efficiency.json
+++ b/data/rain_capture_efficiency.json
@@ -1,0 +1,5 @@
+{
+  "bare_soil": 0.9,
+  "mulch": 0.75,
+  "plastic": 0.5
+}

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -11,6 +11,8 @@ from plant_engine.irrigation_manager import (
     generate_irrigation_schedule,
     adjust_irrigation_for_efficiency,
     generate_env_irrigation_schedule,
+    generate_precipitation_schedule,
+    get_rain_capture_efficiency,
     IrrigationRecommendation,
 )
 from plant_engine.rootzone_model import RootZone, calculate_remaining_water
@@ -187,4 +189,24 @@ def test_generate_env_irrigation_schedule():
     assert sched[1]["metrics"] == m1
     assert sched[2]["volume_ml"] == vol2
     assert sched[2]["metrics"] == m2
+
+
+def test_generate_precipitation_schedule():
+    zone = RootZone(
+        root_depth_cm=10,
+        root_volume_cm3=1000,
+        total_available_water_ml=200.0,
+        readily_available_water_ml=100.0,
+    )
+    schedule = generate_precipitation_schedule(
+        zone,
+        150.0,
+        [30.0, 30.0, 30.0],
+        [10.0, 0.0, 20.0],
+        surface="mulch",
+    )
+    # First day net ET = 30 - 10*0.75 = 22.5 -> no irrigation needed
+    assert schedule[1] == 0.0
+    # Second day no rain -> irrigation required
+    assert schedule[2] > 0.0
 


### PR DESCRIPTION
## Summary
- integrate new `rain_capture_efficiency.json` dataset for rainfall capture factors
- extend irrigation manager with rainfall-adjusted schedule helpers
- cover new logic with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f9853c048330a403c5b78e8f8cba