### PR TITLE
Enhance WSDA fertilizer lookup and datasets

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -65,5 +65,7 @@
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
   "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
-  "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage."
+  "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
+  "wsda_fertilizer_database.json": "Full WSDA fertilizer product database for nutrient lookups.",
+  "products_index.jsonl": "Compact index of WSDA fertilizer products (JSON Lines)."
 }

--- a/plant_engine/wsda_lookup.py
+++ b/plant_engine/wsda_lookup.py
@@ -11,7 +11,13 @@ from typing import Dict, List, Tuple
 # Path to the WSDA fertilizer database packaged with the repository
 _WSDA_PATH = Path(__file__).resolve().parents[1] / "wsda_fertilizer_database.json"
 
-__all__ = ["get_product_npk_by_name", "get_product_npk_by_number", "search_products"]
+__all__ = [
+    "get_product_npk_by_name",
+    "get_product_npk_by_number",
+    "search_products",
+    "list_product_names",
+    "list_product_numbers",
+]
 
 @dataclass(frozen=True)
 class _Product:
@@ -78,3 +84,15 @@ def search_products(query: str, limit: int = 10) -> List[str]:
     matches = [prod.name for key, prod in names.items() if q in key]
     matches.sort()
     return matches[: max(limit, 0)]
+
+
+def list_product_names() -> List[str]:
+    """Return all product names sorted alphabetically."""
+    names, _ = _build_indexes()
+    return sorted(prod.name for prod in names.values())
+
+
+def list_product_numbers() -> List[str]:
+    """Return all WSDA product numbers sorted alphabetically."""
+    _, numbers = _build_indexes()
+    return sorted(numbers.keys())

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -25,3 +25,6 @@ def test_get_dataset_description():
 
     desc4 = get_dataset_description("irrigation_intervals.json")
     assert "irrigation" in desc4
+
+    desc5 = get_dataset_description("wsda_fertilizer_database.json")
+    assert "WSDA" in desc5

--- a/tests/test_wsda_lookup.py
+++ b/tests/test_wsda_lookup.py
@@ -11,6 +11,8 @@ spec.loader.exec_module(wsda)
 get_product_npk_by_name = wsda.get_product_npk_by_name
 get_product_npk_by_number = wsda.get_product_npk_by_number
 search_products = wsda.search_products
+list_product_names = wsda.list_product_names
+list_product_numbers = wsda.list_product_numbers
 
 
 def test_lookup_by_name():
@@ -40,3 +42,13 @@ def test_lookup_unknown_product():
 def test_search_limit():
     results = search_products("CARE", limit=1)
     assert len(results) == 1
+
+
+def test_list_product_names_contains_known():
+    names = list_product_names()
+    assert any("EARTH-CARE" in n for n in names)
+
+
+def test_list_product_numbers_contains_known():
+    numbers = list_product_numbers()
+    assert "(#4083-0001)" in numbers


### PR DESCRIPTION
## Summary
- document WSDA fertilizer datasets in `dataset_catalog.json`
- expose product name/number listings in `wsda_lookup`
- cover new lookup helpers and dataset entries with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811c0d24c083308e626ffbb18f4b2b