### PR TITLE
Enhance dataset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ variable `HORTICULTURE_DATA_DIR` when running scripts or tests. An additional
 datasets without copying the entire directory. Overlay files are merged
 recursively so nested keys can be customized without redefining the entire
 structure.
+Multiple extra dataset directories can also be specified via
+`HORTICULTURE_EXTRA_DATA_DIRS` as a list separated by your OS path separator
+(``:`` on Linux/macOS, ``;`` on Windows). These paths are merged in the order
+provided before any overlay files.
 Call `plant_engine.utils.clear_dataset_cache()` if you modify these
 environment variables while the application is running so changes are
 immediately reflected.

--- a/tests/test_dataset_extra_dirs.py
+++ b/tests/test_dataset_extra_dirs.py
@@ -1,0 +1,52 @@
+import importlib
+import json
+import os
+
+import plant_engine.utils as utils
+
+
+def test_dataset_extra_dirs(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    extra1 = tmp_path / "extra1"
+    extra2 = tmp_path / "extra2"
+    base.mkdir()
+    extra1.mkdir()
+    extra2.mkdir()
+
+    (base / "sample.json").write_text(json.dumps({"a": 1}))
+    (extra1 / "sample.json").write_text(json.dumps({"b": 2}))
+    (extra2 / "sample.json").write_text(json.dumps({"b": 3, "c": 4}))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    dirs = os.pathsep.join([str(extra1), str(extra2)])
+    monkeypatch.setenv("HORTICULTURE_EXTRA_DATA_DIRS", dirs)
+
+    importlib.reload(utils)
+
+    result = utils.load_dataset("sample.json")
+    assert result == {"a": 1, "b": 3, "c": 4}
+
+
+
+
+def test_dataset_extra_dirs_with_overlay(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    extra = tmp_path / "extra"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    extra.mkdir()
+    overlay.mkdir()
+
+    (base / "sample.json").write_text(json.dumps({"val": 1}))
+    (extra / "sample.json").write_text(json.dumps({"val": 2}))
+    (overlay / "sample.json").write_text(json.dumps({"val": 3}))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    monkeypatch.setenv("HORTICULTURE_EXTRA_DATA_DIRS", str(extra))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+
+    importlib.reload(utils)
+
+    result = utils.load_dataset("sample.json")
+    assert result == {"val": 3}
+


### PR DESCRIPTION
## Summary
- allow specifying multiple extra data directories
- document new `HORTICULTURE_EXTRA_DATA_DIRS` env var
- test dataset merging across extra directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d111c2883309924e9b38d222829