### PR TITLE
Add pest pressure scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Key reference datasets reside in the `data/` directory:
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage
+- `pest_severity_weights.json` – weighting factors used to score pest pressure
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `water_quality_actions.json` – recommended treatments when limits are exceeded
 - `fertilizer_purity.json` – default purity factors for common fertilizers
@@ -246,6 +247,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Pest Scouting Intervals**: `get_pest_monitoring_interval` returns recommended days between checks using `pest_monitoring_intervals.json`.
 - **Next Scouting Date**: `next_monitor_date` adds ``timedelta`` days to the last
   scouting date based on these intervals.
+- **Pest Pressure Score**: `score_pest_pressure` returns a 0‑100 index using
+  weights from `pest_severity_weights.json`.
 - **Disease Monitoring Report**: `generate_disease_report` now provides
   severity and treatment guidance based on new `disease_thresholds.json`.
 - **Harvest Date Prediction**: If plant profiles include a `start_date`, daily

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -42,6 +42,7 @@
   "nutrient_toxicity_treatments.json": "Actions for nutrient toxicity issues.",
   "nutrient_uptake.json": "Estimated daily uptake rates for nutrients.",
   "pest_monitoring_intervals.json": "Recommended days between scouting events.",
+  "pest_severity_weights.json": "Relative weights for scoring overall pest pressure.",
   "pest_prevention.json": "Cultural practices to reduce pest pressure.",
   "pest_risk_factors.json": "Environmental factors increasing pest risk.",
   "pest_severity_actions.json": "Actions to take based on pest severity level.",

--- a/data/pest_severity_weights.json
+++ b/data/pest_severity_weights.json
@@ -1,0 +1,14 @@
+{
+  "citrus": {
+    "aphids": 1.0,
+    "scale": 1.5
+  },
+  "tomato": {
+    "aphids": 1.0,
+    "whiteflies": 1.2
+  },
+  "lettuce": {
+    "aphids": 1.0,
+    "thrips": 1.4
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -188,6 +188,7 @@ __all__ = [
     "list_pest_plants",
     "get_pest_thresholds",
     "assess_pest_pressure",
+    "score_pest_pressure",
     "recommend_threshold_actions",
     "get_disease_guidelines",
     "recommend_disease_treatments",

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -81,3 +81,14 @@ def test_next_monitor_date():
     assert next_monitor_date("tomato", "fruiting", last) == expected
     assert next_monitor_date("unknown", None, last) is None
 
+
+def test_score_pest_pressure():
+    from plant_engine.pest_monitor import score_pest_pressure
+
+    obs = {"aphids": 5, "scale": 4}
+    score = score_pest_pressure("citrus", obs)
+    assert round(score, 1) == 80.0
+
+    low = score_pest_pressure("citrus", {"aphids": 1})
+    assert low < score
+


### PR DESCRIPTION
## Summary
- add `pest_severity_weights.json` dataset
- calculate pest pressure score in `pest_monitor`
- export new helper in `__init__`
- document pest pressure data and helper in README
- include tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f99b23f88330b5569e45198430c7