### PR TITLE
Add fertigation cost reporting to daily cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Comprehensive Fertigation**: `recommend_precise_fertigation` adjusts for
   existing water nutrient levels, can include micronutrients, and returns cost
   estimates along with any water quality warnings.
+- **Fertigation Cost Reporting**: `run_daily_cycle` writes the estimated cost of
+  its generated `fertigation_schedule` under the `fertigation_cost` field.
 - **Nutrient Profile Analysis**: `analyze_nutrient_profile` combines macro and
   micro guidelines with interaction checks to summarize deficiencies and
   surpluses at once.

--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -30,4 +30,5 @@ def test_run_daily_cycle_extended(tmp_path):
     assert report["predicted_harvest_date"] == "2025-05-01"
     assert "environment_optimization" in report
     assert "fertigation_schedule" in report
+    assert "fertigation_cost" in report
     assert (out_dir / f"sample_{report['timestamp'][:10]}.json").exists()


### PR DESCRIPTION
## Summary
- report cost of fertigation schedule in daily cycle
- handle missing fertilizer pricing gracefully
- update tests for the new `fertigation_cost` field
- document fertigation cost reporting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813250a4588330963eca093e2dd950