### PR TITLE
Enhance env manager with soil moisture targets

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -63,6 +63,7 @@
   "soil_nutrient_guidelines.json": "Target soil nutrient levels by crop.",
   "soil_texture_parameters.json": "Typical sand, silt and clay percentages.",
   "soil_infiltration_rates.json": "Infiltration rates (mm/hr) by soil texture.",
+  "soil_moisture_guidelines.json": "Recommended soil moisture percentages for common crops.",
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",

--- a/data/soil_moisture_guidelines.json
+++ b/data/soil_moisture_guidelines.json
@@ -1,0 +1,17 @@
+{
+  "citrus": {
+    "seedling": [30, 50],
+    "fruiting": [25, 40],
+    "optimal": [30, 50]
+  },
+  "lettuce": {
+    "seedling": [40, 60],
+    "harvest": [40, 60],
+    "optimal": [40, 60]
+  },
+  "tomato": {
+    "seedling": [60, 80],
+    "fruiting": [50, 70],
+    "optimal": [60, 80]
+  }
+}

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -5,6 +5,7 @@ def test_list_datasets_contains_known():
     datasets = list_datasets()
     assert "nutrient_guidelines.json" in datasets
     assert "irrigation_intervals.json" in datasets
+    assert "soil_moisture_guidelines.json" in datasets
     assert "dataset_catalog.json" not in datasets
 
 
@@ -28,3 +29,6 @@ def test_get_dataset_description():
 
     desc5 = get_dataset_description("wsda_fertilizer_database.json")
     assert "WSDA" in desc5
+
+    desc6 = get_dataset_description("soil_moisture_guidelines.json")
+    assert "moisture" in desc6

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -563,14 +563,14 @@ def test_optimize_environment_humidity_stress():
 
 
 def test_evaluate_stress_conditions():
-    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, "lettuce", "seedling")
+    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling")
     assert stress.heat is True
     assert stress.cold is False
     assert stress.light == "low"
     assert stress.wind is True
     assert stress.humidity is None
 
-    stress_none = evaluate_stress_conditions(None, None, None, None, None, "citrus")
+    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, "citrus")
     assert stress_none.heat is None
     assert stress_none.humidity is None
 

--- a/tests/test_soil_moisture_guidelines.py
+++ b/tests/test_soil_moisture_guidelines.py
@@ -1,0 +1,15 @@
+from plant_engine.environment_manager import (
+    get_target_soil_moisture,
+    evaluate_moisture_stress,
+)
+
+
+def test_get_target_soil_moisture():
+    assert get_target_soil_moisture("citrus", "seedling") == (30, 50)
+    assert get_target_soil_moisture("unknown") is None
+
+
+def test_evaluate_moisture_stress():
+    assert evaluate_moisture_stress(20, "citrus", "seedling") == "dry"
+    assert evaluate_moisture_stress(55, "citrus", "seedling") == "wet"
+    assert evaluate_moisture_stress(40, "citrus", "seedling") is None


### PR DESCRIPTION
## Summary
- integrate new soil_moisture_guidelines dataset
- extend environment manager with soil moisture helpers
- include moisture stress in optimization utilities
- update dataset catalog
- broaden tests for new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881325b743c8330a1660bb977ec1ee9