### PR TITLE
Enhance disease monitoring utilities

### DIFF
--- a/data/disease_monitoring_intervals.json
+++ b/data/disease_monitoring_intervals.json
@@ -1,0 +1,17 @@
+{
+  "citrus": {
+    "seedling": 7,
+    "fruiting": 4,
+    "optimal": 5
+  },
+  "lettuce": {
+    "seedling": 6,
+    "harvest": 2,
+    "optimal": 4
+  },
+  "tomato": {
+    "seedling": 7,
+    "fruiting": 3,
+    "optimal": 5
+  }
+}

--- a/tests/test_disease_monitor.py
+++ b/tests/test_disease_monitor.py
@@ -1,9 +1,12 @@
+from datetime import date
 from plant_engine.disease_monitor import (
     get_disease_thresholds,
     assess_disease_pressure,
     classify_disease_severity,
     recommend_threshold_actions,
     generate_disease_report,
+    get_monitoring_interval,
+    next_monitor_date,
 )
 
 
@@ -39,3 +42,16 @@ def test_generate_disease_report():
     assert report["thresholds_exceeded"]["citrus_greening"] is True
     assert "citrus greening" in report["treatments"]
     assert "root rot" in report["prevention"]
+
+
+def test_get_monitoring_interval():
+    assert get_monitoring_interval("citrus", "fruiting") == 4
+    assert get_monitoring_interval("CITRUS") == 5
+    assert get_monitoring_interval("unknown") is None
+
+
+def test_next_monitor_date():
+    last = date(2023, 1, 1)
+    expected = date(2023, 1, 5)
+    assert next_monitor_date("citrus", "fruiting", last) == expected
+    assert next_monitor_date("unknown", None, last) is None


### PR DESCRIPTION
## Summary
- add disease monitoring interval dataset
- extend `disease_monitor` with monitoring interval helpers
- test disease monitoring interval helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812719eeac8330a5b4d856e4e010ff