### PR TITLE
Add CO₂ cost utilities

### DIFF
--- a/data/co2_prices.json
+++ b/data/co2_prices.json
@@ -1,0 +1,5 @@
+{
+  "compressed": 1.2,
+  "liquid": 0.8,
+  "dry_ice": 1.5
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -61,5 +61,6 @@
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
-  "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm)."
+  "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
+  "co2_prices.json": "Cost per kg of CO2 from different sources."
 }

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -25,6 +25,12 @@ from .environment_manager import (
     evaluate_stress_conditions,
     list_supported_plants as list_environment_plants,
 )
+from .co2_manager import (
+    list_sources as list_co2_sources,
+    get_co2_price,
+    estimate_injection_cost,
+)
+
 from .pest_manager import (
     get_pest_guidelines,
     recommend_treatments as recommend_pest_treatments,
@@ -190,6 +196,9 @@ __all__ = [
     "evaluate_wind_stress",
     "evaluate_stress_conditions",
     "list_environment_plants",
+    "list_co2_sources",
+    "get_co2_price",
+    "estimate_injection_cost",
     "get_pest_guidelines",
     "recommend_pest_treatments",
     "get_pest_prevention",

--- a/plant_engine/co2_manager.py
+++ b/plant_engine/co2_manager.py
@@ -1,0 +1,37 @@
+"""CO₂ cost calculations and source metadata."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "co2_prices.json"
+
+# Load once using caching in :func:`load_dataset`
+_DATA: Dict[str, float] = load_dataset(DATA_FILE)
+
+__all__ = ["list_sources", "get_co2_price", "estimate_injection_cost"]
+
+
+def list_sources() -> List[str]:
+    """Return available CO₂ source identifiers."""
+    return list_dataset_entries(_DATA)
+
+
+def get_co2_price(source: str) -> float | None:
+    """Return price per kg of CO₂ for ``source`` if known."""
+    val = _DATA.get(normalize_key(source))
+    if isinstance(val, (int, float)):
+        return float(val)
+    return None
+
+
+def estimate_injection_cost(grams: float, source: str = "compressed") -> float:
+    """Return estimated cost in USD for ``grams`` of CO₂."""
+    if grams < 0:
+        raise ValueError("grams must be non-negative")
+    price = get_co2_price(source)
+    if price is None:
+        raise KeyError(f"Price for '{source}' is not defined")
+    kg = grams / 1000
+    return round(price * kg, 2)

--- a/tests/test_co2_manager.py
+++ b/tests/test_co2_manager.py
@@ -1,0 +1,25 @@
+import pytest
+
+from plant_engine.co2_manager import (
+    list_sources,
+    get_co2_price,
+    estimate_injection_cost,
+)
+
+
+def test_list_sources_contains_compressed():
+    assert "compressed" in list_sources()
+
+
+def test_get_co2_price_positive():
+    price = get_co2_price("compressed")
+    assert price and price > 0
+
+
+def test_estimate_injection_cost():
+    cost = estimate_injection_cost(500, "compressed")
+    assert cost > 0
+    with pytest.raises(ValueError):
+        estimate_injection_cost(-1)
+    with pytest.raises(KeyError):
+        estimate_injection_cost(100, "unknown")


### PR DESCRIPTION
## Summary
- integrate new `co2_prices.json` dataset and expose in dataset catalog
- add `co2_manager` module with helpers to query CO₂ costs
- export new helpers from `plant_engine.__init__`
- test CO₂ cost helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688110d84e048330a4f07190139a0d65