### PR TITLE
Enhance nutrient analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ or incomplete and should only be used as a starting point for your own research.
   returns a 0‑100 rating based on toxicity thresholds.
 - **Guideline Summary**: `get_guideline_summary` consolidates environment,
   nutrient and pest guidance for quick reference.
+- **Nutrient Score Trend**: `score_nutrient_series` averages multiple nutrient
+  samples to quickly gauge overall balance over time.
 - **Environment Targets in Reports**: Daily report files now include the
   recommended temperature, humidity, light and CO₂ ranges for the plant's
   current stage.

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -1,7 +1,7 @@
 """Utility helpers for nutrient recommendation and analysis."""
 from __future__ import annotations
 
-from typing import Dict, Mapping
+from typing import Dict, Mapping, Iterable
 
 from .utils import load_dataset, normalize_key, list_dataset_entries
 
@@ -29,6 +29,7 @@ __all__ = [
     "get_stage_ratio",
     "get_nutrient_weight",
     "score_nutrient_levels",
+    "score_nutrient_series",
     "recommend_ratio_adjustments",
 ]
 
@@ -186,6 +187,17 @@ def score_nutrient_levels(
         return 0.0
 
     return round((score / total_weight) * 100, 1)
+
+
+def score_nutrient_series(
+    series: Iterable[Mapping[str, float]], plant_type: str, stage: str
+) -> float:
+    """Return the average nutrient score for a sequence of readings."""
+
+    scores = [score_nutrient_levels(s, plant_type, stage) for s in series]
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 1)
 
 
 def get_all_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -11,6 +11,7 @@ from plant_engine.nutrient_manager import (
     get_npk_ratio,
     get_stage_ratio,
     score_nutrient_levels,
+    score_nutrient_series,
 )
 
 
@@ -118,3 +119,10 @@ def test_calculate_all_nutrient_balance():
     assert "N" in ratios and "Fe" in ratios
     assert ratios["N"] > 0
     assert ratios["Fe"] > 0
+
+
+def test_score_nutrient_series():
+    s1 = {"N": 80, "P": 60, "K": 120}
+    s2 = {"N": 60, "P": 50, "K": 100}
+    score = score_nutrient_series([s1, s2], "tomato", "fruiting")
+    assert score == (100.0 + score_nutrient_levels(s2, "tomato", "fruiting")) / 2


### PR DESCRIPTION
## Summary
- add `score_nutrient_series` helper to nutrient manager
- document nutrient series scoring in README
- test nutrient series scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f9a507f88330b97bcba46f5eca72