### PR TITLE
Improve profile loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,17 @@ The generated YAML is written to `templates/generated/` for easy import.
 python -m custom_components.horticulture_assistant.analytics.export_all_growth_yield
 ```
 
+The `load_all_profiles` helper can validate and aggregate every profile in the
+`plants/` directory. It returns a mapping of plant IDs to structured results:
+
+```python
+from custom_components.horticulture_assistant.utils.load_all_profiles import load_all_profiles
+
+profiles = load_all_profiles(validate=True)
+for pid, result in profiles.items():
+    print(pid, result.loaded, result.issues)
+```
+
 ## Troubleshooting
 - **Sensors show `unavailable`**: verify the entity IDs and that the devices are reporting to Home Assistant.
 - **Config flow fails**: check the logs for JSON errors in your plant profiles or missing permissions.

--- a/tests/test_load_all_profiles.py
+++ b/tests/test_load_all_profiles.py
@@ -1,0 +1,42 @@
+import json
+import os
+from custom_components.horticulture_assistant.utils.load_all_profiles import (
+    load_all_profiles,
+    ProfileLoadResult,
+)
+
+
+def _make_profile(base: str, pid: str, extra: dict | None = None) -> None:
+    os.makedirs(f"{base}/plants/{pid}", exist_ok=True)
+    data = {"name": pid}
+    if extra:
+        data.update(extra)
+    with open(f"{base}/plants/{pid}/general.json", "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def test_load_all_profiles_basic(tmp_path):
+    _make_profile(tmp_path, "demo")
+
+    result = load_all_profiles(base_path=tmp_path / "plants")
+    assert "demo" in result
+    res = result["demo"]
+    assert isinstance(res, ProfileLoadResult)
+    assert res.loaded
+    assert "general" in res.profile_data
+    assert res.issues == {}
+
+
+def test_load_all_profiles_pattern(tmp_path):
+    os.makedirs(tmp_path / "plants/test", exist_ok=True)
+    with open(tmp_path / "plants/test" / "data_one.json", "w", encoding="utf-8") as f:
+        json.dump({"a": 1}, f)
+    with open(tmp_path / "plants/test" / "skip.txt", "w", encoding="utf-8") as f:
+        f.write("bad")
+
+    result = load_all_profiles(base_path=tmp_path / "plants", pattern="data_*.json")
+    assert "test" in result
+    res = result["test"]
+    assert "data_one" in res.profile_data
+    assert "skip" not in res.profile_data
+


### PR DESCRIPTION
## Summary
- refactor load_all_profiles for clarity
- add ProfileLoadResult dataclass and file pattern support
- document new helper in README
- add unit tests for load_all_profiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688106c1565883309043be9c3b6d1d62