### PR TITLE
Add irrigation data to guideline summary and refactor approval queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ or incomplete and should only be used as a starting point for your own research.
 - **Water Quality Scoring**: `score_water_quality` evaluates irrigation water and
   returns a 0‑100 rating based on toxicity thresholds.
 - **Guideline Summary**: `get_guideline_summary` consolidates environment,
-  nutrient and pest guidance for quick reference.
+  nutrient, irrigation and pest guidance for quick reference.
 - **Nutrient Score Trend**: `score_nutrient_series` averages multiple nutrient
   samples to quickly gauge overall balance over time.
 - **Environment Targets in Reports**: Daily report files now include the

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -14,6 +14,7 @@ from . import (
     disease_manager,
     ph_manager,
     ec_manager,
+    irrigation_manager,
     growth_stage,
 )
 
@@ -34,6 +35,8 @@ class GuidelineSummary:
     beneficial_insects: Dict[str, list[str]] = dataclass_field(default_factory=dict)
     ph_range: List[float] = dataclass_field(default_factory=list)
     ec_range: List[float] = dataclass_field(default_factory=list)
+    irrigation_volume_ml: float | None = None
+    irrigation_interval_days: float | None = None
     stage_info: Optional[Dict[str, Any]] = None
     stages: Optional[List[str]] = None
 
@@ -64,6 +67,16 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         beneficial_insects=beneficial,
         ph_range=ph_manager.get_ph_range(plant_type, stage),
         ec_range=list(ec_manager.get_ec_range(plant_type, stage) or []),
+        irrigation_volume_ml=(
+            irrigation_manager.get_daily_irrigation_target(plant_type, stage)
+            if stage
+            else None
+        ),
+        irrigation_interval_days=(
+            irrigation_manager.get_recommended_interval(plant_type, stage)
+            if stage
+            else None
+        ),
         stage_info=growth_stage.get_stage_info(plant_type, stage) if stage else None,
         stages=None if stage else growth_stage.list_growth_stages(plant_type),
     )

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -10,7 +10,7 @@ def test_queue_and_apply(tmp_path, monkeypatch):
     plant_data = {"thresholds": {"soil_moisture_pct": 30}}
     plant_path.write_text(json.dumps(plant_data))
 
-    monkeypatch.setattr(approval_queue, "PENDING_DIR", str(pending_dir))
+    monkeypatch.setattr(approval_queue, "PENDING_DIR", pending_dir)
 
     # Queue change
     approval_queue.queue_threshold_updates(
@@ -21,6 +21,8 @@ def test_queue_and_apply(tmp_path, monkeypatch):
 
     pending_file = pending_dir / "test.json"
     assert pending_file.exists()
+    pending_data = approval_queue.list_pending_changes("test", pending_dir)
+    assert pending_data["changes"]["soil_moisture_pct"]["proposed_value"] == 35
 
     # Approve one change
     pending = load_json(str(pending_file))

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -13,6 +13,8 @@ def test_get_guideline_summary():
     assert data["micronutrients"] == {}
     assert data["pest_thresholds"]["aphids"] == 5
     assert "ladybugs" in data["beneficial_insects"]["aphids"]
+    assert data["irrigation_volume_ml"] == 300
+    assert "irrigation_interval_days" in data
 
 
 def test_guideline_summary_no_stage():


### PR DESCRIPTION
## Summary
- include irrigation targets in `get_guideline_summary`
- refactor `approval_queue` to use dataclasses and pathlib
- add helper to list pending changes
- update tests for new functionality
- mention irrigation guidance in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d0cace883308365a45818e6f1b8