### PR TITLE
Add water quality support to environment optimization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -275,6 +275,9 @@ class EnvironmentOptimization:
     wind_stress: bool | None = None
     humidity_stress: str | None = None
     ph_stress: str | None = None
+    quality: str | None = None
+    score: float | None = None
+    water_quality: WaterQualityInfo | None = None
 
     def as_dict(self) -> Dict[str, Any]:
         """Return the optimization result as a serializable dictionary."""
@@ -301,6 +304,9 @@ class EnvironmentOptimization:
             "wind_stress": self.wind_stress,
             "humidity_stress": self.humidity_stress,
             "ph_stress": self.ph_stress,
+            "quality": self.quality,
+            "score": self.score,
+            "water_quality": self.water_quality.as_dict() if self.water_quality else None,
         }
 
 
@@ -1049,7 +1055,10 @@ def calculate_environment_metrics(
 
 
 def optimize_environment(
-    current: Mapping[str, float], plant_type: str, stage: str | None = None
+    current: Mapping[str, float],
+    plant_type: str,
+    stage: str | None = None,
+    water_test: Mapping[str, float] | None = None,
 ) -> Dict[str, object]:
     """Return optimized environment data for a plant.
 
@@ -1115,6 +1124,15 @@ def optimize_environment(
         stage,
     )
 
+    quality = classify_environment_quality(readings, plant_type, stage)
+    score = score_environment(readings, plant_type, stage)
+
+    wq = None
+    if water_test is not None:
+        rating = water_quality.classify_water_quality(water_test)
+        wscore = water_quality.score_water_quality(water_test)
+        wq = WaterQualityInfo(rating=rating, score=wscore)
+
     result = EnvironmentOptimization(
         setpoints,
         actions,
@@ -1132,6 +1150,9 @@ def optimize_environment(
         wind_stress=stress.wind,
         humidity_stress=stress.humidity,
         ph_stress=stress.ph,
+        quality=quality,
+        score=score,
+        water_quality=wq,
     )
     return result.as_dict()
 

--- a/plant_engine/health_report.py
+++ b/plant_engine/health_report.py
@@ -22,13 +22,17 @@ def generate_health_report(
     *,
     pests: Iterable[str] = (),
     diseases: Iterable[str] = (),
+    water_test: Mapping[str, float] | None = None,
 ) -> Dict[str, object]:
     """Return a consolidated health report for a plant.
 
     The report includes optimized environment data, nutrient deficiencies with
-    symptoms, and recommended pest and disease treatments.
+    symptoms, recommended pest and disease treatments and optional water quality
+    information.
     """
-    env_opt = environment_manager.optimize_environment(env, plant_type, stage)
+    env_opt = environment_manager.optimize_environment(
+        env, plant_type, stage, water_test=water_test
+    )
     deficits = nutrient_manager.calculate_deficiencies(
         nutrient_levels, plant_type, stage
     )

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -484,6 +484,17 @@ def test_summarize_environment_with_water_quality():
     assert "score" in summary["water_quality"]
 
 
+def test_optimize_environment_with_water_quality():
+    result = optimize_environment(
+        {"temperature": 22, "humidity": 70},
+        "citrus",
+        "vegetative",
+        water_test={"Na": 60, "Cl": 50},
+    )
+    assert result["water_quality"]["rating"] == "fair"
+    assert isinstance(result["score"], float)
+
+
 def test_evaluate_light_stress():
     assert evaluate_light_stress(8, "lettuce", "seedling") == "low"
     assert evaluate_light_stress(14, "lettuce", "seedling") == "high"

--- a/tests/test_health_report.py
+++ b/tests/test_health_report.py
@@ -18,3 +18,16 @@ def test_generate_health_report():
     assert report["pest_actions"]["aphids"].startswith("Apply")
     assert report["disease_actions"]["root rot"].startswith("Ensure")
 
+
+def test_generate_health_report_with_water():
+    env = {"temp_c": 22, "humidity_pct": 70}
+    nutrients = {"N": 50, "K": 70}
+    report = generate_health_report(
+        "citrus",
+        "vegetative",
+        env,
+        nutrients,
+        water_test={"Na": 60},
+    )
+    assert report["environment"]["water_quality"]["rating"] == "fair"
+


### PR DESCRIPTION
## Summary
- extend `optimize_environment` with scoring and water quality analysis
- surface quality metrics in the optimization dataclass
- allow health reports to include water test data
- test environment optimization with water quality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f997b7f48330bb6efee4a9f7a3de