### PR TITLE
Add overall environment scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ or incomplete and should only be used as a starting point for your own research.
   quick evaluation.
 - **Environment Score Breakdown**: `score_environment_components` returns
   per-parameter scores so problem areas are easy to identify.
+- **Overall Environment Score**: `score_overall_environment` combines
+  environment quality with water test results for a single rating.
 - **Photoperiod Suggestions**: `recommend_photoperiod` returns the daily light
   hours required to hit midpoint DLI targets at the current PPFD.
 - **Light Intensity Suggestions**: `recommend_light_intensity` calculates the

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -42,6 +42,7 @@ from plant_engine.environment_manager import (
     _check_range,
     generate_environment_alerts,
     classify_environment_quality,
+    score_overall_environment,
     normalize_environment_readings,
     summarize_environment,
     summarize_environment_series,
@@ -583,3 +584,17 @@ def test_summarize_environment_series():
     avg = summarize_environment({"temp_c": 21, "humidity_pct": 72}, "citrus", "seedling")
     assert summary["quality"] == avg["quality"]
     assert summary["metrics"]["vpd"] == avg["metrics"]["vpd"]
+
+
+def test_score_overall_environment():
+    env = {
+        "temp_c": 22,
+        "humidity_pct": 70,
+        "light_ppfd": 250,
+        "co2_ppm": 450,
+    }
+    water = {"Na": 60}
+    score = score_overall_environment(env, "citrus", "seedling", water)
+    base = score_environment(env, "citrus", "seedling")
+    assert score < base
+    assert score > 90


### PR DESCRIPTION
## Summary
- combine environment & water quality metrics using `score_overall_environment`
- document new helper in README
- test overall scoring logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f990b3bc8330b20ac79aafa49562