### PR TITLE
Add configurable stage multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Key reference datasets reside in the `data/` directory:
 - `nutrient_toxicity_treatments.json` – suggested mitigation steps for toxicity
 - `growth_medium_ph_ranges.json` – preferred pH ranges for soil, coco and hydroponics
 - `growth_stages.json` – lifecycle stage durations and notes by crop
+- `stage_multipliers.json` – default nutrient scaling factors by stage
 - `pruning_guidelines.json` – stage-specific pruning recommendations
 - `pruning_intervals.json` – days between recommended pruning events
 - `soil_texture_parameters.json` – default field capacity and MAD values by soil texture

--- a/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
@@ -16,7 +16,7 @@ except ImportError:
 from custom_components.horticulture_assistant.utils.plant_profile_loader import load_profile
 from plant_engine.nutrient_manager import get_recommended_levels
 from plant_engine.utils import load_json, save_json, load_dataset
-from plant_engine.constants import STAGE_MULTIPLIERS
+from plant_engine.constants import get_stage_multiplier
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ def _stage_multiplier(profile: dict, stage_key: str) -> float:
                         mult = 1.0
                     break
     if mult == 1.0:
-        mult = STAGE_MULTIPLIERS.get(stage_key, 1.0)
+        mult = get_stage_multiplier(stage_key)
     return mult
 
 

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -14,6 +14,7 @@
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",
+  "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",
   "light_dli_guidelines.json": "Daily Light Integral targets for growth stages.",
   "vpd_guidelines.json": "Vapor pressure deficit targets for growth stages.",
   "photoperiod_guidelines.json": "Recommended photoperiod ranges for growth stages.",

--- a/data/stage_multipliers.json
+++ b/data/stage_multipliers.json
@@ -1,0 +1,6 @@
+{
+  "seedling": 0.5,
+  "vegetative": 1.0,
+  "flowering": 1.2,
+  "fruiting": 1.1
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -130,7 +130,7 @@ from .yield_prediction import (
     get_estimated_yield,
     estimate_remaining_yield,
 )
-from .constants import STAGE_MULTIPLIERS, DEFAULT_ENV
+from .constants import get_stage_multiplier, STAGE_MULTIPLIERS, DEFAULT_ENV
 from .pruning_manager import (
     list_supported_plants as list_pruning_plants,
     list_stages as list_pruning_stages,
@@ -325,5 +325,6 @@ __all__ = [
     "load_profile",
     "TranspirationMetrics",
     "STAGE_MULTIPLIERS",
+    "get_stage_multiplier",
     "DEFAULT_ENV",
 ]

--- a/plant_engine/constants.py
+++ b/plant_engine/constants.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
-# Multipliers used to scale nutrient recommendations based on lifecycle stage.
-STAGE_MULTIPLIERS: dict[str, float] = {
+from .utils import load_dataset, normalize_key
+
+_MULTIPLIER_FILE = "stage_multipliers.json"
+_DEFAULT_MULTIPLIERS: dict[str, float] = {
     "seedling": 0.5,
     "vegetative": 1.0,
     "flowering": 1.2,
     "fruiting": 1.1,
 }
+
+try:
+    STAGE_MULTIPLIERS: dict[str, float] = (
+        load_dataset(_MULTIPLIER_FILE) or _DEFAULT_MULTIPLIERS
+    )
+except Exception:  # pragma: no cover - dataset loading should succeed
+    STAGE_MULTIPLIERS = _DEFAULT_MULTIPLIERS
+
+def get_stage_multiplier(stage: str) -> float:
+    """Return nutrient multiplier for ``stage`` with fallback to ``1.0``."""
+
+    return float(STAGE_MULTIPLIERS.get(normalize_key(stage), 1.0))
 
 # Default environment readings applied when a plant profile lacks recent data.
 DEFAULT_ENV: dict[str, float] = {
@@ -19,3 +33,5 @@ DEFAULT_ENV: dict[str, float] = {
     "par_w_m2": 350,
     "wind_speed_m_s": 1.2,
 }
+
+__all__ = ["STAGE_MULTIPLIERS", "get_stage_multiplier", "DEFAULT_ENV"]

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -32,7 +32,7 @@ from plant_engine.disease_manager import (
 )
 from plant_engine.growth_stage import get_stage_info
 from plant_engine.report import DailyReport
-from plant_engine.constants import STAGE_MULTIPLIERS, DEFAULT_ENV
+from plant_engine.constants import get_stage_multiplier, DEFAULT_ENV
 
 PLANTS_DIR = "plants"
 OUTPUT_DIR = "data/reports"
@@ -126,8 +126,8 @@ def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
         profile.get("stage", "")
     )
 
-    stage_name = str(profile.get("stage", "")).lower()
-    stage_mult = STAGE_MULTIPLIERS.get(stage_name, 1.0)
+    stage_name = str(profile.get("stage", ""))
+    stage_mult = get_stage_multiplier(stage_name)
     nutrient_targets = {
         n: round(v * stage_mult, 2) for n, v in guidelines.items()
     } if guidelines else {}

--- a/tests/test_stage_multipliers.py
+++ b/tests/test_stage_multipliers.py
@@ -1,0 +1,21 @@
+import importlib
+import json
+
+from plant_engine import constants
+
+
+def test_get_stage_multiplier_default():
+    assert constants.get_stage_multiplier("fruiting") == 1.1
+
+
+def test_get_stage_multiplier_overlay(tmp_path, monkeypatch):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "stage_multipliers.json").write_text(json.dumps({"fruiting": 1.5}))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+    importlib.reload(constants)
+    try:
+        assert constants.get_stage_multiplier("fruiting") == 1.5
+    finally:
+        monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR", raising=False)
+        importlib.reload(constants)


### PR DESCRIPTION
## Summary
- add new `stage_multipliers.json` dataset and document it
- load stage multipliers from dataset in `constants` with helper
- use `get_stage_multiplier` in nutrient scheduler and engine
- update dataset catalog and README
- add tests for configurable stage multipliers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813263dff483309a6dbc498e400a5d