### PR TITLE
Add environment quality sensor and threshold overrides

### DIFF
--- a/custom_components/horticulture_assistant/utils/load_plant_profile.py
+++ b/custom_components/horticulture_assistant/utils/load_plant_profile.py
@@ -1,5 +1,13 @@
-import logging
+"""Helper for loading multi-file plant profiles from disk.
+
+Each plant has its own directory under ``plants/`` containing JSON fragments
+describing the profile. This module aggregates those fragments into a single
+dictionary which other modules can consume. Validation-only files are skipped by
+default to speed up loading in production.
+"""
+
 import json
+import logging
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -603,14 +603,23 @@ def score_environment_series(
 
 
 def classify_environment_quality(
-    current: Mapping[str, float], plant_type: str, stage: str | None = None
+    current: Mapping[str, float],
+    plant_type: str,
+    stage: str | None = None,
+    thresholds: Mapping[str, float] | None = None,
 ) -> str:
-    """Return ``good``, ``fair`` or ``poor`` based on environment score."""
-    thresholds = get_environment_quality_thresholds()
+    """Return ``good``, ``fair`` or ``poor`` based on environment score.
+
+    The optional ``thresholds`` mapping can override the default values loaded
+    from :data:`environment_quality_thresholds.json` which enables customized
+    quality bands for specific deployments.
+    """
+
+    thresh = thresholds or get_environment_quality_thresholds()
     score = score_environment(current, plant_type, stage)
-    if score >= thresholds.get("good", 75):
+    if score >= thresh.get("good", 75):
         return "good"
-    if score >= thresholds.get("fair", 50):
+    if score >= thresh.get("fair", 50):
         return "fair"
     return "poor"
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -445,12 +445,13 @@ def test_classify_environment_quality():
     assert classify_environment_quality(poor, "citrus", "seedling") == "poor"
 
 
-def test_classify_environment_quality_custom(monkeypatch):
+def test_classify_environment_quality_custom():
     good = {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450}
-    from plant_engine import environment_manager as em
-    monkeypatch.setitem(em._QUALITY_THRESHOLDS, "good", 105)
-    monkeypatch.setitem(em._QUALITY_THRESHOLDS, "fair", 80)
-    assert classify_environment_quality(good, "citrus", "seedling") == "fair"
+    thresholds = {"good": 105, "fair": 80}
+    assert (
+        classify_environment_quality(good, "citrus", "seedling", thresholds)
+        == "fair"
+    )
 
 
 def test_normalize_environment_readings_aliases():

--- a/tests/test_environment_score_sensor.py
+++ b/tests/test_environment_score_sensor.py
@@ -59,6 +59,7 @@ sys.modules.setdefault("homeassistant.const", ha.const)
 
 spec.loader.exec_module(sensor)
 EnvironmentScoreSensor = sensor.EnvironmentScoreSensor
+EnvironmentQualitySensor = sensor.EnvironmentQualitySensor
 
 class DummyStates:
     def __init__(self):
@@ -84,3 +85,16 @@ def test_environment_score_sensor():
     }
     asyncio.run(sensor_entity.async_update())
     assert sensor_entity.native_value >= 90
+
+
+def test_environment_quality_sensor():
+    hass = DummyHass()
+    sensor_entity = EnvironmentQualitySensor(hass, "Plant", "pid")
+    hass.states._data = {
+        "sensor.pid_raw_temperature": "24",
+        "sensor.pid_raw_humidity": "60",
+        "sensor.pid_raw_light": "400",
+        "sensor.pid_raw_co2": "800",
+    }
+    asyncio.run(sensor_entity.async_update())
+    assert sensor_entity.native_value in {"good", "fair", "poor"}


### PR DESCRIPTION
## Summary
- support custom thresholds in `classify_environment_quality`
- expose environment quality rating via new sensor
- document plant profile loader
- test environment quality sensor and custom thresholds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d82e08c8330b2804936e69a0ecf