### PR TITLE
Enhance fertigation utilities with foliar feed intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Key reference datasets reside in the `data/` directory:
 - `water_usage_guidelines.json` – estimated daily water use by crop stage
 - `irrigation_efficiency.json` – efficiency factors for common irrigation methods
 - `foliar_feed_guidelines.json` – recommended nutrient ppm for foliar sprays
+- `foliar_feed_intervals.json` – suggested days between foliar applications
 - `yield/` – per‑plant yield logs created during operation
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -34,6 +34,7 @@
   "fertilizer_solubility.json": "Solubility limits for common fertilizers.",
   "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",
   "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
+  "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",

--- a/data/foliar_feed_intervals.json
+++ b/data/foliar_feed_intervals.json
@@ -1,0 +1,11 @@
+{
+  "tomato": {
+    "vegetative": 7,
+    "flowering": 10,
+    "optimal": 7
+  },
+  "lettuce": {
+    "vegetative": 14,
+    "optimal": 14
+  }
+}

--- a/tests/test_foliar_feed.py
+++ b/tests/test_foliar_feed.py
@@ -1,4 +1,11 @@
-from plant_engine.fertigation import get_foliar_guidelines, recommend_foliar_feed
+from datetime import date
+
+from plant_engine.fertigation import (
+    get_foliar_guidelines,
+    recommend_foliar_feed,
+    get_foliar_feed_interval,
+    next_foliar_feed_date,
+)
 
 
 def test_get_foliar_guidelines():
@@ -10,3 +17,16 @@ def test_recommend_foliar_feed():
     sched = recommend_foliar_feed("tomato", "vegetative", 1.0, purity={"N": 1.0, "K": 1.0})
     assert sched["N"] == 0.3
     assert sched["K"] == 0.4
+
+
+def test_get_foliar_feed_interval():
+    assert get_foliar_feed_interval("tomato", "vegetative") == 7
+    assert get_foliar_feed_interval("lettuce") == 14
+    assert get_foliar_feed_interval("unknown") is None
+
+
+def test_next_foliar_feed_date():
+    last = date(2023, 1, 1)
+    expected = date(2023, 1, 8)
+    assert next_foliar_feed_date("tomato", "vegetative", last) == expected
+    assert next_foliar_feed_date("unknown", None, last) is None


### PR DESCRIPTION
## Summary
- add `foliar_feed_intervals.json` dataset
- load intervals in `plant_engine.fertigation`
- expose `get_foliar_feed_interval` and `next_foliar_feed_date`
- extend README and dataset catalog
- cover new utilities with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811c1071f88330b9cafdf869aa3253