### PR TITLE
Add nutrient-based product search utility

### DIFF
--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -348,6 +348,7 @@ __all__ = [
     "list_products",
     "get_product_info",
     "find_products",
+    "search_products_by_nutrient",
     "calculate_mix_ppm",
 ]
 
@@ -377,4 +378,26 @@ def find_products(term: str) -> list[str]:
         if term in pid.lower() or term in name:
             results.append(pid)
     return sorted(results)
+
+
+def search_products_by_nutrient(nutrient: str, min_pct: float = 0.0) -> list[str]:
+    """Return product IDs with at least ``min_pct`` of ``nutrient``.
+
+    Parameters
+    ----------
+    nutrient : str
+        Nutrient element symbol, e.g. ``"N"`` or ``"K"``.
+    min_pct : float, optional
+        Minimum guaranteed analysis percentage as a decimal fraction.
+    """
+
+    nutrient_key = nutrient.strip()
+    inventory = _inventory()
+    matches: list[str] = []
+    for pid, info in inventory.items():
+        ga = convert_guaranteed_analysis(info.guaranteed_analysis)
+        pct = ga.get(nutrient_key)
+        if pct is not None and pct >= min_pct:
+            matches.append(pid)
+    return sorted(matches, key=lambda pid: inventory[pid].product_name or pid)
 

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -26,6 +26,7 @@ calculate_mix_nutrients = fert_mod.calculate_mix_nutrients
 calculate_mix_ppm = fert_mod.calculate_mix_ppm
 calculate_mix_density = fert_mod.calculate_mix_density
 check_solubility_limits = fert_mod.check_solubility_limits
+search_products_by_nutrient = fert_mod.search_products_by_nutrient
 
 
 def test_convert_guaranteed_analysis():
@@ -168,4 +169,12 @@ def test_check_solubility_limits():
 
     with pytest.raises(ValueError):
         check_solubility_limits(schedule, 0)
+
+
+def test_search_products_by_nutrient():
+    results = search_products_by_nutrient("N", min_pct=0.05)
+    assert "foxfarm_grow_big" in results
+
+    # Should return empty list for unknown nutrient
+    assert search_products_by_nutrient("X") == []
 


### PR DESCRIPTION
## Summary
- search fertilizer inventory by guaranteed analysis
- test nutrient search helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881325f838483309c0766be87a514f3