### PR TITLE
Improve environment summary handling

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -1305,21 +1305,20 @@ def summarize_environment_series(
 ) -> Dict[str, Any]:
     """Return summary for averaged environment readings.
 
-    When multiple readings are provided they are normalized, averaged and then
+    The ``series`` argument can be any iterable of reading mappings. Each
+    reading is normalized and accumulated without loading the entire sequence
+    into memory before the average is calculated. The averaged values are then
     passed to :func:`summarize_environment`.
     """
 
-    iterator = list(series)
-    if not iterator:
-        avg = {}
-    else:
-        totals: Dict[str, float] = {}
-        count = 0
-        for reading in iterator:
-            for key, value in normalize_environment_readings(reading).items():
-                totals[key] = totals.get(key, 0.0) + float(value)
-            count += 1
-        avg = {k: v / count for k, v in totals.items()}
+    totals: Dict[str, float] = {}
+    count = 0
+    for reading in series:
+        for key, value in normalize_environment_readings(reading).items():
+            totals[key] = totals.get(key, 0.0) + float(value)
+        count += 1
+
+    avg = {k: v / count for k, v in totals.items()} if count else {}
 
     return summarize_environment(
         avg,

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -626,6 +626,17 @@ def test_summarize_environment_series():
     assert summary["metrics"]["vpd"] == avg["metrics"]["vpd"]
 
 
+def test_summarize_environment_series_generator():
+    records = [
+        {"temp_c": 20, "humidity_pct": 70},
+        {"temp_c": 22, "humidity_pct": 74},
+    ]
+    gen = (r for r in records)
+    gen_summary = summarize_environment_series(gen, "citrus", "seedling")
+    list_summary = summarize_environment_series(records, "citrus", "seedling")
+    assert gen_summary == list_summary
+
+
 def test_score_overall_environment():
     env = {
         "temp_c": 22,


### PR DESCRIPTION
## Summary
- refactor environment series summarization to avoid loading entire iterables
- document new streaming behavior in the docstring
- test generator support for summarize_environment_series

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811bfbc7588330aefcc2df4b72ed8a