### PR TITLE
Add cache controls and rootzone helpers

### DIFF
--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -46,6 +46,7 @@ from plant_engine.environment_manager import (
     normalize_environment_readings,
     summarize_environment,
     summarize_environment_series,
+    clear_environment_cache,
 )
 
 
@@ -620,3 +621,10 @@ def test_score_overall_environment():
     base = score_environment(env, "citrus", "seedling")
     assert score < base
     assert score > 90
+
+
+def test_clear_environment_cache():
+    data1 = get_environmental_targets("citrus", "seedling")
+    clear_environment_cache()
+    data2 = get_environmental_targets("citrus", "seedling")
+    assert data1 == data2

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -78,3 +78,10 @@ def test_soil_moisture_pct():
     with pytest.raises(ValueError):
         soil_moisture_pct(rz, -1)
 
+
+def test_rootzone_methods():
+    rz = estimate_water_capacity(10, area_cm2=100)
+    new = rz.calculate_remaining_water(100.0, irrigation_ml=50.0, et_ml=25.0)
+    assert new == 125.0
+    assert rz.moisture_pct(new) == soil_moisture_pct(rz, new)
+


### PR DESCRIPTION
## Summary
- add `RangeTuple` alias and caching helper in `environment_manager`
- export and test cache clearing
- implement root zone instance methods for water calculations
- refactor functions to use new methods
- expand unit tests to cover new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688106a0ae608330a6dc12125a6b4e53