### PR TITLE
Add fertigation interval support and stage date helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 data/pending_thresholds/
 data/water_balance/
 data/reports/
+custom_components/horticulture_assistant/analytics/all_plants_growth_yield.json

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ or incomplete and should only be used as a starting point for your own research.
   pruning tips loaded from `pruning_guidelines.json`.
 - **Pruning Schedule Planning**: Use `get_pruning_interval` and `next_pruning_date`
   to determine when each plant should be pruned based on `pruning_intervals.json`.
+- **Fertigation Intervals**: `get_fertigation_interval` and `next_fertigation_date`
+  provide recommended application spacing using `fertigation_intervals.json`.
 - **Beneficial Insect Suggestions**: Daily reports list natural predators for
   observed pests using `beneficial_insects.json`.
 - **Biological Control Helper**: `recommend_biological_controls` suggests

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -74,5 +74,6 @@
   "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
   "wsda_fertilizer_database.json": "Full WSDA fertilizer product database for nutrient lookups.",
   "products_index.jsonl": "Compact index of WSDA fertilizer products (JSON Lines).",
-  "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient."
+  "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient.",
+  "fertigation_intervals.json": "Recommended days between fertigation events per stage."
 }

--- a/data/fertigation_intervals.json
+++ b/data/fertigation_intervals.json
@@ -1,0 +1,11 @@
+{
+  "tomato": {
+    "vegetative": 2,
+    "flowering": 3,
+    "optimal": 2
+  },
+  "lettuce": {
+    "vegetative": 1,
+    "optimal": 1
+  }
+}

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -21,6 +21,7 @@ __all__ = [
     "list_growth_stages",
     "get_stage_duration",
     "estimate_stage_from_age",
+    "estimate_stage_from_date",
     "predict_harvest_date",
     "stage_progress",
     "days_until_harvest",
@@ -73,6 +74,17 @@ def estimate_stage_from_age(plant_type: str, days_since_start: int) -> str | Non
                 return stage_name
 
     return None
+
+
+def estimate_stage_from_date(
+    plant_type: str, start_date: date, current_date: date
+) -> str | None:
+    """Return growth stage for ``current_date`` based on ``start_date``."""
+
+    days = (current_date - start_date).days
+    if days < 0:
+        raise ValueError("current_date cannot be before start_date")
+    return estimate_stage_from_age(plant_type, days)
 
 
 def predict_harvest_date(plant_type: str, start_date: date) -> date | None:

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import date
 from plant_engine.fertigation import (
     recommend_fertigation_schedule,
     recommend_fertigation_with_water,
@@ -12,6 +13,8 @@ from plant_engine.fertigation import (
     recommend_nutrient_mix_with_cost_breakdown,
     generate_fertigation_plan,
     calculate_mix_nutrients,
+    get_fertigation_interval,
+    next_fertigation_date,
 )
 
 
@@ -302,4 +305,17 @@ def test_grams_to_ppm_invalid():
         grams_to_ppm(1.0, 0.0, 1.0)
     with pytest.raises(ValueError):
         grams_to_ppm(1.0, 1.0, 0.0)
+
+
+def test_get_fertigation_interval():
+    assert get_fertigation_interval("tomato", "vegetative") == 2
+    assert get_fertigation_interval("lettuce") == 1
+    assert get_fertigation_interval("unknown") is None
+
+
+def test_next_fertigation_date():
+    last = date(2025, 1, 1)
+    expected = date(2025, 1, 3)
+    assert next_fertigation_date("tomato", "vegetative", last) == expected
+    assert next_fertigation_date("unknown", None, last) is None
 

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -5,6 +5,7 @@ from plant_engine.growth_stage import (
     get_stage_info,
     get_stage_duration,
     estimate_stage_from_age,
+    estimate_stage_from_date,
     predict_harvest_date,
     stage_progress,
     days_until_harvest,
@@ -77,4 +78,14 @@ def test_predict_next_stage_date():
     assert (
         predict_next_stage_date("unknown", "seedling", stage_start) is None
     )
+
+
+def test_estimate_stage_from_date():
+    start = date(2025, 1, 1)
+    cur = date(2025, 1, 15)
+    assert estimate_stage_from_date("tomato", start, cur) == "seedling"
+
+    with pytest.raises(ValueError):
+        estimate_stage_from_date("tomato", cur, start)
+
 


### PR DESCRIPTION
## Summary
- add `fertigation_intervals.json` dataset
- expose fertigation interval utilities in fertigation module
- add `estimate_stage_from_date` helper to growth_stage module
- document new fertigation interval helpers
- test fertigation interval and stage date helpers

## Testing
- `pytest -q`
- `pytest tests/test_growth_stage.py tests/test_fertigation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d7b17908330b3a0d98c7d8cb3a2