### PR TITLE
Improve utils and env scoring

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -543,14 +543,18 @@ def score_environment_series(
     plant_type: str,
     stage: str | None = None,
 ) -> float:
-    """Return the average environment score for a sequence of readings."""
+    """Return the average environment score for ``series``."""
 
-    scores = [
-        score_environment(reading, plant_type, stage) for reading in series
-    ]
-    if not scores:
+    total = 0.0
+    count = 0
+    for reading in series:
+        total += score_environment(reading, plant_type, stage)
+        count += 1
+
+    if count == 0:
         return 0.0
-    return round(sum(scores) / len(scores), 1)
+
+    return round(total / count, 1)
 
 
 def classify_environment_quality(

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -19,9 +19,21 @@ __all__ = [
 
 
 def load_json(path: str) -> Dict[str, Any]:
-    """Load a JSON file and return its contents."""
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+    """Return the parsed JSON contents of ``path``.
+
+    A :class:`FileNotFoundError` is raised if the file does not exist and a
+    :class:`ValueError` is raised when the contents cannot be decoded as JSON.
+    The error message always includes the file path to aid debugging.
+    """
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
 
 
 def save_json(path: str, data: Dict[str, Any]) -> None:

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -574,6 +574,17 @@ def test_score_environment_series_empty():
     assert score_environment_series([], "citrus") == 0.0
 
 
+def test_score_environment_series_generator():
+    records = [
+        {"temp_c": 22, "humidity_pct": 70},
+        {"temp_c": 24, "humidity_pct": 75},
+    ]
+    gen = (r for r in records)
+    list_score = score_environment_series(records, "citrus")
+    gen_score = score_environment_series(gen, "citrus")
+    assert list_score == gen_score
+
+
 def test_summarize_environment_series():
     series = [
         {"temp_c": 20, "humidity_pct": 70},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
-from plant_engine.utils import normalize_key
+import os
+import pytest
+
+from plant_engine.utils import load_json, normalize_key
 
 
 def test_normalize_key_lowercase():
@@ -11,3 +14,22 @@ def test_normalize_key_spaces_replaced():
 
 def test_normalize_key_non_string():
     assert normalize_key(123) == "123"
+
+
+def test_load_json_success(tmp_path):
+    path = tmp_path / "data.json"
+    path.write_text('{"a":1}')
+    assert load_json(str(path)) == {"a": 1}
+
+
+def test_load_json_missing(tmp_path):
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        load_json(str(missing))
+
+
+def test_load_json_invalid(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{oops}")
+    with pytest.raises(ValueError):
+        load_json(str(bad))


### PR DESCRIPTION
## Summary
- improve load_json error handling with helpful messages
- optimize score_environment_series to stream scores
- test load_json error cases
- test score_environment_series with generator input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f98e203c8330a631dd58ccbbb812