### PR TITLE
Add yield-based fertigation calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Comprehensive Fertigation**: `recommend_precise_fertigation` adjusts for
   existing water nutrient levels, can include micronutrients, and returns cost
   estimates along with any water quality warnings.
+- **Yield-Based Fertigation**: `recommend_yield_based_fertigation` converts
+  nutrient removal rates and fertilizer purity data into a complete schedule to
+  meet a desired crop yield.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and
   micro guidelines with interaction checks to summarize deficiencies and
   surpluses at once.

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -266,3 +266,19 @@ def test_estimate_solution_ec():
     schedule = {"N": 100, "K": 150}
     ec = estimate_solution_ec(schedule)
     assert ec == pytest.approx(0.465, rel=1e-3)
+
+
+def test_recommend_yield_based_fertigation():
+    from plant_engine.fertigation import recommend_yield_based_fertigation
+
+    schedule = recommend_yield_based_fertigation(
+        "tomato",
+        yield_kg=2.0,
+        fertilizers={
+            "N": "foxfarm_grow_big",
+            "P": "foxfarm_grow_big",
+            "K": "intrepid_granular_potash_0_0_60",
+        },
+    )
+    assert schedule["foxfarm_grow_big"] > 0
+    assert schedule["intrepid_granular_potash_0_0_60"] > 0


### PR DESCRIPTION
## Summary
- support yield-based fertigation planning using nutrient removal data
- document new capability in README
- test yield based fertigation schedule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811bec1f58833091daec41ade380df