### PR TITLE
Improve rootzone model with infiltration data

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -59,6 +59,7 @@
   "pruning_guidelines.json": "Stage-specific pruning recommendations.",
   "soil_nutrient_guidelines.json": "Target soil nutrient levels by crop.",
   "soil_texture_parameters.json": "Typical sand, silt and clay percentages.",
+  "soil_infiltration_rates.json": "Infiltration rates (mm/hr) by soil texture.",
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",

--- a/data/soil_infiltration_rates.json
+++ b/data/soil_infiltration_rates.json
@@ -1,0 +1,9 @@
+{
+  "sand": 25,
+  "loamy_sand": 20,
+  "sandy_loam": 15,
+  "loam": 10,
+  "silt_loam": 7,
+  "clay_loam": 5,
+  "clay": 2
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -73,6 +73,8 @@ from .rootzone_model import (
     estimate_rootzone_depth,
     estimate_water_capacity,
     get_soil_parameters,
+    get_infiltration_rate,
+    estimate_infiltration_time,
     RootZone,
 )
 from .soil_manager import (
@@ -261,6 +263,8 @@ __all__ = [
     "estimate_rootzone_depth",
     "estimate_water_capacity",
     "get_soil_parameters",
+    "get_infiltration_rate",
+    "estimate_infiltration_time",
     "RootZone",
     "list_soil_plants",
     "get_soil_targets",

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -5,6 +5,8 @@ from plant_engine.rootzone_model import (
     calculate_remaining_water,
     get_soil_parameters,
     soil_moisture_pct,
+    get_infiltration_rate,
+    estimate_infiltration_time,
     RootZone,
 )
 import pytest
@@ -84,4 +86,18 @@ def test_rootzone_methods():
     new = rz.calculate_remaining_water(100.0, irrigation_ml=50.0, et_ml=25.0)
     assert new == 125.0
     assert rz.moisture_pct(new) == soil_moisture_pct(rz, new)
+
+
+def test_get_infiltration_rate():
+    rate = get_infiltration_rate("loam")
+    assert rate == 10
+    assert get_infiltration_rate("unknown") is None
+
+
+def test_estimate_infiltration_time():
+    hours = estimate_infiltration_time(1000, 1.0, "loam")
+    assert hours == 0.1
+    assert estimate_infiltration_time(1000, 1.0, "unknown") is None
+    with pytest.raises(ValueError):
+        estimate_infiltration_time(-1, 1.0, "loam")
 


### PR DESCRIPTION
## Summary
- add soil infiltration rate dataset for new irrigation calculations
- extend `rootzone_model` with infiltration helpers
- export helpers via public API
- test new infiltration functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688120d923b48330acb7bf467dce6cbc