### PR TITLE
Add monitoring schedule utilities

### DIFF
--- a/plant_engine/disease_monitor.py
+++ b/plant_engine/disease_monitor.py
@@ -24,6 +24,7 @@ __all__ = [
     "recommend_threshold_actions",
     "get_monitoring_interval",
     "next_monitor_date",
+    "generate_monitoring_schedule",
     "generate_disease_report",
     "DiseaseReport",
 ]
@@ -104,6 +105,19 @@ def next_monitor_date(
     if interval is None:
         return None
     return last_date + timedelta(days=interval)
+
+
+def generate_monitoring_schedule(
+    plant_type: str,
+    stage: str | None,
+    start: date,
+    events: int,
+) -> list[date]:
+    """Return list of upcoming disease monitoring dates."""
+    interval = get_monitoring_interval(plant_type, stage)
+    if interval is None or events <= 0:
+        return []
+    return [start + timedelta(days=interval * i) for i in range(1, events + 1)]
 
 
 @dataclass

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -35,6 +35,7 @@ __all__ = [
     "get_severity_action",
     "get_monitoring_interval",
     "next_monitor_date",
+    "generate_monitoring_schedule",
     "PestReport",
 ]
 
@@ -78,6 +79,22 @@ def next_monitor_date(
     if interval is None:
         return None
     return last_date + timedelta(days=interval)
+
+
+def generate_monitoring_schedule(
+    plant_type: str,
+    stage: str | None,
+    start: date,
+    events: int,
+) -> list[date]:
+    """Return list of upcoming monitoring dates.
+
+    If ``events`` is 0 or no interval is defined, an empty list is returned.
+    """
+    interval = get_monitoring_interval(plant_type, stage)
+    if interval is None or events <= 0:
+        return []
+    return [start + timedelta(days=interval * i) for i in range(1, events + 1)]
 
 
 def get_severity_action(level: str) -> str:

--- a/tests/test_disease_monitor.py
+++ b/tests/test_disease_monitor.py
@@ -7,6 +7,7 @@ from plant_engine.disease_monitor import (
     generate_disease_report,
     get_monitoring_interval,
     next_monitor_date,
+    generate_monitoring_schedule,
 )
 
 
@@ -55,3 +56,10 @@ def test_next_monitor_date():
     expected = date(2023, 1, 5)
     assert next_monitor_date("citrus", "fruiting", last) == expected
     assert next_monitor_date("unknown", None, last) is None
+
+
+def test_generate_monitoring_schedule():
+    start = date(2023, 1, 1)
+    sched = generate_monitoring_schedule("citrus", "fruiting", start, 2)
+    assert sched == [date(2023, 1, 5), date(2023, 1, 9)]
+    assert generate_monitoring_schedule("unknown", None, start, 1) == []

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -9,6 +9,7 @@ from plant_engine.pest_monitor import (
     generate_pest_report,
     get_monitoring_interval,
     next_monitor_date,
+    generate_monitoring_schedule,
 )
 
 
@@ -80,4 +81,11 @@ def test_next_monitor_date():
     expected = date(2023, 1, 4)
     assert next_monitor_date("tomato", "fruiting", last) == expected
     assert next_monitor_date("unknown", None, last) is None
+
+
+def test_generate_monitoring_schedule():
+    start = date(2023, 1, 1)
+    sched = generate_monitoring_schedule("tomato", "fruiting", start, 3)
+    assert sched == [date(2023, 1, 4), date(2023, 1, 7), date(2023, 1, 10)]
+    assert generate_monitoring_schedule("unknown", None, start, 2) == []
 


### PR DESCRIPTION
## Summary
- support generating pest monitoring dates
- support generating disease monitoring dates
- test new monitoring schedule helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881325822348330995a41cc11ff224c