### PR TITLE
Add IPM dataset and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Key reference datasets reside in the `data/` directory:
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage
+- `ipm_guidelines.json` – integrated pest management practices by crop
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `water_quality_actions.json` – recommended treatments when limits are exceeded
 - `fertilizer_purity.json` – default purity factors for common fertilizers
@@ -249,6 +250,8 @@ or incomplete and should only be used as a starting point for your own research.
   observed pests using `beneficial_insects.json`.
 - **Biological Control Helper**: `recommend_biological_controls` suggests
   beneficial insects to deploy when pest thresholds are exceeded.
+- **IPM Guidance**: `recommend_ipm_actions` returns cultural practices and
+  crop-specific actions from `ipm_guidelines.json`.
 - **Pest Monitoring Report**: `generate_pest_report` combines severity,
   treatment, biological control, severity actions and prevention advice for observed pests using `pest_severity_actions.json`.
 - **Pest Scouting Intervals**: `get_pest_monitoring_interval` returns recommended days between checks using `pest_monitoring_intervals.json`.

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -10,6 +10,7 @@
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",
   "pest_monitoring_intervals.json": "Recommended days between scouting events.",
+  "ipm_guidelines.json": "Integrated pest management practices by crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",

--- a/data/ipm_guidelines.json
+++ b/data/ipm_guidelines.json
@@ -1,0 +1,12 @@
+{
+  "citrus": {
+    "general": "Prune regularly and monitor weekly for pests.",
+    "aphids": "Introduce ladybugs when counts exceed threshold; avoid broad-spectrum insecticides.",
+    "scale": "Apply horticultural oil and encourage parasitic wasps."
+  },
+  "lettuce": {
+    "general": "Rotate crops and maintain good airflow to reduce disease pressure.",
+    "aphids": "Release lacewings and use reflective mulches.",
+    "slugs": "Use shallow beer traps and nighttime scouting."
+  }
+}

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -8,6 +8,7 @@ from .utils import load_dataset, normalize_key
 DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
 PREVENTION_FILE = "pest_prevention.json"
+IPM_FILE = "ipm_guidelines.json"
 
 
 
@@ -15,6 +16,7 @@ PREVENTION_FILE = "pest_prevention.json"
 _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
 _BENEFICIALS: Dict[str, List[str]] = load_dataset(BENEFICIAL_FILE)
 _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
+_IPM: Dict[str, Dict[str, str]] = load_dataset(IPM_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -65,6 +67,28 @@ def recommend_prevention(plant_type: str, pests: Iterable[str]) -> Dict[str, str
     return actions
 
 
+def get_ipm_guidelines(plant_type: str) -> Dict[str, str]:
+    """Return integrated pest management guidance for a crop."""
+    return _IPM.get(normalize_key(plant_type), {})
+
+
+def recommend_ipm_actions(plant_type: str, pests: Iterable[str] | None = None) -> Dict[str, str]:
+    """Return IPM actions for the crop and specific pests if provided."""
+    data = get_ipm_guidelines(plant_type)
+    if not data:
+        return {}
+    actions: Dict[str, str] = {}
+    general = data.get("general")
+    if general:
+        actions["general"] = general
+    if pests:
+        for pest in pests:
+            action = data.get(normalize_key(pest))
+            if action:
+                actions[pest] = action
+    return actions
+
+
 __all__ = [
     "list_supported_plants",
     "get_pest_guidelines",
@@ -74,4 +98,6 @@ __all__ = [
     "recommend_beneficials",
     "get_pest_prevention",
     "recommend_prevention",
+    "get_ipm_guidelines",
+    "recommend_ipm_actions",
 ]

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -5,6 +5,8 @@ from plant_engine.pest_manager import (
     recommend_beneficials,
     get_pest_prevention,
     recommend_prevention,
+    get_ipm_guidelines,
+    recommend_ipm_actions,
     list_known_pests,
 )
 
@@ -53,3 +55,15 @@ def test_recommend_prevention():
     rec = recommend_prevention("citrus", ["aphids", "unknown"])
     assert rec["aphids"].startswith("Encourage")
     assert rec["unknown"] == "No guideline available"
+
+
+def test_get_ipm_guidelines():
+    data = get_ipm_guidelines("citrus")
+    assert data["general"].startswith("Prune")
+    assert "aphids" in data
+
+
+def test_recommend_ipm_actions():
+    actions = recommend_ipm_actions("citrus", ["aphids"])
+    assert "general" in actions
+    assert actions["aphids"].startswith("Introduce ladybugs")


### PR DESCRIPTION
## Summary
- integrate IPM (Integrated Pest Management) dataset
- expose `get_ipm_guidelines` and `recommend_ipm_actions` helpers
- document the new dataset in the README
- test IPM utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811c414c7c8330bf86fff20491810a