### PR TITLE
Add dataset-based nutrient tag modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Key reference datasets reside in the `data/` directory:
 - `fertilizer_purity.json` – default purity factors for common fertilizers
 - `fertilizer_solubility.json` – maximum solubility (g/L) for fertilizers
 - `nutrient_uptake.json` – typical daily N‑P‑K demand per plant stage
+- `nutrient_tag_modifiers.json` – per-tag multipliers for nutrient scheduling
 - `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress
 - `wind_stress_thresholds.json` – maximum safe wind speed before damage

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -4,6 +4,7 @@
   "micronutrient_guidelines.json": "Recommended micronutrient ppm levels for each plant stage.",
   "nutrient_ratio_guidelines.json": "Optimal NPK ratios by stage for balanced fertilization.",
   "nutrient_weights.json": "Relative importance weighting for nutrient scoring.",
+  "nutrient_tag_modifiers.json": "Tag-based multipliers for nutrient targets.",
   "environment_score_weights.json": "Weights for environment quality metrics.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",

--- a/data/nutrient_tag_modifiers.json
+++ b/data/nutrient_tag_modifiers.json
@@ -1,0 +1,7 @@
+{
+  "high-nitrogen": {"N": 1.2},
+  "low-nitrogen": {"N": 0.8},
+  "potassium-sensitive": {"K": 0.8},
+  "high-potassium": {"K": 1.2},
+  "low-potassium": {"K": 0.9}
+}


### PR DESCRIPTION
## Summary
- load tag nutrient modifiers from `nutrient_tag_modifiers.json`
- integrate dataset with `_tag_modifiers` helper and normalization
- document new dataset
- test dataset overlay loading for nutrient scheduler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688106b65b8c83308e826c32b9629412