### PR TITLE
Enhance fertigation planning

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -68,6 +68,7 @@ from .fertigation import (
     estimate_stage_cost,
     estimate_cycle_cost,
     generate_cycle_fertigation_plan,
+    generate_cycle_fertigation_plan_with_cost,
 )
 from .rootzone_model import (
     estimate_rootzone_depth,
@@ -242,6 +243,7 @@ __all__ = [
     "estimate_stage_cost",
     "estimate_cycle_cost",
     "generate_cycle_fertigation_plan",
+    "generate_cycle_fertigation_plan_with_cost",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -93,6 +93,7 @@ __all__ = [
     "estimate_stage_cost",
     "estimate_cycle_cost",
     "generate_cycle_fertigation_plan",
+    "generate_cycle_fertigation_plan_with_cost",
     "recommend_precise_fertigation",
 ]
 
@@ -720,6 +721,46 @@ def generate_cycle_fertigation_plan(
             product=product,
         )
     return cycle_plan
+
+
+def generate_cycle_fertigation_plan_with_cost(
+    plant_type: str,
+    purity: Mapping[str, float] | None = None,
+    *,
+    product: str | None = None,
+) -> tuple[Dict[str, Dict[int, Dict[str, float]]], float]:
+    """Return cycle fertigation plan and estimated total cost."""
+
+    plan = generate_cycle_fertigation_plan(
+        plant_type, purity, product=product
+    )
+
+    from custom_components.horticulture_assistant.fertilizer_formulator import (
+        estimate_mix_cost,
+    )
+
+    fert_map = {
+        "N": "foxfarm_grow_big",
+        "P": "foxfarm_grow_big",
+        "K": "intrepid_granular_potash_0_0_60",
+    }
+
+    totals: Dict[str, float] = {}
+    for stage_plan in plan.values():
+        for day_schedule in stage_plan.values():
+            for nutrient, grams in day_schedule.items():
+                fert = fert_map.get(nutrient)
+                if fert:
+                    totals[fert] = totals.get(fert, 0.0) + grams
+
+    total = 0.0
+    if totals:
+        try:
+            total = estimate_mix_cost(totals)
+        except KeyError:
+            total = 0.0
+
+    return plan, round(total, 2)
 
 
 

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -266,3 +266,17 @@ def test_estimate_solution_ec():
     schedule = {"N": 100, "K": 150}
     ec = estimate_solution_ec(schedule)
     assert ec == pytest.approx(0.465, rel=1e-3)
+
+
+def test_generate_cycle_fertigation_plan_with_cost():
+    from plant_engine.fertigation import (
+        generate_cycle_fertigation_plan,
+        generate_cycle_fertigation_plan_with_cost,
+    )
+
+    basic_plan = generate_cycle_fertigation_plan("lettuce")
+    plan, cost = generate_cycle_fertigation_plan_with_cost("lettuce")
+
+    assert plan == basic_plan
+    assert cost > 0
+


### PR DESCRIPTION
## Summary
- add function to estimate fertigation costs for an entire crop cycle
- expose new helper in plant engine API
- test new cost-aware planner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811c031a908330b85d35b6058a79ac