### PR TITLE
Add irrigation interval dataset and helper

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -17,6 +17,7 @@
   "vpd_guidelines.json": "Vapor pressure deficit targets for growth stages.",
   "photoperiod_guidelines.json": "Recommended photoperiod ranges for growth stages.",
   "irrigation_guidelines.json": "Daily irrigation volume guidelines by stage.",
+  "irrigation_intervals.json": "Recommended days between irrigation events for each plant stage.",
   "irrigation_efficiency.json": "Efficiency factors for irrigation methods.",
   "rain_capture_efficiency.json": "Fraction of rainfall captured by different ground covers.",
   "water_quality_thresholds.json": "Maximum safe levels of common water analytes.",

--- a/data/irrigation_intervals.json
+++ b/data/irrigation_intervals.json
@@ -1,0 +1,4 @@
+{
+  "citrus": {"seedling": 2, "vegetative": 3, "flowering": 4},
+  "lettuce": {"seedling": 1, "vegetative": 2}
+}

--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -23,6 +23,7 @@ __all__ = [
     "generate_env_irrigation_schedule",
     "generate_precipitation_schedule",
     "get_rain_capture_efficiency",
+    "get_recommended_interval",
     "IrrigationRecommendation",
 ]
 
@@ -31,6 +32,9 @@ _KC_DATA = load_dataset(_KC_DATA_FILE)
 
 _IRRIGATION_FILE = "irrigation_guidelines.json"
 _IRRIGATION_DATA: Dict[str, Dict[str, float]] = load_dataset(_IRRIGATION_FILE)
+
+_INTERVAL_FILE = "irrigation_intervals.json"
+_INTERVAL_DATA: Dict[str, Dict[str, float]] = load_dataset(_INTERVAL_FILE)
 
 _EFFICIENCY_FILE = "irrigation_efficiency.json"
 _EFFICIENCY_DATA: Dict[str, float] = load_dataset(_EFFICIENCY_FILE)
@@ -248,6 +252,17 @@ def get_daily_irrigation_target(plant_type: str, stage: str) -> float:
     plant = _IRRIGATION_DATA.get(normalize_key(plant_type), {})
     value = plant.get(normalize_key(stage))
     return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+def get_recommended_interval(plant_type: str, stage: str) -> float | None:
+    """Return days between irrigation events for a plant stage if known."""
+
+    plant = _INTERVAL_DATA.get(normalize_key(plant_type), {})
+    value = plant.get(normalize_key(stage))
+    if isinstance(value, (int, float)):
+        return float(value)
+    value = plant.get("optimal")
+    return float(value) if isinstance(value, (int, float)) else None
 
 
 def generate_irrigation_schedule(

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -4,6 +4,7 @@ from plant_engine.datasets import list_datasets, get_dataset_description
 def test_list_datasets_contains_known():
     datasets = list_datasets()
     assert "nutrient_guidelines.json" in datasets
+    assert "irrigation_intervals.json" in datasets
     assert "dataset_catalog.json" not in datasets
 
 
@@ -21,3 +22,6 @@ def test_get_dataset_description():
 
     desc3 = get_dataset_description("fertilizer_purity.json")
     assert "purity" in desc3
+
+    desc4 = get_dataset_description("irrigation_intervals.json")
+    assert "irrigation" in desc4

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -14,6 +14,7 @@ from plant_engine.irrigation_manager import (
     generate_env_irrigation_schedule,
     generate_precipitation_schedule,
     get_rain_capture_efficiency,
+    get_recommended_interval,
     IrrigationRecommendation,
 )
 from plant_engine.rootzone_model import RootZone, calculate_remaining_water
@@ -149,6 +150,11 @@ def test_daily_irrigation_target_lookup():
     assert get_daily_irrigation_target("citrus", "vegetative") == 250
     assert "citrus" in list_supported_plants()
     assert get_daily_irrigation_target("unknown", "stage") == 0.0
+
+
+def test_get_recommended_interval():
+    assert get_recommended_interval("citrus", "seedling") == 2
+    assert get_recommended_interval("citrus", "unknown") is None
 
 
 def test_generate_irrigation_schedule():


### PR DESCRIPTION
## Summary
- add `irrigation_intervals.json` dataset
- describe irrigation intervals in `dataset_catalog.json`
- support recommended irrigation intervals in `irrigation_manager`
- exercise new dataset in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688110d04434833085b1e77c2dd76073