### PR TITLE
Add grams_to_ppm utility

### DIFF
--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -127,6 +127,7 @@ __all__ = [
     "generate_cycle_fertigation_plan",
     "generate_cycle_fertigation_plan_with_cost",
     "recommend_precise_fertigation",
+    "grams_to_ppm",
 ]
 
 
@@ -161,6 +162,28 @@ def _ppm_to_grams(ppm: float, volume_l: float, purity: float) -> float:
         raise ValueError("purity must be > 0")
     mg = ppm * volume_l
     return round((mg / 1000) / purity, 3)
+
+
+def grams_to_ppm(grams: float, volume_l: float, purity: float) -> float:
+    """Return nutrient ppm for ``grams`` dissolved in ``volume_l`` solution.
+
+    Parameters
+    ----------
+    grams : float
+        Fertilizer mass in grams.
+    volume_l : float
+        Final solution volume in liters. Must be greater than zero.
+    purity : float
+        Fractional nutrient purity (0-1). Must be greater than zero.
+    """
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be > 0")
+    if purity <= 0:
+        raise ValueError("purity must be > 0")
+
+    mg = grams * 1000 * purity
+    return round(mg / volume_l, 2)
 
 
 def recommend_fertigation_schedule(

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -280,3 +280,26 @@ def test_generate_cycle_fertigation_plan_with_cost():
     assert plan == basic_plan
     assert cost > 0
 
+
+def test_grams_to_ppm_roundtrip():
+    from plant_engine.fertigation import grams_to_ppm
+
+    schedule = recommend_fertigation_schedule(
+        "tomato",
+        "vegetative",
+        volume_l=10.0,
+        purity={"N": 0.5},
+    )
+    grams = schedule["N"]
+    ppm = grams_to_ppm(grams, 10.0, 0.5)
+    assert ppm == pytest.approx(100.0)
+
+
+def test_grams_to_ppm_invalid():
+    from plant_engine.fertigation import grams_to_ppm
+
+    with pytest.raises(ValueError):
+        grams_to_ppm(1.0, 0.0, 1.0)
+    with pytest.raises(ValueError):
+        grams_to_ppm(1.0, 1.0, 0.0)
+


### PR DESCRIPTION
## Summary
- add `grams_to_ppm` helper in fertigation module
- expose new function and update `__all__`
- test roundtrip ppm conversion and invalid inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881271ecdc883308577b8a9f45784bb