### PR TITLE
Refactor repeated helpers

### DIFF
--- a/custom_components/horticulture_assistant/sensor.py
+++ b/custom_components/horticulture_assistant/sensor.py
@@ -17,6 +17,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .utils.state_helpers import get_numeric_state
+
 from plant_engine.environment_manager import score_environment
 
 from .const import (
@@ -77,15 +79,8 @@ class HorticultureBaseSensor(SensorEntity):
         }
 
     def _get_state_value(self, entity_id: str) -> float | None:
-        """Get state of an entity as a float, or None if unavailable/invalid."""
-        state = self.hass.states.get(entity_id)
-        if not state or state.state in ("unknown", "unavailable"):
-            return None
-        try:
-            return float(state.state)
-        except (ValueError, TypeError):
-            _LOGGER.warning("State of %s is not a number: %s", entity_id, state.state)
-            return None
+        """Return the numeric state of ``entity_id`` using :func:`get_numeric_state`."""
+        return get_numeric_state(self.hass, entity_id)
 
 class ExponentialMovingAverageSensor(HorticultureBaseSensor):
     """Base sensor applying an exponential moving average to another sensor."""

--- a/custom_components/horticulture_assistant/utils/daily_report_builder.py
+++ b/custom_components/horticulture_assistant/utils/daily_report_builder.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 from homeassistant.core import HomeAssistant
 
+from .state_helpers import get_numeric_state
+
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_profile,
 )
@@ -43,19 +45,7 @@ class DailyReport:
         return asdict(self)
 
 
-__all__ = ["DailyReport", "build_daily_report", "get_state_value"]
-
-def get_state_value(hass: HomeAssistant, entity_id: str) -> float | None:
-    """Return the numeric state of ``entity_id`` or ``None`` if missing."""
-    state = hass.states.get(entity_id)
-    if not state or state.state in ("unknown", "unavailable"):
-        _LOGGER.debug("Sensor %s is unavailable or unknown; skipping.", entity_id)
-        return None
-    try:
-        return float(state.state)
-    except (ValueError, TypeError):
-        _LOGGER.warning("State of %s is not a numeric value: %s", entity_id, state.state)
-        return None
+__all__ = ["DailyReport", "build_daily_report"]
 
 
 def _resolve_plant_type(hass: HomeAssistant, plant_id: str, profile: dict) -> Optional[str]:
@@ -112,11 +102,11 @@ def build_daily_report(hass: HomeAssistant, plant_id: str) -> dict:
         or profile.get("general", {}).get("sensor_entities")
         or {}
     )
-    moisture = get_state_value(hass, sensor_map.get("moisture") or f"sensor.{plant_id}_raw_moisture")
-    ec = get_state_value(hass, sensor_map.get("ec") or f"sensor.{plant_id}_raw_ec")
-    temperature = get_state_value(hass, sensor_map.get("temperature") or f"sensor.{plant_id}_raw_temperature")
-    humidity = get_state_value(hass, sensor_map.get("humidity") or f"sensor.{plant_id}_raw_humidity")
-    light = get_state_value(hass, sensor_map.get("light") or f"sensor.{plant_id}_raw_light")
+    moisture = get_numeric_state(hass, sensor_map.get("moisture") or f"sensor.{plant_id}_raw_moisture")
+    ec = get_numeric_state(hass, sensor_map.get("ec") or f"sensor.{plant_id}_raw_ec")
+    temperature = get_numeric_state(hass, sensor_map.get("temperature") or f"sensor.{plant_id}_raw_temperature")
+    humidity = get_numeric_state(hass, sensor_map.get("humidity") or f"sensor.{plant_id}_raw_humidity")
+    light = get_numeric_state(hass, sensor_map.get("light") or f"sensor.{plant_id}_raw_light")
 
     # Last known yield (e.g., total yield or current yield progress)
     yield_val = profile.get("last_yield")
@@ -128,7 +118,7 @@ def build_daily_report(hass: HomeAssistant, plant_id: str) -> dict:
             f"sensor.plant_{short_id}_yield_progress"
         ]
         for ent in possible_yield_entities:
-            y_state = get_state_value(hass, ent)
+            y_state = get_numeric_state(hass, ent)
             if y_state is not None:
                 yield_val = y_state
                 break

--- a/custom_components/horticulture_assistant/utils/state_helpers.py
+++ b/custom_components/horticulture_assistant/utils/state_helpers.py
@@ -1,0 +1,22 @@
+"""Utility helpers for working with Home Assistant state values."""
+
+from __future__ import annotations
+
+import logging
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["get_numeric_state"]
+
+def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
+    """Return the state of ``entity_id`` cast to ``float`` if available."""
+    state = hass.states.get(entity_id)
+    if not state or state.state in ("unknown", "unavailable"):
+        _LOGGER.debug("State unavailable: %s", entity_id)
+        return None
+    try:
+        return float(state.state)
+    except (ValueError, TypeError):
+        _LOGGER.warning("State of %s is not numeric: %s", entity_id, state.state)
+        return None

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -4,7 +4,10 @@ from typing import Dict, Mapping, Any
 
 from functools import lru_cache
 
-from plant_engine.utils import load_json, save_json
+from plant_engine.utils import save_json
+from custom_components.horticulture_assistant.utils.plant_profile_loader import (
+    load_profile_by_id,
+)
 from plant_engine.ai_model import analyze
 from plant_engine.compute_transpiration import compute_transpiration
 from plant_engine.water_deficit_tracker import update_water_balance
@@ -40,8 +43,12 @@ _LOGGER = logging.getLogger(__name__)
 @lru_cache(maxsize=None)
 def load_profile(plant_id: str) -> Dict[str, Any]:
     """Return the plant profile for ``plant_id`` loaded from disk."""
-    path = os.path.join(PLANTS_DIR, f"{plant_id}.json")
-    return load_json(path)
+    profile = load_profile_by_id(plant_id, PLANTS_DIR)
+    if "general" in profile and isinstance(profile["general"], dict):
+        flat = {k: v for k, v in profile.items() if k != "general"}
+        flat.update(profile["general"])
+        return flat
+    return profile
 
 
 def _normalize_env(env: Mapping[str, Any]) -> Dict[str, float]:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@ import json
 
 from plant_engine import engine
 from plant_engine import growth_model
+from custom_components.horticulture_assistant.utils import plant_profile_loader
 
 
 def test_run_daily_cycle_with_rootzone(tmp_path, monkeypatch):
@@ -72,12 +73,12 @@ def test_load_profile_cached(tmp_path, monkeypatch):
 
     calls = 0
 
-    def fake_load(path):
+    def fake_load(pid, base_dir):
         nonlocal calls
         calls += 1
         return {"a": 1}
 
-    monkeypatch.setattr(engine, "load_json", fake_load)
+    monkeypatch.setattr(engine, "load_profile_by_id", fake_load)
     engine.load_profile.cache_clear()
 
     engine.load_profile("demo")


### PR DESCRIPTION
## Summary
- move repeated state checks into `state_helpers.get_numeric_state`
- use helper in sensors and daily report builder
- load profiles via `plant_profile_loader` while flattening to preserve original structure
- update engine tests for new loader behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812d735f888330ba2308ba1432d7b4