### PR TITLE
Add water usage dataset and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Key reference datasets reside in the `data/` directory:
 - `root_depth_guidelines.json` – typical maximum root depth (cm) for common crops
 - `soil_nutrient_guidelines.json` – baseline soil N‑P‑K targets by crop
 - `irrigation_guidelines.json` – default daily irrigation volume per plant stage
+- `water_usage_guidelines.json` – estimated daily water use by crop stage
 - `irrigation_efficiency.json` – efficiency factors for common irrigation methods
 - `foliar_feed_guidelines.json` – recommended nutrient ppm for foliar sprays
 - `yield/` – per‑plant yield logs created during operation
@@ -225,7 +226,7 @@ or incomplete and should only be used as a starting point for your own research.
 - **Uptake Cost Estimation**: `estimate_stage_cost` and `estimate_cycle_cost`
   convert those totals into fertilizer costs using price data.
 - **Irrigation Targets**: `get_daily_irrigation_target` returns default
-  milliliters per plant based on `irrigation_guidelines.json`.
+  milliliters per plant based on `irrigation_guidelines.json`. The `get_daily_water_use` helper provides similar estimates from `water_usage_guidelines.json`.
 - **Irrigation Efficiency**: `adjust_irrigation_for_efficiency` scales volumes
   based on delivery method using `irrigation_efficiency.json`.
 - **Irrigation Schedule Efficiency**: `generate_irrigation_schedule` accepts a

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -61,5 +61,6 @@
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
-  "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm)."
+  "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
+  "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage."
 }

--- a/data/water_usage_guidelines.json
+++ b/data/water_usage_guidelines.json
@@ -1,0 +1,4 @@
+{
+  "lettuce": {"seedling": 60, "vegetative": 180, "harvest": 140},
+  "tomato": {"seedling": 80, "vegetative": 220, "fruiting": 320}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -137,6 +137,10 @@ from .ec_manager import (
     classify_ec_level,
     recommend_ec_adjustment,
 )
+from .water_usage import (
+    list_supported_plants as list_water_use_plants,
+    get_daily_use as get_daily_water_use,
+)
 from .toxicity_manager import (
     list_supported_plants as list_toxicity_plants,
     get_toxicity_thresholds,
@@ -261,6 +265,8 @@ __all__ = [
     "get_ec_range",
     "classify_ec_level",
     "recommend_ec_adjustment",
+    "list_water_use_plants",
+    "get_daily_water_use",
     "list_ph_plants",
     "get_ph_range",
     "recommend_ph_adjustment",

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -12,6 +12,7 @@ CATALOG_FILE = DATA_DIR / "dataset_catalog.json"
 __all__ = ["list_datasets", "get_dataset_description", "list_dataset_info"]
 
 
+@lru_cache(maxsize=None)
 def list_datasets() -> List[str]:
     """Return relative paths of available JSON datasets.
 
@@ -43,6 +44,7 @@ def get_dataset_description(name: str) -> str | None:
     return _load_catalog().get(name)
 
 
+@lru_cache(maxsize=None)
 def list_dataset_info() -> Dict[str, str]:
     """Return mapping of dataset names to descriptions."""
 

--- a/plant_engine/water_usage.py
+++ b/plant_engine/water_usage.py
@@ -1,0 +1,28 @@
+"""Lookup daily water use estimates for irrigation planning."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "water_usage_guidelines.json"
+
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_daily_use"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return all plant types with water use data."""
+    return list_dataset_entries(_DATA)
+
+
+def get_daily_use(plant_type: str, stage: str) -> float:
+    """Return daily water usage in milliliters for a plant stage."""
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return 0.0
+    try:
+        return float(plant.get(normalize_key(stage), 0.0))
+    except (TypeError, ValueError):
+        return 0.0

--- a/tests/test_water_usage.py
+++ b/tests/test_water_usage.py
@@ -1,0 +1,14 @@
+from plant_engine import water_usage
+
+
+def test_get_daily_use():
+    assert water_usage.get_daily_use("lettuce", "vegetative") == 180
+    assert water_usage.get_daily_use("tomato", "fruiting") == 320
+    # Unknown plant returns 0
+    assert water_usage.get_daily_use("unknown", "stage") == 0.0
+
+
+def test_list_supported_plants():
+    plants = water_usage.list_supported_plants()
+    assert "lettuce" in plants
+    assert "tomato" in plants


### PR DESCRIPTION
## Summary
- add water_usage_guidelines dataset
- expose new water_usage helper module
- cache dataset discovery functions for performance
- document new dataset and helper in README
- unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688110b9e6c88330bfc7cf5abf726889