### PR TITLE
Reduce JSON helper duplication

### DIFF
--- a/custom_components/horticulture_assistant/utils/json_io.py
+++ b/custom_components/horticulture_assistant/utils/json_io.py
@@ -1,31 +1,49 @@
+"""Lightweight helpers for JSON file operations.
+
+This module previously re-implemented basic ``json.load`` and ``json.dump``
+logic in several places across the code base.  To reduce repetition we now
+delegate to the existing helpers in :mod:`plant_engine.utils` while preserving
+the simple error handling behaviour expected by callers.
+"""
+
 import json
 import logging
 from pathlib import Path
 from typing import Any
 
+from plant_engine.utils import load_json as _load_json, save_json as _save_json
+
 _LOGGER = logging.getLogger(__name__)
 
 
 def load_json(path: str | Path, default: Any | None = None) -> Any:
-    """Load JSON data from ``path``. Return ``default`` on error."""
+    """Load JSON data from ``path``.
+
+    Any errors are logged and ``default`` is returned instead of raising
+    exceptions.  This mirrors the behaviour of the previous implementation
+    while relying on :func:`plant_engine.utils.load_json` for the heavy
+    lifting.
+    """
+
     try:
-        with open(Path(path), "r", encoding="utf-8") as f:
-            return json.load(f)
-    except FileNotFoundError:
-        _LOGGER.error("File not found: %s", path)
-    except json.JSONDecodeError as err:
-        _LOGGER.error("Invalid JSON in %s: %s", path, err)
+        return _load_json(str(path))
     except Exception as err:  # pragma: no cover - unexpected errors
         _LOGGER.error("Error reading %s: %s", path, err)
-    return default
+        return default
 
 
 def save_json(path: str | Path, data: Any, *, indent: int = 2) -> bool:
     """Write JSON data to ``path``. Return ``True`` on success."""
+
     try:
-        with open(Path(path), "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=indent)
+        if indent == 2:
+            _save_json(str(path), data)
+        else:  # honour custom indentation
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            with open(Path(path), "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=indent)
         return True
     except Exception as err:  # pragma: no cover - unexpected errors
         _LOGGER.error("Failed to write %s: %s", path, err)
-    return False
+        return False
+


### PR DESCRIPTION
## Summary
- centralize JSON load/save utilities to remove duplicate code
- refactor yield tracker and grafana exporter to use the shared helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688130ad59f08330a278f9bbf1e1c3ee