### PR TITLE
Add nutrient removal calculation

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -124,6 +124,7 @@ from .yield_manager import (
     load_yield_history,
     record_harvest,
     get_total_yield,
+    get_total_nutrient_removal,
 )
 from .yield_prediction import (
     list_supported_plants as list_yield_plants,
@@ -288,6 +289,7 @@ __all__ = [
     "load_yield_history",
     "record_harvest",
     "get_total_yield",
+    "get_total_nutrient_removal",
     "list_yield_plants",
     "get_estimated_yield",
     "estimate_remaining_yield",

--- a/plant_engine/yield_manager.py
+++ b/plant_engine/yield_manager.py
@@ -6,6 +6,8 @@ from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict, List
 
+from . import nutrient_budget
+
 from .utils import load_json, save_json
 
 # Default yield directory. Can be overridden with the ``HORTICULTURE_YIELD_DIR``
@@ -69,9 +71,21 @@ def get_total_yield(plant_id: str) -> float:
     return sum(record.yield_grams for record in history)
 
 
+def get_total_nutrient_removal(plant_id: str, plant_type: str) -> nutrient_budget.RemovalEstimate:
+    """Return cumulative nutrient removal for ``plant_id``.
+
+    The function sums all recorded harvest weights and multiplies by the
+    per-kilogram removal rates defined in :data:`nutrient_removal_rates.json`.
+    """
+
+    total_yield_kg = get_total_yield(plant_id) / 1000
+    return nutrient_budget.estimate_total_removal(plant_type, total_yield_kg)
+
+
 __all__ = [
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",
     "get_total_yield",
+    "get_total_nutrient_removal",
 ]

--- a/tests/test_yield_manager.py
+++ b/tests/test_yield_manager.py
@@ -14,3 +14,17 @@ def test_record_and_total_yield(tmp_path):
 
     total = yield_manager.get_total_yield(plant_id)
     assert total == 180
+
+
+def test_get_total_nutrient_removal(tmp_path):
+    plant_id = 'removalplant'
+    yield_manager.YIELD_DIR = str(tmp_path)
+
+    yield_manager.record_harvest(plant_id, grams=1000, date='2025-01-01')
+
+    removal = yield_manager.get_total_nutrient_removal(plant_id, 'lettuce')
+    data = removal.as_dict()['nutrients_g']
+
+    assert data['N'] == 1.2
+    assert data['P'] == 0.2
+    assert data['K'] == 1.5


### PR DESCRIPTION
## Summary
- compute cumulative nutrient removal from yield logs
- export this helper via plant_engine package
- test nutrient removal logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d894b2c83309b3ad105f44555bb