### PR TITLE
Add light spectrum guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Key reference datasets reside in the `data/` directory:
 - `water_quality_actions.json` – recommended treatments when limits are exceeded
 - `fertilizer_purity.json` – default purity factors for common fertilizers
 - `fertilizer_solubility.json` – maximum solubility (g/L) for fertilizers
+- `light_spectrum_guidelines.json` – optimal red/blue light ratios by stage
 - `nutrient_uptake.json` – typical daily N‑P‑K demand per plant stage
 - `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -28,6 +28,7 @@
   "ec_guidelines.json": "Electrical conductivity ranges for nutrient solutions.",
   "fertilizer_purity.json": "Nutrient purity factors for fertilizer products.",
   "fertilizer_solubility.json": "Solubility limits for common fertilizers.",
+  "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",
   "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",

--- a/data/light_spectrum_guidelines.json
+++ b/data/light_spectrum_guidelines.json
@@ -1,0 +1,14 @@
+{
+  "lettuce": {
+    "seedling": {"red": 0.4, "blue": 0.6},
+    "vegetative": {"red": 0.45, "blue": 0.55}
+  },
+  "basil": {
+    "vegetative": {"red": 0.5, "blue": 0.5},
+    "harvest": {"red": 0.45, "blue": 0.55}
+  },
+  "citrus": {
+    "vegetative": {"red": 0.5, "blue": 0.5},
+    "fruiting": {"red": 0.55, "blue": 0.45}
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -146,6 +146,11 @@ from .ph_manager import (
     recommend_ph_adjustment,
     estimate_ph_adjustment_volume,
 )
+from .light_spectrum import (
+    list_supported_plants as list_spectrum_plants,
+    get_spectrum as get_light_spectrum,
+    get_red_blue_ratio,
+)
 from .thermal_time import (
     calculate_gdd,
     list_supported_plants as list_gdd_plants,
@@ -256,6 +261,9 @@ __all__ = [
     "get_ph_range",
     "recommend_ph_adjustment",
     "estimate_ph_adjustment_volume",
+    "list_spectrum_plants",
+    "get_light_spectrum",
+    "get_red_blue_ratio",
     "list_pruning_plants",
     "list_pruning_stages",
     "get_pruning_instructions",

--- a/plant_engine/light_spectrum.py
+++ b/plant_engine/light_spectrum.py
@@ -1,0 +1,42 @@
+"""Helpers for recommended light spectrum ratios."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "light_spectrum_guidelines.json"
+
+_DATA: Dict[str, Dict[str, Mapping[str, float]]] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_spectrum", "get_red_blue_ratio"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with light spectrum guidance."""
+    return list_dataset_entries(_DATA)
+
+
+def get_spectrum(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return red/blue fractions for a plant stage if available."""
+    plant = _DATA.get(normalize_key(plant_type), {})
+    info = plant.get(normalize_key(stage))
+    result: Dict[str, float] = {}
+    if isinstance(info, Mapping):
+        for color in ("red", "blue"):
+            try:
+                value = float(info.get(color))
+            except (TypeError, ValueError):
+                continue
+            result[color] = value
+    return result
+
+
+def get_red_blue_ratio(plant_type: str, stage: str) -> float | None:
+    """Return red-to-blue ratio for a plant stage if defined."""
+    spec = get_spectrum(plant_type, stage)
+    red = spec.get("red")
+    blue = spec.get("blue")
+    if red is None or blue is None or blue == 0:
+        return None
+    return round(red / blue, 2)

--- a/tests/test_light_spectrum.py
+++ b/tests/test_light_spectrum.py
@@ -1,0 +1,21 @@
+from plant_engine.light_spectrum import (
+    list_supported_plants,
+    get_spectrum,
+    get_red_blue_ratio,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "lettuce" in plants
+    assert "citrus" in plants
+
+
+def test_get_spectrum():
+    spec = get_spectrum("lettuce", "seedling")
+    assert spec == {"red": 0.4, "blue": 0.6}
+
+
+def test_get_red_blue_ratio():
+    ratio = get_red_blue_ratio("lettuce", "seedling")
+    assert ratio == 0.67


### PR DESCRIPTION
## Summary
- integrate light spectrum dataset with access helpers
- document light spectrum guidelines data file
- expose new utilities through plant_engine package
- test light spectrum helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f9a18de483309041d3471d1b77bf