### PR TITLE
Reduce duplicated profile writer logic

### DIFF
--- a/custom_components/horticulture_assistant/utils/profile_econ_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_econ_writer.py
@@ -1,74 +1,31 @@
-# File: custom_components/horticulture_assistant/utils/profile_econ_writer.py
-
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """Create economics.json and management.json for a given plant's profile directory.
-    
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "economics.json" and "management.json".
-    Each file contains preset fields relevant to plant economics and management, initialized to null values.
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default structure.
-    Logs messages for each created file, any skipped creations, and any errors encountered.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-    
-    # Define default structures for economics and management
-    economics_data = {
-        "labor_costs": None,
-        "equipment_costs": None,
-        "consumables": None,
-        "production_expenses": None,
-        "unit_economics": None,
-        "market_value": None,
-        "product_shelf_life": None,
-        "transportation_and_logistics": None,
-        "pricing_trends": None
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create economics and management profile files for ``plant_id``."""
+    profile_sections = {
+        "economics.json": {
+            "labor_costs": None,
+            "equipment_costs": None,
+            "consumables": None,
+            "production_expenses": None,
+            "unit_economics": None,
+            "market_value": None,
+            "product_shelf_life": None,
+            "transportation_and_logistics": None,
+            "pricing_trends": None,
+        },
+        "management.json": {
+            "recommended_cultivation_practices": None,
+            "labor_cycles": None,
+            "growth_stages_by_calendar": None,
+            "harvest_strategies": None,
+            "propagation_methods": None,
+            "trellising_staking_spacing": None,
+            "other_sops": None,
+        },
     }
-    management_data = {
-        "recommended_cultivation_practices": None,
-        "labor_cycles": None,
-        "growth_stages_by_calendar": None,
-        "harvest_strategies": None,
-        "propagation_methods": None,
-        "trellising_staking_spacing": None,
-        "other_sops": None
-    }
-    
-    # File paths
-    econ_file = os.path.join(plant_dir, "economics.json")
-    mgmt_file = os.path.join(plant_dir, "management.json")
-    
-    # Write or skip economics.json
-    if not overwrite and os.path.isfile(econ_file):
-        _LOGGER.info("Economics file already exists at %s; skipping (overwrite=False).", econ_file)
-    else:
-        try:
-            with open(econ_file, "w", encoding="utf-8") as f:
-                json.dump(economics_data, f, indent=2)
-            _LOGGER.info("Economics profile created for plant %s at %s", plant_id, econ_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write economics profile for plant %s: %s", plant_id, e)
-    
-    # Write or skip management.json
-    if not overwrite and os.path.isfile(mgmt_file):
-        _LOGGER.info("Management file already exists at %s; skipping (overwrite=False).", mgmt_file)
-    else:
-        try:
-            with open(mgmt_file, "w", encoding="utf-8") as f:
-                json.dump(management_data, f, indent=2)
-            _LOGGER.info("Management profile created for plant %s at %s", plant_id, mgmt_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write management profile for plant %s: %s", plant_id, e)
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_environmental_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_environmental_log_writer.py
@@ -1,85 +1,13 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """
-    Create environmental incident and cultural disruption log files for a given plant's profile directory.
 
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "environmental_incident_log.json" and "cultural_disruption_log.json".
-    The environmental_incident_log.json file is initialized as an empty list intended to hold incident events.
-    Each incident entry is a dictionary with fields such as "timestamp", "event_type", "severity", "duration_estimate",
-    "detection_method", "impact_area", "resolution_status", and "notes". The cultural_disruption_log.json file is also
-    initialized as an empty list intended to log skipped cultural practices. Each entry includes fields like "timestamp",
-    "practice_skipped", "reason", "duration_skipped_days", "observed_impact", "corrective_action_taken", and "notes".
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default (empty list) structure.
-    Logs messages for each created file, any skipped creations (with entry count if available), and any overwrite or error events.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-
-    # Default empty structures for environmental incident and cultural disruption logs
-    environmental_data = []
-    cultural_data = []
-
-    # File paths
-    env_log_file = os.path.join(plant_dir, "environmental_incident_log.json")
-    cult_log_file = os.path.join(plant_dir, "cultural_disruption_log.json")
-
-    # Write or skip environmental_incident_log.json
-    if not overwrite and os.path.isfile(env_log_file):
-        entry_count = None
-        try:
-            with open(env_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing environmental incident log at %s for counting entries: %s", env_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Environmental incident log already exists at %s with %d entries; skipping (overwrite=False).", env_log_file, entry_count)
-        else:
-            _LOGGER.info("Environmental incident log already exists at %s; skipping (overwrite=False).", env_log_file)
-    else:
-        if overwrite and os.path.isfile(env_log_file):
-            _LOGGER.info("Existing environmental incident log at %s will be overwritten.", env_log_file)
-        try:
-            with open(env_log_file, "w", encoding="utf-8") as f:
-                json.dump(environmental_data, f, indent=2)
-            _LOGGER.info("Environmental incident log created for plant %s at %s", plant_id, env_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write environmental incident log for plant %s: %s", plant_id, e)
-
-    # Write or skip cultural_disruption_log.json
-    if not overwrite and os.path.isfile(cult_log_file):
-        entry_count = None
-        try:
-            with open(cult_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing cultural disruption log at %s for counting entries: %s", cult_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Cultural disruption log already exists at %s with %d entries; skipping (overwrite=False).", cult_log_file, entry_count)
-        else:
-            _LOGGER.info("Cultural disruption log already exists at %s; skipping (overwrite=False).", cult_log_file)
-    else:
-        if overwrite and os.path.isfile(cult_log_file):
-            _LOGGER.info("Existing cultural disruption log at %s will be overwritten.", cult_log_file)
-        try:
-            with open(cult_log_file, "w", encoding="utf-8") as f:
-                json.dump(cultural_data, f, indent=2)
-            _LOGGER.info("Cultural disruption log created for plant %s at %s", plant_id, cult_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write cultural disruption log for plant %s: %s", plant_id, e)
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create environmental incident and cultural disruption logs for ``plant_id``."""
+    profile_sections = {
+        "environmental_incident_log.json": [],
+        "cultural_disruption_log.json": [],
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_helpers.py
+++ b/custom_components/horticulture_assistant/utils/profile_helpers.py
@@ -31,13 +31,14 @@ def write_profile_sections(
         if file_path.exists() and not overwrite:
             _LOGGER.info("File %s already exists. Skipping write.", file_path)
             continue
-        if save_json(file_path, data):
-            if file_path.exists() and overwrite:
+        try:
+            save_json(file_path, data)
+            if overwrite and file_path.exists():
                 _LOGGER.info("Overwrote existing file: %s", file_path)
             else:
                 _LOGGER.info("Created file: %s", file_path)
-        else:
-            _LOGGER.error("Failed to write %s", file_path)
+        except Exception as err:  # pragma: no cover - unexpected errors
+            _LOGGER.error("Failed to write %s: %s", file_path, err)
 
     _LOGGER.info("Profile files prepared for '%s' at %s", plant_id, plant_dir)
     return plant_id

--- a/custom_components/horticulture_assistant/utils/profile_intro_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_intro_writer.py
@@ -1,105 +1,38 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False):
-    """
-    Create introduction.json and identification.json files for a given plant profile with default fields.
-    If base_path is provided, use that as base directory; otherwise, default to a "plants" directory in current working path.
-    If overwrite is False, existing files will not be modified.
-    Logs all actions (directory creation, file writing, skipping, errors).
-    :param plant_id: Identifier for the plant (used as directory name under base_path).
-    :param base_path: Base directory where the 'plants' folder is located (optional).
-    :param overwrite: Whether to overwrite existing files if they exist.
-    :return: List of files created or overwritten. Returns None if an error prevents file creation.
-    """
-    # Determine base directory for plant profiles
-    base_dir = base_path if base_path is not None else os.path.join(os.getcwd(), "plants")
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Log starting action
-    _LOGGER.info("Scaffolding profile files for plant '%s' in directory: %s (overwrite=%s)", plant_id, plant_dir, overwrite)
-    # Ensure the plant directory exists
-    if not os.path.isdir(plant_dir):
-        try:
-            os.makedirs(plant_dir, exist_ok=True)
-            _LOGGER.info("Created plant directory: %s", plant_dir)
-        except Exception as e:
-            _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-            return None
-    else:
-        _LOGGER.info("Plant directory already exists: %s", plant_dir)
-    # Default profile content for introduction and identification
-    introduction_data = {
-        "primary_uses": None,
-        "duration": None,
-        "growth_habit": None,
-        "key_features": None,
-        "deciduous_or_evergreen": None,
-        "history": None,
-        "native_regions": None,
-        "domestication": None,
-        "cultural_significance": None,
-        "legal_restrictions": None,
-        "etymology": None,
-        "cautions": None
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create introduction and identification profile files for ``plant_id``."""
+    profile_sections = {
+        "introduction.json": {
+            "primary_uses": None,
+            "duration": None,
+            "growth_habit": None,
+            "key_features": None,
+            "deciduous_or_evergreen": None,
+            "history": None,
+            "native_regions": None,
+            "domestication": None,
+            "cultural_significance": None,
+            "legal_restrictions": None,
+            "etymology": None,
+            "cautions": None,
+        },
+        "identification.json": {
+            "general_description": None,
+            "leaf_structure": None,
+            "adaptations": None,
+            "rooting": None,
+            "storm_resistance": None,
+            "self_pruning": None,
+            "growth_rates": None,
+            "dimensions": None,
+            "phylogeny": None,
+            "defenses": None,
+            "ecological_interactions": None,
+        },
     }
-    identification_data = {
-        "general_description": None,
-        "leaf_structure": None,
-        "adaptations": None,
-        "rooting": None,
-        "storm_resistance": None,
-        "self_pruning": None,
-        "growth_rates": None,
-        "dimensions": None,
-        "phylogeny": None,
-        "defenses": None,
-        "ecological_interactions": None
-    }
-    # File paths
-    intro_path = os.path.join(plant_dir, "introduction.json")
-    ident_path = os.path.join(plant_dir, "identification.json")
-    created_or_updated = []
-    # Handle introduction.json
-    if os.path.exists(intro_path):
-        if overwrite:
-            try:
-                with open(intro_path, 'w', encoding='utf-8') as f:
-                    json.dump(introduction_data, f, ensure_ascii=False, indent=4)
-                _LOGGER.info("Overwrote existing introduction.json for plant '%s'", plant_id)
-                created_or_updated.append("introduction.json")
-            except Exception as e:
-                _LOGGER.error("Failed to write introduction.json for plant '%s': %s", plant_id, e)
-        else:
-            _LOGGER.info("introduction.json already exists for plant '%s'; skipping (overwrite=False)", plant_id)
-    else:
-        try:
-            with open(intro_path, 'w', encoding='utf-8') as f:
-                json.dump(introduction_data, f, ensure_ascii=False, indent=4)
-            _LOGGER.info("Created introduction.json for plant '%s'", plant_id)
-            created_or_updated.append("introduction.json")
-        except Exception as e:
-            _LOGGER.error("Failed to write introduction.json for plant '%s': %s", plant_id, e)
-    # Handle identification.json
-    if os.path.exists(ident_path):
-        if overwrite:
-            try:
-                with open(ident_path, 'w', encoding='utf-8') as f:
-                    json.dump(identification_data, f, ensure_ascii=False, indent=4)
-                _LOGGER.info("Overwrote existing identification.json for plant '%s'", plant_id)
-                created_or_updated.append("identification.json")
-            except Exception as e:
-                _LOGGER.error("Failed to write identification.json for plant '%s': %s", plant_id, e)
-        else:
-            _LOGGER.info("identification.json already exists for plant '%s'; skipping (overwrite=False)", plant_id)
-    else:
-        try:
-            with open(ident_path, 'w', encoding='utf-8') as f:
-                json.dump(identification_data, f, ensure_ascii=False, indent=4)
-            _LOGGER.info("Created identification.json for plant '%s'", plant_id)
-            created_or_updated.append("identification.json")
-        except Exception as e:
-            _LOGGER.error("Failed to write identification.json for plant '%s': %s", plant_id, e)
-    return created_or_updated
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_lab_zone_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_lab_zone_writer.py
@@ -1,97 +1,24 @@
-import os
-import json
 import logging
-from pathlib import Path
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def generate_lab_zone_profiles(plant_id: str, base_path: str = None, overwrite: bool = False) -> str:
-    """
-    Create or update lab analysis log and zone calendar files for a plant profile.
 
-    This function scaffolds two JSON files (`lab_analysis_log.json` and `zone_calendar.json`)
-    in the `plants/<plant_id>/` directory.
-
-    `lab_analysis_log.json` is initialized as an empty list. Each future entry in this log should be a dictionary with keys:
-    "timestamp", "sample_type" (e.g., leaf, water, media), "lab_name", "results" (dict), "units" (dict), "detection_limits" (optional), and "notes".
-
-    `zone_calendar.json` is initialized as a dictionary containing keys for USDA hardiness zones (e.g., "6a", "10b"). 
-    Each zone key maps to a dictionary of cultural recommendations:
-    "seeding_months", "transplant_months", "expected_harvest_months", "frost_risk_months", "critical_stress_windows".
-    All values in this zone mapping default to null (JSON null, represented as None in Python).
-
-    If a file already exists and `overwrite` is False, the file is left unchanged (skipped).
-    If `overwrite` is True or the file is missing, a new file is created (or an existing file overwritten) with the default structure.
-
-    All actions (creation, skipping, overwriting) are logged.
-
-    :param plant_id: Identifier for the plant (used as directory name under the base path).
-    :param base_path: Optional base directory path for plant profiles (defaults to "plants/" in current working directory).
-    :param overwrite: If True, overwrite existing files; if False, skip writing if files already exist.
-    :return: The plant_id if files were successfully created or already existed (skipped without error), or an empty string on error.
-    """
-    # Determine base directory for plant profiles
-    if base_path:
-        base_dir = Path(base_path)
-    else:
-        base_dir = Path("plants")
-    plant_dir = base_dir / str(plant_id)
-
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return ""
-
-    # Define default content for each file
-    lab_log_data = []  # empty list for lab_analysis_log
-    zone_calendar_data = {}
-    # Populate dictionary with all USDA hardiness zones (1a through 13b)
-    for i in range(1, 14):
-        for suffix in ["a", "b"]:
-            zone_key = f"{i}{suffix}"
-            zone_calendar_data[zone_key] = {
-                "seeding_months": None,
-                "transplant_months": None,
-                "expected_harvest_months": None,
-                "frost_risk_months": None,
-                "critical_stress_windows": None
-            }
-
-    file_sections = {
-        "lab_analysis_log.json": lab_log_data,
-        "zone_calendar.json": zone_calendar_data
+def generate_lab_zone_profiles(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create lab analysis log and zone calendar files for ``plant_id``."""
+    zone_calendar = {
+        f"{i}{suffix}": {
+            "seeding_months": None,
+            "transplant_months": None,
+            "expected_harvest_months": None,
+            "frost_risk_months": None,
+            "critical_stress_windows": None,
+        }
+        for i in range(1, 14)
+        for suffix in ("a", "b")
     }
-
-    for filename, default_content in file_sections.items():
-        file_path = plant_dir / filename
-        if file_path.exists() and not overwrite:
-            # Skip writing and log entry count if applicable
-            entry_count = None
-            try:
-                with open(file_path, "r", encoding="utf-8") as existing_file:
-                    existing_data = json.load(existing_file)
-                    if isinstance(existing_data, list):
-                        entry_count = len(existing_data)
-            except Exception as e:
-                _LOGGER.warning("Failed to read existing file %s: %s", file_path, e)
-            if entry_count is not None:
-                _LOGGER.info("File %s already exists with %d entries. Skipping write.", file_path, entry_count)
-            else:
-                _LOGGER.info("File %s already exists. Skipping write.", file_path)
-            continue
-
-        # Write new file or overwrite existing file with default content
-        existed_before = file_path.exists()
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(default_content, f, indent=2)
-            if existed_before and overwrite:
-                _LOGGER.info("Overwrote existing file: %s", file_path)
-            else:
-                _LOGGER.info("Created file: %s", file_path)
-        except Exception as e:
-            _LOGGER.error("Failed to write %s: %s", file_path, e)
-    _LOGGER.info("Lab analysis log and zone calendar prepared for '%s' at %s", plant_id, plant_dir)
-    return plant_id
+    profile_sections = {
+        "lab_analysis_log.json": [],
+        "zone_calendar.json": zone_calendar,
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_light_training_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_light_training_writer.py
@@ -1,87 +1,13 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """
-    Create light cycle and training/pruning log files for a given plant's profile directory.
-    
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "light_cycle_log.json" and "training_pruning_log.json".
-    The light_cycle_log.json file is initialized as an empty list intended to hold lighting cycle entries.
-    Each light cycle entry is a dictionary with fields such as "timestamp", "light_type" (e.g., "LED", "HPS", "natural"),
-    "hours_on", "DLI", "spectrum_target", "start_time", "end_time", and "notes". The training_pruning_log.json file is 
-    initialized as an empty list intended to hold training and pruning entries. Each training/pruning entry includes fields 
-    like "timestamp", "action_type" (e.g., "topping", "defoliation", "LST"), "performed_by", "tool_used", "plant_section", 
-    "reason", and "notes".
-    
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default (empty list) structure.
-    Logs messages for each created file, any skipped creations (with entry count if available), and any overwrite or error events.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-    
-    # Default empty structures for light cycle and training/pruning logs
-    light_cycle_data = []
-    training_pruning_data = []
-    
-    # File paths
-    light_log_file = os.path.join(plant_dir, "light_cycle_log.json")
-    training_log_file = os.path.join(plant_dir, "training_pruning_log.json")
-    
-    # Write or skip light_cycle_log.json
-    if not overwrite and os.path.isfile(light_log_file):
-        entry_count = None
-        try:
-            with open(light_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing light cycle log at %s for counting entries: %s", light_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Light cycle log already exists at %s with %d entries; skipping (overwrite=False).", light_log_file, entry_count)
-        else:
-            _LOGGER.info("Light cycle log already exists at %s; skipping (overwrite=False).", light_log_file)
-    else:
-        if overwrite and os.path.isfile(light_log_file):
-            _LOGGER.info("Existing light cycle log at %s will be overwritten.", light_log_file)
-        try:
-            with open(light_log_file, "w", encoding="utf-8") as f:
-                json.dump(light_cycle_data, f, indent=2)
-            _LOGGER.info("Light cycle log created for plant %s at %s", plant_id, light_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write light cycle log for plant %s: %s", plant_id, e)
-    
-    # Write or skip training_pruning_log.json
-    if not overwrite and os.path.isfile(training_log_file):
-        entry_count = None
-        try:
-            with open(training_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing training/pruning log at %s for counting entries: %s", training_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Training/pruning log already exists at %s with %d entries; skipping (overwrite=False).", training_log_file, entry_count)
-        else:
-            _LOGGER.info("Training/pruning log already exists at %s; skipping (overwrite=False).", training_log_file)
-    else:
-        if overwrite and os.path.isfile(training_log_file):
-            _LOGGER.info("Existing training/pruning log at %s will be overwritten.", training_log_file)
-        try:
-            with open(training_log_file, "w", encoding="utf-8") as f:
-                json.dump(training_pruning_data, f, indent=2)
-            _LOGGER.info("Training/pruning log created for plant %s at %s", plant_id, training_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write training/pruning log for plant %s: %s", plant_id, e)
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create light cycle and training/pruning log files for ``plant_id``."""
+    profile_sections = {
+        "light_cycle_log.json": [],
+        "training_pruning_log.json": [],
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_log_writer.py
@@ -1,75 +1,13 @@
-import os
-import json
 import logging
-from pathlib import Path
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def generate_profile_logs(plant_id: str, base_path: str = None, overwrite: bool = False) -> str:
-    """
-    Create or update log files (pest scouting and irrigation) for a plant profile.
 
-    This function scaffolds two JSON files (`pest_scouting_log.json` and `irrigation_log.json`)
-    in the `plants/<plant_id>/` directory. These files are initialized as empty lists, intended to hold log entries.
-
-    Each entry in `pest_scouting_log.json` should be a dictionary with keys:
-    "timestamp", "observer", "pest_type", "severity", "location", "notes".
-    Each entry in `irrigation_log.json` should be a dictionary with keys:
-    "timestamp", "volume_applied_ml", "method", "source", "zone_targeted", "success", "notes".
-
-    If a file already exists and `overwrite` is False, the file is left unchanged.
-    If `overwrite` is True or the file is missing, a new file is created (or an existing file overwritten) with an empty list.
-
-    If an existing file is not overwritten and contains a list, the length of the list (number of entries) is logged.
-
-    All actions (creation, skipping, overwriting) are logged.
-
-    :param plant_id: Identifier for the plant (used as directory name under the base path).
-    :param base_path: Optional base directory path for plant profiles (defaults to "plants/" in current working directory).
-    :param overwrite: If True, overwrite existing log files; if False, skip writing if files already exist.
-    :return: The plant_id if logs were successfully created or already existed (skipped), or an empty string on error.
-    """
-    # Determine base directory for plant profiles
-    if base_path:
-        base_dir = Path(base_path)
-    else:
-        base_dir = Path("plants")
-    plant_dir = base_dir / str(plant_id)
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return ""
-    # Define default (empty list) content for each log file
-    log_sections = {
+def generate_profile_logs(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create pest scouting and irrigation log files for ``plant_id``."""
+    profile_sections = {
         "pest_scouting_log.json": [],
-        "irrigation_log.json": []
+        "irrigation_log.json": [],
     }
-    # Create or skip each log file
-    for filename, default_content in log_sections.items():
-        file_path = plant_dir / filename
-        if file_path.exists() and not overwrite:
-            try:
-                with open(file_path, "r", encoding="utf-8") as existing_file:
-                    existing_data = json.load(existing_file)
-                if isinstance(existing_data, list):
-                    _LOGGER.info("File %s already exists with %d entries. Skipping write.", file_path, len(existing_data))
-                else:
-                    _LOGGER.info("File %s already exists. Skipping write.", file_path)
-            except Exception as e:
-                _LOGGER.error("Failed to read existing file %s: %s", file_path, e)
-                _LOGGER.info("File %s already exists. Skipping write.", file_path)
-            continue
-        # Write new or overwrite existing log file with default content
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump(default_content, f, indent=2)
-            if file_path.exists() and overwrite:
-                _LOGGER.info("Overwrote existing file: %s", file_path)
-            else:
-                _LOGGER.info("Created file: %s", file_path)
-        except Exception as e:
-            _LOGGER.error("Failed to write %s: %s", file_path, e)
-    _LOGGER.info("Pest scouting and irrigation logs prepared for '%s' at %s", plant_id, plant_dir)
-    return plant_id
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_media_fert_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_media_fert_writer.py
@@ -1,76 +1,13 @@
-import os
-import json
 import logging
-from pathlib import Path
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def initialize_media_fertilizer_logs(plant_id: str, base_path: str = None, overwrite: bool = False) -> bool:
-    """
-    Initialize media composition and fertilizer batch log files for a given plant profile.
-    
-    This creates two JSON log files under plants/<plant_id>/ if they do not exist (or if overwrite is True):
-      - media_composition_log.json: an empty list; each entry includes keys like 
-        "timestamp", "mix_name", "components", "blend_ratios", "water_holding_capacity_pct", 
-        "pH", "EC", and "notes".
-      - fertilizer_batch_history.json: an empty list; each entry includes keys like 
-        "timestamp", "product_name", "source_vendor", "batch_id", "analysis_label", 
-        "derived_from", "formulation_type", "expiration_date", "date_received", 
-        "storage_conditions", "status", and "notes".
-    
-    If files already exist and overwrite is False, they are left untouched.
-    If overwrite is True, existing files are cleared (overwritten with an empty list structure).
-    
-    Logs file creations, skips (with entry count if applicable), and any errors encountered.
-    
-    :param plant_id: Identifier of the plant (also directory name under base path).
-    :param base_path: Base directory containing plant profile folders (defaults to "plants/" in current working directory).
-    :param overwrite: If True, overwrite existing log files; if False, skip creating files that already exist.
-    :return: True if operation succeeded (or files skipped) without errors, False if an error occurred.
-    """
-    # Determine base directory for plant logs
-    if base_path:
-        base_dir = Path(base_path)
-    else:
-        base_dir = Path("plants")
-    plant_dir = base_dir / str(plant_id)
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return False
-    
-    log_files = ["media_composition_log.json", "fertilizer_batch_history.json"]
-    success = True
-    for filename in log_files:
-        file_path = plant_dir / filename
-        if file_path.exists() and not overwrite:
-            # Skip creation if file already exists and not overwriting
-            entry_count = None
-            try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    if isinstance(data, list):
-                        entry_count = len(data)
-            except Exception as e:
-                _LOGGER.warning("Could not read %s to count entries: %s", file_path, e)
-            if entry_count is not None:
-                _LOGGER.info("File %s already exists with %d entries. Skipping creation.", file_path, entry_count)
-            else:
-                _LOGGER.info("File %s already exists. Skipping creation.", file_path)
-            continue
-        
-        # Create or overwrite the file with an empty list
-        existed_before = file_path.exists()
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump([], f, indent=2)
-            if existed_before and overwrite:
-                _LOGGER.info("Overwrote existing file: %s", file_path)
-            else:
-                _LOGGER.info("Created file: %s", file_path)
-        except Exception as e:
-            _LOGGER.error("Failed to write %s: %s", file_path, e)
-            success = False
-    return success
+
+def initialize_media_fertilizer_logs(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> bool:
+    """Create media composition and fertilizer batch logs for ``plant_id``."""
+    profile_sections = {
+        "media_composition_log.json": [],
+        "fertilizer_batch_history.json": [],
+    }
+    return bool(write_profile_sections(plant_id, profile_sections, base_path, overwrite))

--- a/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
@@ -1,88 +1,34 @@
-import os
-import json
 import logging
 from pathlib import Path
-
 try:
     from homeassistant.core import HomeAssistant
-except ImportError:
-    HomeAssistant = None  # Allow usage outside Home Assistant for testing
+except ImportError:  # pragma: no cover - outside Home Assistant
+    HomeAssistant = None
+
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def initialize_nutrient_logs(plant_id: str, hass: 'HomeAssistant' = None, base_dir: str = None, overwrite: bool = False) -> bool:
-    """
-    Initialize nutrient log files for a given plant profile.
-    
-    This creates two JSON log files under plants/<plant_id>/ if they do not exist (or if overwrite is True):
-      - nutrient_application_log.json: an empty list; each future entry to include keys like 
-        "timestamp", "product_name", "nutrient_formulation", "rate_applied_ml", 
-        "delivery_method", "zone_targeted", "application_success", and "notes".
-      - fertilizer_cost_tracking.json: an empty list; each entry to include keys like 
-        "product_name", "unit_cost", "unit_type", "purchase_date", "vendor", 
-        "batch_id", "expiration_date", and "notes".
-    
-    If files already exist and overwrite is False, they are left untouched.
-    If overwrite is True, existing files are cleared (overwritten with an empty list structure).
-    
-    Logs file creations, skips (with entry count if applicable), and any errors encountered.
-    
-    :param plant_id: Identifier of the plant (also directory name under base path).
-    :param hass: HomeAssistant instance (optional) for path resolution.
-    :param base_dir: Base directory containing plant profile folders (defaults to "plants/" in current working directory or Home Assistant config).
-    :param overwrite: If True, overwrite existing log files; if False, skip creating files that already exist.
-    :return: True if operation succeeded (or files skipped) without errors, False if an error occurred.
-    """
-    # Determine base directory for plant logs
+
+def initialize_nutrient_logs(
+    plant_id: str,
+    hass: HomeAssistant | None = None,
+    base_dir: str | None = None,
+    overwrite: bool = False,
+) -> bool:
+    """Create nutrient application and fertilizer cost logs for ``plant_id``."""
     if base_dir:
         base_path = Path(base_dir)
     elif hass is not None:
         try:
             base_path = Path(hass.config.path("plants"))
-        except Exception as e:
-            _LOGGER.error("Error resolving Home Assistant plants directory: %s", e)
+        except Exception as err:  # pragma: no cover - path resolution failure
+            _LOGGER.error("Error resolving Home Assistant plants directory: %s", err)
             base_path = Path("plants")
     else:
         base_path = Path("plants")
-    
-    plant_dir = base_path / plant_id
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return False
-    
-    log_files = ["nutrient_application_log.json", "fertilizer_cost_tracking.json"]
-    success = True
-    for filename in log_files:
-        file_path = plant_dir / filename
-        if file_path.exists() and not overwrite:
-            # Skip creation if file already exists and not overwriting
-            entry_count = None
-            try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    if isinstance(data, list):
-                        entry_count = len(data)
-            except Exception as e:
-                _LOGGER.warning("Could not read %s to count entries: %s", file_path, e)
-            if entry_count is not None:
-                _LOGGER.info("File %s already exists with %d entries. Skipping creation.", file_path, entry_count)
-            else:
-                _LOGGER.info("File %s already exists. Skipping creation.", file_path)
-            continue
-        
-        # Create or overwrite the file with an empty list
-        existed_before = file_path.exists()
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump([], f, indent=2)
-            if existed_before and overwrite:
-                _LOGGER.info("Overwrote existing file: %s", file_path)
-            else:
-                _LOGGER.info("Created file: %s", file_path)
-        except Exception as e:
-            _LOGGER.error("Failed to write %s: %s", file_path, e)
-            success = False
-    return success
+    sections = {
+        "nutrient_application_log.json": [],
+        "fertilizer_cost_tracking.json": [],
+    }
+    return bool(write_profile_sections(plant_id, sections, base_path, overwrite))

--- a/custom_components/horticulture_assistant/utils/profile_phenophase_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_phenophase_writer.py
@@ -1,69 +1,28 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """Create phenophase_observations.json and developmental_thresholds.json for a given plant's profile directory.
 
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "phenophase_observations.json" and "developmental_thresholds.json".
-    Each file contains preset fields relevant to plant phenological observations and developmental thresholds, initialized to null values.
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default structure.
-    Logs messages for each created file, any skipped creations, and any errors encountered.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-
-    # Define default structures for phenophase observations and developmental thresholds
-    phenophase_observations_data = {
-        "bud_break_date": None,
-        "flowering_onset": None,
-        "fruit_set_date": None,
-        "first_harvest": None,
-        "senescence_onset": None,
-        "recorded_by": None,
-        "notes": None
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create phenophase observation and developmental threshold profiles."""
+    profile_sections = {
+        "phenophase_observations.json": {
+            "bud_break_date": None,
+            "flowering_onset": None,
+            "fruit_set_date": None,
+            "first_harvest": None,
+            "senescence_onset": None,
+            "recorded_by": None,
+            "notes": None,
+        },
+        "developmental_thresholds.json": {
+            "gdd_required_per_stage": None,
+            "photoperiod_triggers": None,
+            "chill_hours_required": None,
+            "stage_transition_factors": None,
+            "nutrient_triggers": None,
+            "vgi_thresholds": None,
+        },
     }
-    developmental_thresholds_data = {
-        "gdd_required_per_stage": None,
-        "photoperiod_triggers": None,
-        "chill_hours_required": None,
-        "stage_transition_factors": None,
-        "nutrient_triggers": None,
-        "vgi_thresholds": None
-    }
-
-    # File paths
-    phenophase_file = os.path.join(plant_dir, "phenophase_observations.json")
-    thresholds_file = os.path.join(plant_dir, "developmental_thresholds.json")
-
-    # Write or skip phenophase_observations.json
-    if not overwrite and os.path.isfile(phenophase_file):
-        _LOGGER.info("Phenophase observations file already exists at %s; skipping (overwrite=False).", phenophase_file)
-    else:
-        try:
-            with open(phenophase_file, "w", encoding="utf-8") as f:
-                json.dump(phenophase_observations_data, f, indent=2)
-            _LOGGER.info("Phenophase observations profile created for plant %s at %s", plant_id, phenophase_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write phenophase observations profile for plant %s: %s", plant_id, e)
-
-    # Write or skip developmental_thresholds.json
-    if not overwrite and os.path.isfile(thresholds_file):
-        _LOGGER.info("Developmental thresholds file already exists at %s; skipping (overwrite=False).", thresholds_file)
-    else:
-        try:
-            with open(thresholds_file, "w", encoding="utf-8") as f:
-                json.dump(developmental_thresholds_data, f, indent=2)
-            _LOGGER.info("Developmental thresholds profile created for plant %s at %s", plant_id, thresholds_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write developmental thresholds profile for plant %s: %s", plant_id, e)
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_postharvest_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_postharvest_writer.py
@@ -1,118 +1,13 @@
-# File: custom_components/horticulture_assistant/utils/profile_postharvest_writer.py
-
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """Create drying_log.json and curing_log.json for a given plant's profile directory.
-    
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "drying_log.json" and "curing_log.json".
-    Each file is initialized as an empty list to which drying or curing events can be appended.
-    Each drying log entry includes timestamp, method (e.g., rack, oven, freeze-dry), start_moisture_pct,
-    target_moisture_pct, temp_range_C, RH_range_pct, airflow_rate_cfm, duration_hrs, observed_outcome, and notes.
-    Each curing log entry includes timestamp, method (e.g., burp, vacuum, sealed humidistat), container_type,
-    duration_days, CO₂_release_events, final_moisture_pct, aroma_score, user_rating, and notes.
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files (this will reset any existing log entries).
-    Logs messages for each created file, any skipped creations (with existing entry counts if applicable), and any errors encountered.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-    
-    # Default log structures: empty lists
-    drying_data = []
-    curing_data = []
-    
-    # File paths
-    dry_file = os.path.join(plant_dir, "drying_log.json")
-    cur_file = os.path.join(plant_dir, "curing_log.json")
-    
-    # Handle drying_log.json
-    dry_existed = os.path.isfile(dry_file)
-    if dry_existed and not overwrite:
-        # File exists and we are not allowed to overwrite, skip creation
-        entry_count = None
-        try:
-            with open(dry_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-            if isinstance(existing_data, list):
-                entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Could not read existing drying log at %s to count entries: %s", dry_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Drying log file already exists at %s with %d entries; skipping (overwrite=False).", dry_file, entry_count)
-        else:
-            _LOGGER.info("Drying log file already exists at %s; skipping (overwrite=False).", dry_file)
-    else:
-        prev_count = None
-        if dry_existed:
-            # If file existed and will be overwritten, capture previous entry count
-            try:
-                with open(dry_file, "r", encoding="utf-8") as f:
-                    existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    prev_count = len(existing_data)
-            except Exception as e:
-                _LOGGER.warning("Could not read existing drying log at %s to count entries before overwrite: %s", dry_file, e)
-        try:
-            with open(dry_file, "w", encoding="utf-8") as f:
-                json.dump(drying_data, f, indent=2)
-            if dry_existed:
-                # File was overwritten
-                if prev_count is not None:
-                    _LOGGER.info("Drying log for plant %s at %s overwritten (previous entries: %d).", plant_id, dry_file, prev_count)
-                else:
-                    _LOGGER.info("Drying log for plant %s at %s overwritten.", plant_id, dry_file)
-            else:
-                # File did not exist before, so it was created
-                _LOGGER.info("Drying log created for plant %s at %s", plant_id, dry_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write drying log for plant %s: %s", plant_id, e)
-    
-    # Handle curing_log.json
-    cur_existed = os.path.isfile(cur_file)
-    if cur_existed and not overwrite:
-        entry_count = None
-        try:
-            with open(cur_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-            if isinstance(existing_data, list):
-                entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Could not read existing curing log at %s to count entries: %s", cur_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Curing log file already exists at %s with %d entries; skipping (overwrite=False).", cur_file, entry_count)
-        else:
-            _LOGGER.info("Curing log file already exists at %s; skipping (overwrite=False).", cur_file)
-    else:
-        prev_count = None
-        if cur_existed:
-            try:
-                with open(cur_file, "r", encoding="utf-8") as f:
-                    existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    prev_count = len(existing_data)
-            except Exception as e:
-                _LOGGER.warning("Could not read existing curing log at %s to count entries before overwrite: %s", cur_file, e)
-        try:
-            with open(cur_file, "w", encoding="utf-8") as f:
-                json.dump(curing_data, f, indent=2)
-            if cur_existed:
-                if prev_count is not None:
-                    _LOGGER.info("Curing log for plant %s at %s overwritten (previous entries: %d).", plant_id, cur_file, prev_count)
-                else:
-                    _LOGGER.info("Curing log for plant %s at %s overwritten.", plant_id, cur_file)
-            else:
-                _LOGGER.info("Curing log created for plant %s at %s", plant_id, cur_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write curing log for plant %s: %s", plant_id, e)
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create drying and curing log files for ``plant_id``."""
+    profile_sections = {
+        "drying_log.json": [],
+        "curing_log.json": [],
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_recipe_vpd_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_recipe_vpd_writer.py
@@ -1,75 +1,13 @@
-import os
-import json
 import logging
-from pathlib import Path
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def initialize_recipe_vpd_logs(plant_id: str, base_path: str = None, overwrite: bool = False) -> bool:
-    """
-    Initialize recipe audit and VPD adjustment log files for a given plant profile.
-    
-    This creates two JSON log files under plants/<plant_id>/ if they do not exist (or if overwrite is True):
-      - recipe_audit_log.json: an empty list; each entry includes keys like 
-        "timestamp", "changed_by", "version_number", "previous_settings", "new_settings", "justification",
-        "confirmed_by", "approval_status", and "notes".
-      - vpd_adjustment_log.json: an empty list; each entry includes keys like 
-        "timestamp", "observed_vpd", "target_vpd", "action_taken" (e.g., "humidify", "dehumidify", "cool", "heat"),
-        "success_flag", "sensor_source", and "notes".
-    
-    If files already exist and overwrite is False, they are left untouched.
-    If overwrite is True, existing files are cleared (overwritten with an empty list structure).
-    
-    Logs file creations, skips (with entry count if applicable), and any errors encountered.
-    
-    :param plant_id: Identifier of the plant (also directory name under base path).
-    :param base_path: Base directory containing plant profile folders (defaults to "plants/" in current working directory).
-    :param overwrite: If True, overwrite existing log files; if False, skip creating files that already exist.
-    :return: True if operation succeeded (or files skipped) without errors, False if an error occurred.
-    """
-    # Determine base directory for plant logs
-    if base_path:
-        base_dir = Path(base_path)
-    else:
-        base_dir = Path("plants")
-    plant_dir = base_dir / str(plant_id)
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return False
-    
-    log_files = ["recipe_audit_log.json", "vpd_adjustment_log.json"]
-    success = True
-    for filename in log_files:
-        file_path = plant_dir / filename
-        if file_path.exists() and not overwrite:
-            # Skip creation if file already exists and not overwriting
-            entry_count = None
-            try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    if isinstance(data, list):
-                        entry_count = len(data)
-            except Exception as e:
-                _LOGGER.warning("Could not read %s to count entries: %s", file_path, e)
-            if entry_count is not None:
-                _LOGGER.info("File %s already exists with %d entries. Skipping creation.", file_path, entry_count)
-            else:
-                _LOGGER.info("File %s already exists. Skipping creation.", file_path)
-            continue
-        
-        # Create or overwrite the file with an empty list
-        existed_before = file_path.exists()
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump([], f, indent=2)
-            if existed_before and overwrite:
-                _LOGGER.info("Overwrote existing file: %s", file_path)
-            else:
-                _LOGGER.info("Created file: %s", file_path)
-        except Exception as e:
-            _LOGGER.error("Failed to write %s: %s", file_path, e)
-            success = False
-    return success
+
+def initialize_recipe_vpd_logs(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> bool:
+    """Create recipe audit and VPD adjustment logs for ``plant_id``."""
+    profile_sections = {
+        "recipe_audit_log.json": [],
+        "vpd_adjustment_log.json": [],
+    }
+    return bool(write_profile_sections(plant_id, profile_sections, base_path, overwrite))

--- a/custom_components/horticulture_assistant/utils/profile_regulatory_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_regulatory_writer.py
@@ -1,73 +1,30 @@
-# File: custom_components/horticulture_assistant/utils/profile_regulatory_writer.py
-
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """Create regulatory.json and export_profile.json for a given plant's profile directory.
-    
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "regulatory.json" and "export_profile.json".
-    Each file contains preset fields relevant to plant regulatory compliance and export profiles, initialized to null values.
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default structure.
-    Logs messages for each created file, any skipped creations, and any errors encountered.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-    
-    # Define default structures for regulatory and export profile
-    regulatory_data = {
-        "propagation_laws": None,
-        "local_restrictions": None,
-        "state_restrictions": None,
-        "national_restrictions": None,
-        "seed_labeling_requirements": None,
-        "intellectual_property_claims": None,
-        "banned_substances": None,
-        "ethical_sourcing": None
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create regulatory and export profile files for ``plant_id``."""
+    profile_sections = {
+        "regulatory.json": {
+            "propagation_laws": None,
+            "local_restrictions": None,
+            "state_restrictions": None,
+            "national_restrictions": None,
+            "seed_labeling_requirements": None,
+            "intellectual_property_claims": None,
+            "banned_substances": None,
+            "ethical_sourcing": None,
+        },
+        "export_profile.json": {
+            "exportable_forms": None,
+            "phytosanitary_certificates": None,
+            "fumigation_status": None,
+            "customs_codes": None,
+            "known_trade_restrictions": None,
+            "preferred_international_markets": None,
+            "country_specific_demand": None,
+        },
     }
-    export_profile_data = {
-        "exportable_forms": None,
-        "phytosanitary_certificates": None,
-        "fumigation_status": None,
-        "customs_codes": None,
-        "known_trade_restrictions": None,
-        "preferred_international_markets": None,
-        "country_specific_demand": None
-    }
-    
-    # File paths
-    reg_file = os.path.join(plant_dir, "regulatory.json")
-    export_file = os.path.join(plant_dir, "export_profile.json")
-    
-    # Write or skip regulatory.json
-    if not overwrite and os.path.isfile(reg_file):
-        _LOGGER.info("Regulatory file already exists at %s; skipping (overwrite=False).", reg_file)
-    else:
-        try:
-            with open(reg_file, "w", encoding="utf-8") as f:
-                json.dump(regulatory_data, f, indent=2)
-            _LOGGER.info("Regulatory profile created for plant %s at %s", plant_id, reg_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write regulatory profile for plant %s: %s", plant_id, e)
-    
-    # Write or skip export_profile.json
-    if not overwrite and os.path.isfile(export_file):
-        _LOGGER.info("Export profile file already exists at %s; skipping (overwrite=False).", export_file)
-    else:
-        try:
-            with open(export_file, "w", encoding="utf-8") as f:
-                json.dump(export_profile_data, f, indent=2)
-            _LOGGER.info("Export profile created for plant %s at %s", plant_id, export_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write export profile for plant %s: %s", plant_id, e)
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_sensor_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_sensor_log_writer.py
@@ -1,90 +1,13 @@
-# File: custom_components/horticulture_assistant/utils/profile_sensor_log_writer.py
-
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """Create sensor_reading_log.json and alert_event_log.json for a given plant's profile directory.
-    
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "sensor_reading_log.json" and "alert_event_log.json".
-    The sensor_reading_log.json file is initialized as an empty list intended to hold sensor reading entries.
-    Each sensor reading entry will be a dictionary with fields such as "timestamp", "sensor_type", "value", 
-    "unit", "source", "zone", and "notes". The alert_event_log.json file is initialized as an empty list 
-    intended to hold alert event entries. Each alert event entry will be a dictionary with fields such as 
-    "timestamp", "alert_type", "trigger_condition", "sensor_source", "resolved", "resolution_timestamp", 
-    "user_acknowledged", and "notes".
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default structure (empty list).
-    Logs messages for each created file, any skipped creations (including current entry count if applicable), 
-    and any overwrite or error events encountered.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-    
-    # Default log structures (empty lists for log files)
-    sensor_readings = []  # list for sensor reading log entries
-    alert_events = []     # list for alert event log entries
-    
-    # File paths
-    reading_log_file = os.path.join(plant_dir, "sensor_reading_log.json")
-    alert_log_file = os.path.join(plant_dir, "alert_event_log.json")
-    
-    # Write or skip sensor_reading_log.json
-    if not overwrite and os.path.isfile(reading_log_file):
-        # File exists and not overwriting: log skip and current entry count
-        entry_count = None
-        try:
-            with open(reading_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing sensor reading log at %s for counting entries: %s", reading_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Sensor reading log already exists at %s with %d entries; skipping (overwrite=False).", reading_log_file, entry_count)
-        else:
-            _LOGGER.info("Sensor reading log already exists at %s; skipping (overwrite=False).", reading_log_file)
-    else:
-        if overwrite and os.path.isfile(reading_log_file):
-            _LOGGER.info("Existing sensor reading log at %s will be overwritten.", reading_log_file)
-        try:
-            with open(reading_log_file, "w", encoding="utf-8") as f:
-                json.dump(sensor_readings, f, indent=2)
-            _LOGGER.info("Sensor reading log created for plant %s at %s", plant_id, reading_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write sensor reading log for plant %s: %s", plant_id, e)
-    
-    # Write or skip alert_event_log.json
-    if not overwrite and os.path.isfile(alert_log_file):
-        # File exists and not overwriting: log skip and current entry count
-        entry_count = None
-        try:
-            with open(alert_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing alert event log at %s for counting entries: %s", alert_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Alert event log already exists at %s with %d entries; skipping (overwrite=False).", alert_log_file, entry_count)
-        else:
-            _LOGGER.info("Alert event log already exists at %s; skipping (overwrite=False).", alert_log_file)
-    else:
-        if overwrite and os.path.isfile(alert_log_file):
-            _LOGGER.info("Existing alert event log at %s will be overwritten.", alert_log_file)
-        try:
-            with open(alert_log_file, "w", encoding="utf-8") as f:
-                json.dump(alert_events, f, indent=2)
-            _LOGGER.info("Alert event log created for plant %s at %s", plant_id, alert_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write alert event log for plant %s: %s", plant_id, e)
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create sensor reading and alert event logs for ``plant_id``."""
+    profile_sections = {
+        "sensor_reading_log.json": [],
+        "alert_event_log.json": [],
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_solution_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_solution_log_writer.py
@@ -1,81 +1,13 @@
-import os
-import json
 import logging
-from pathlib import Path
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def initialize_solution_logs(plant_id: str, base_path: str = None, overwrite: bool = False) -> bool:
-    """
-    Initialize pH adjustment and recipe revision log files for a given plant profile.
-    
-    This function scaffolds two JSON files (`ph_adjustment_log.json` and `recipe_revision_log.json`)
-    in the `plants/<plant_id>/` directory. These files are initialized as empty lists, intended to hold log entries.
-    
-    Each entry in `ph_adjustment_log.json` should be a dictionary with keys like:
-    "timestamp", "solution_type", "starting_pH", "adjusted_pH", "agent_used", "amount_applied_ml", "reason", "person_responsible", "notes".
-    Each entry in `recipe_revision_log.json` should be a dictionary with keys like:
-    "timestamp", "previous_formula", "new_formula", "reason_for_change", "impacted_zones", "user_confirmed", "notes".
-    
-    If a file already exists and `overwrite` is False, the file is left unchanged.
-    If `overwrite` is True or the file is missing, a new file is created (or an existing file overwritten) with an empty list.
-    
-    If an existing file is not overwritten and contains a list, the length of the list (number of entries) is logged.
-    
-    All actions (creation, skipping, overwriting) are logged.
-    
-    :param plant_id: Identifier for the plant (used as directory name under the base path).
-    :param base_path: Optional base directory path for plant profiles (defaults to "plants/" in the current working directory).
-    :param overwrite: If True, overwrite existing log files; if False, skip writing if files already exist.
-    :return: True if log files were successfully created or already existed (skipped) without errors, False if an error occurred (e.g., directory creation or file write failure).
-    """
-    # Determine base directory for plant profiles
-    if base_path:
-        base_dir = Path(base_path)
-    else:
-        base_dir = Path("plants")
-    plant_dir = base_dir / str(plant_id)
-    
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return False
-    
-    # List of log files to create
-    log_files = ["ph_adjustment_log.json", "recipe_revision_log.json"]
-    success = True
-    # Iterate through each log file and create or skip as needed
-    for filename in log_files:
-        file_path = plant_dir / filename
-        if file_path.exists() and not overwrite:
-            # Skip creation if file already exists and not overwriting
-            entry_count = None
-            try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    if isinstance(data, list):
-                        entry_count = len(data)
-            except Exception as e:
-                _LOGGER.warning("Could not read %s to count entries: %s", file_path, e)
-            if entry_count is not None:
-                _LOGGER.info("File %s already exists with %d entries. Skipping creation.", file_path, entry_count)
-            else:
-                _LOGGER.info("File %s already exists. Skipping creation.", file_path)
-            continue
-        # Create or overwrite the file with an empty list
-        existed_before = file_path.exists()
-        try:
-            with open(file_path, "w", encoding="utf-8") as f:
-                json.dump([], f, indent=2)
-            if existed_before and overwrite:
-                _LOGGER.info("Overwrote existing file: %s", file_path)
-            else:
-                _LOGGER.info("Created file: %s", file_path)
-        except Exception as e:
-            _LOGGER.error("Failed to write %s: %s", file_path, e)
-            success = False
-    if success:
-        _LOGGER.info("pH adjustment and recipe revision logs prepared for '%s' at %s", plant_id, plant_dir)
-    return success
+
+def initialize_solution_logs(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> bool:
+    """Create pH adjustment and recipe revision logs for ``plant_id``."""
+    profile_sections = {
+        "ph_adjustment_log.json": [],
+        "recipe_revision_log.json": [],
+    }
+    return bool(write_profile_sections(plant_id, profile_sections, base_path, overwrite))

--- a/custom_components/horticulture_assistant/utils/profile_storage_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_storage_writer.py
@@ -1,85 +1,33 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """
-    Create storage.json and processing.json for a given plant's profile directory.
 
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "storage.json" and "processing.json".
-    Each file contains preset fields relevant to post-harvest storage and processing, initialized to null values.
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default structure.
-    Logs messages for each created file, any skipped creations, and any errors encountered.
-
-    :param plant_id: Identifier for the plant (used as directory name under base_path).
-    :param base_path: Base directory for plant profiles (defaults to "plants" in current working directory).
-    :param overwrite: If True, overwrite existing files; if False, skip writing files that already exist.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s: %s", plant_dir, e)
-        return
-
-    # Define default structure for storage and processing profiles
-    storage_data = {
-        "shelf_life": None,
-        "spoilage_conditions": None,
-        "packaging_type": None,
-        "storage_environment": {
-            "temperature": None,
-            "relative_humidity": None,
-            "airflow": None,
-            "darkness": None
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create storage and processing profile files for ``plant_id``."""
+    profile_sections = {
+        "storage.json": {
+            "shelf_life": None,
+            "spoilage_conditions": None,
+            "packaging_type": None,
+            "storage_environment": {
+                "temperature": None,
+                "relative_humidity": None,
+                "airflow": None,
+                "darkness": None,
+            },
+            "stability_notes": None,
+            "post_storage_QA": None,
         },
-        "stability_notes": None,
-        "post_storage_QA": None
+        "processing.json": {
+            "postharvest_steps": None,
+            "critical_control_points": None,
+            "residue_breakdown": None,
+            "transformation_compounds": None,
+            "value_added_processing_options": None,
+            "food_grade_standards": None,
+            "pharmaceutical_standards": None,
+        },
     }
-    processing_data = {
-        "postharvest_steps": None,
-        "critical_control_points": None,
-        "residue_breakdown": None,
-        "transformation_compounds": None,
-        "value_added_processing_options": None,
-        "food_grade_standards": None,
-        "pharmaceutical_standards": None
-    }
-
-    # File paths for the new profile files
-    storage_file = os.path.join(plant_dir, "storage.json")
-    processing_file = os.path.join(plant_dir, "processing.json")
-
-    # Write or skip storage.json
-    if os.path.exists(storage_file) and not overwrite:
-        _LOGGER.info("storage.json already exists for plant '%s'; skipping (overwrite=False).", plant_id)
-    else:
-        try:
-            with open(storage_file, "w", encoding="utf-8") as f:
-                json.dump(storage_data, f, indent=2)
-            if os.path.exists(storage_file) and overwrite:
-                _LOGGER.info("Overwrote existing storage.json for plant '%s'.", plant_id)
-            else:
-                _LOGGER.info("Created storage.json for plant '%s'.", plant_id)
-        except Exception as e:
-            _LOGGER.error("Failed to write storage.json for plant '%s': %s", plant_id, e)
-
-    # Write or skip processing.json
-    if os.path.exists(processing_file) and not overwrite:
-        _LOGGER.info("processing.json already exists for plant '%s'; skipping (overwrite=False).", plant_id)
-    else:
-        try:
-            with open(processing_file, "w", encoding="utf-8") as f:
-                json.dump(processing_data, f, indent=2)
-            if os.path.exists(processing_file) and overwrite:
-                _LOGGER.info("Overwrote existing processing.json for plant '%s'.", plant_id)
-            else:
-                _LOGGER.info("Created processing.json for plant '%s'.", plant_id)
-        except Exception as e:
-            _LOGGER.error("Failed to write processing.json for plant '%s': %s", plant_id, e)
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_visual_stress_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_visual_stress_writer.py
@@ -1,89 +1,13 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """Create visual inspection and stress response log files for a given plant's profile directory.
-    
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "visual_inspection_log.json" and "stress_response_log.json".
-    The visual_inspection_log.json file is initialized as an empty list intended to hold visual inspection entries.
-    Each visual inspection entry is a dictionary with fields such as "timestamp", "inspector_name", "observation_area"
-    (e.g., "canopy", "root zone", "media surface"), "health_status" (visual assessment), "anomalies_detected",
-    "photographic_reference" (URL or path), and "notes". The stress_response_log.json file is initialized as an 
-    empty list intended to hold stress response entries. Each stress response entry includes fields like "timestamp",
-    "stressor_type" (e.g., "light", "heat", "cold", "pest", "nutrient"), "affected_parts", "visible_symptoms",
-    "severity_score" (1–5 scale), "recovery_observed", and "notes".
-    
-    If a file already exists and overwrite is False, the file is left unchanged.
-    Set overwrite=True to replace any existing files with the default (empty list) structure.
-    Logs messages for each created file, any skipped creations (with entry count if available), and any overwrite or error events.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-    
-    # Default log structures (empty lists for log files)
-    visual_data = []    # list for visual inspection log entries
-    stress_data = []    # list for stress response log entries
-    
-    # File paths
-    visual_log_file = os.path.join(plant_dir, "visual_inspection_log.json")
-    stress_log_file = os.path.join(plant_dir, "stress_response_log.json")
-    
-    # Write or skip visual_inspection_log.json
-    if not overwrite and os.path.isfile(visual_log_file):
-        # File exists and not overwriting: log skip and current entry count if possible
-        entry_count = None
-        try:
-            with open(visual_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing visual inspection log at %s for counting entries: %s", visual_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Visual inspection log already exists at %s with %d entries; skipping (overwrite=False).", visual_log_file, entry_count)
-        else:
-            _LOGGER.info("Visual inspection log already exists at %s; skipping (overwrite=False).", visual_log_file)
-    else:
-        if overwrite and os.path.isfile(visual_log_file):
-            _LOGGER.info("Existing visual inspection log at %s will be overwritten.", visual_log_file)
-        try:
-            with open(visual_log_file, "w", encoding="utf-8") as f:
-                json.dump(visual_data, f, indent=2)
-            _LOGGER.info("Visual inspection log created for plant %s at %s", plant_id, visual_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write visual inspection log for plant %s: %s", plant_id, e)
-    
-    # Write or skip stress_response_log.json
-    if not overwrite and os.path.isfile(stress_log_file):
-        # File exists and not overwriting: log skip and current entry count if possible
-        entry_count = None
-        try:
-            with open(stress_log_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-                if isinstance(existing_data, list):
-                    entry_count = len(existing_data)
-        except Exception as e:
-            _LOGGER.warning("Failed to read existing stress response log at %s for counting entries: %s", stress_log_file, e)
-        if entry_count is not None:
-            _LOGGER.info("Stress response log already exists at %s with %d entries; skipping (overwrite=False).", stress_log_file, entry_count)
-        else:
-            _LOGGER.info("Stress response log already exists at %s; skipping (overwrite=False).", stress_log_file)
-    else:
-        if overwrite and os.path.isfile(stress_log_file):
-            _LOGGER.info("Existing stress response log at %s will be overwritten.", stress_log_file)
-        try:
-            with open(stress_log_file, "w", encoding="utf-8") as f:
-                json.dump(stress_data, f, indent=2)
-            _LOGGER.info("Stress response log created for plant %s at %s", plant_id, stress_log_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write stress response log for plant %s: %s", plant_id, e)
+
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create visual inspection and stress response logs for ``plant_id``."""
+    profile_sections = {
+        "visual_inspection_log.json": [],
+        "stress_response_log.json": [],
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)

--- a/custom_components/horticulture_assistant/utils/profile_yield_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_yield_log_writer.py
@@ -1,69 +1,13 @@
 import logging
-import json
-import os
+from .profile_helpers import write_profile_sections
 
 _LOGGER = logging.getLogger(__name__)
 
-def scaffold_profile_files(plant_id: str, base_path: str = None, overwrite: bool = False) -> None:
-    """
-    Create yield tracking and harvest weight log files for a given plant's profile directory.
 
-    This scaffolds a directory under the base_path (defaults to "plants") named after the plant_id,
-    and creates two JSON files within it: "yield_tracking_log.json" and "harvest_weight_log.json".
-    Each file is initialized as an empty list. If a file already exists and overwrite is False,
-    the file is left unchanged (with a log message including the existing entry count).
-    Set overwrite=True to replace any existing files with the default (empty list) structure.
-    Logs messages for each created file, any skipped creations (with entry count), and any errors encountered.
-    """
-    base_dir = base_path or "plants"
-    plant_dir = os.path.join(base_dir, str(plant_id))
-    # Ensure the plant directory exists
-    try:
-        os.makedirs(plant_dir, exist_ok=True)
-    except Exception as e:
-        _LOGGER.error("Failed to create directory %s for plant profile: %s", plant_dir, e)
-        return
-
-    # Default empty structures for yield tracking and harvest weight logs
-    yield_data = []
-    harvest_data = []
-
-    # File paths
-    yield_file = os.path.join(plant_dir, "yield_tracking_log.json")
-    weight_file = os.path.join(plant_dir, "harvest_weight_log.json")
-
-    # Write or skip yield_tracking_log.json
-    if not overwrite and os.path.isfile(yield_file):
-        try:
-            with open(yield_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-            entry_count = len(existing_data) if isinstance(existing_data, list) else 0
-        except Exception as e:
-            _LOGGER.error("Failed to read existing yield tracking log for plant %s at %s: %s", plant_id, yield_file, e)
-            entry_count = 0
-        _LOGGER.info("Yield tracking log already exists at %s with %d entries; skipping (overwrite=False).", yield_file, entry_count)
-    else:
-        try:
-            with open(yield_file, "w", encoding="utf-8") as f:
-                json.dump(yield_data, f, indent=2)
-            _LOGGER.info("Yield tracking log created for plant %s at %s", plant_id, yield_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write yield tracking log for plant %s: %s", plant_id, e)
-
-    # Write or skip harvest_weight_log.json
-    if not overwrite and os.path.isfile(weight_file):
-        try:
-            with open(weight_file, "r", encoding="utf-8") as f:
-                existing_data = json.load(f)
-            entry_count = len(existing_data) if isinstance(existing_data, list) else 0
-        except Exception as e:
-            _LOGGER.error("Failed to read existing harvest weight log for plant %s at %s: %s", plant_id, weight_file, e)
-            entry_count = 0
-        _LOGGER.info("Harvest weight log already exists at %s with %d entries; skipping (overwrite=False).", weight_file, entry_count)
-    else:
-        try:
-            with open(weight_file, "w", encoding="utf-8") as f:
-                json.dump(harvest_data, f, indent=2)
-            _LOGGER.info("Harvest weight log created for plant %s at %s", plant_id, weight_file)
-        except Exception as e:
-            _LOGGER.error("Failed to write harvest weight log for plant %s: %s", plant_id, e)
+def scaffold_profile_files(plant_id: str, base_path: str | None = None, overwrite: bool = False) -> str:
+    """Create yield tracking and harvest weight logs for ``plant_id``."""
+    profile_sections = {
+        "yield_tracking_log.json": [],
+        "harvest_weight_log.json": [],
+    }
+    return write_profile_sections(plant_id, profile_sections, base_path, overwrite)


### PR DESCRIPTION
## Summary
- centralize JSON writing in `write_profile_sections`
- replace large writer modules with thin wrappers around the helper
- keep index writer as-is

## Testing
- `python -m py_compile $(git status --short | awk '{print $2}' | tr '\n' ' ')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688132263670833096496d43b354cd6b