### PR TITLE
Add area-based water usage estimator

### DIFF
--- a/tests/test_water_usage.py
+++ b/tests/test_water_usage.py
@@ -1,3 +1,4 @@
+import pytest
 from plant_engine import water_usage
 
 
@@ -12,3 +13,15 @@ def test_list_supported_plants():
     plants = water_usage.list_supported_plants()
     assert "lettuce" in plants
     assert "tomato" in plants
+
+
+def test_estimate_area_use():
+    daily = water_usage.estimate_area_use("lettuce", "vegetative", 1.0)
+    # spacing 25 cm => 16 plants per m2 * 180 mL
+    assert round(daily, 1) == round(1.0 / (0.25 ** 2) * 180, 1)
+
+    daily_unknown = water_usage.estimate_area_use("unknown", "stage", 1.0)
+    assert daily_unknown == 0.0
+
+    with pytest.raises(ValueError):
+        water_usage.estimate_area_use("lettuce", "vegetative", -1)


### PR DESCRIPTION
## Summary
- extend `water_usage` utilities with helper to estimate water demand for a given area
- cover the new helper with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811bff8d6c83309a62c1f79d2440da