### PR TITLE
Add disease risk evaluation

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -54,6 +54,7 @@
   "nutrient_removal_rates.json": "Nutrient removal from harvested biomass per kg yield.",
   "pest_prevention.json": "Cultural practices to reduce pest pressure.",
   "pest_risk_factors.json": "Environmental factors increasing pest risk.",
+  "disease_risk_factors.json": "Environmental factors increasing disease risk.",
   "pest_severity_actions.json": "Actions to take based on pest severity level.",
   "ph_adjustment_factors.json": "Acid/base amounts for pH corrections.",
   "ph_guidelines.json": "Optimal pH ranges for nutrient uptake.",

--- a/data/disease_risk_factors.json
+++ b/data/disease_risk_factors.json
@@ -1,0 +1,9 @@
+{
+  "citrus": {
+    "greasy_spot": {"humidity_pct": [60, 100], "temp_c": [20, 30]},
+    "powdery_mildew": {"humidity_pct": [70, 100], "temp_c": [15, 30]}
+  },
+  "tomato": {
+    "blight": {"humidity_pct": [80, 100], "temp_c": [15, 25]}
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -49,6 +49,7 @@ from .disease_monitor import (
     assess_disease_pressure,
     classify_disease_severity,
     recommend_threshold_actions as recommend_disease_threshold_actions,
+    estimate_disease_risk,
     generate_disease_report,
 )
 from .disease_manager import (
@@ -241,6 +242,7 @@ __all__ = [
     "assess_disease_pressure",
     "classify_disease_severity",
     "recommend_disease_threshold_actions",
+    "estimate_disease_risk",
     "generate_disease_report",
     "recommend_fertigation_schedule",
     "recommend_correction_schedule",

--- a/plant_engine/disease_monitor.py
+++ b/plant_engine/disease_monitor.py
@@ -7,14 +7,17 @@ from typing import Dict, Mapping
 
 from .utils import load_dataset, normalize_key, list_dataset_entries
 from .disease_manager import recommend_treatments, recommend_prevention
+from . import environment_manager
 
 DATA_FILE = "disease_thresholds.json"
 MONITOR_INTERVAL_FILE = "disease_monitoring_intervals.json"
+RISK_DATA_FILE = "disease_risk_factors.json"
 
 # Cached dataset
 _THRESHOLDS: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
 # Recommended days between scouting events per plant stage
 _MONITOR_INTERVALS: Dict[str, Dict[str, int]] = load_dataset(MONITOR_INTERVAL_FILE)
+_RISK_FACTORS: Dict[str, Dict[str, Dict[str, list]]] = load_dataset(RISK_DATA_FILE)
 
 __all__ = [
     "list_supported_plants",
@@ -22,6 +25,7 @@ __all__ = [
     "assess_disease_pressure",
     "classify_disease_severity",
     "recommend_threshold_actions",
+    "estimate_disease_risk",
     "get_monitoring_interval",
     "next_monitor_date",
     "generate_monitoring_schedule",
@@ -80,6 +84,39 @@ def recommend_threshold_actions(plant_type: str, observations: Mapping[str, int]
     if not exceeded:
         return {}
     return recommend_treatments(plant_type, exceeded)
+
+
+def estimate_disease_risk(
+    plant_type: str, environment: Mapping[str, float]
+) -> Dict[str, str]:
+    """Return disease risk level based on environmental conditions."""
+
+    factors = _RISK_FACTORS.get(normalize_key(plant_type), {})
+    if not factors:
+        return {}
+
+    readings = environment_manager.normalize_environment_readings(environment)
+    risks: Dict[str, str] = {}
+    for disease, reqs in factors.items():
+        matches = 0
+        total = 0
+        for key, (low, high) in reqs.items():
+            total += 1
+            value = readings.get(key)
+            if value is None:
+                continue
+            if low <= value <= high:
+                matches += 1
+        if total == 0:
+            continue
+        if matches == 0:
+            level = "low"
+        elif matches < total:
+            level = "moderate"
+        else:
+            level = "high"
+        risks[disease] = level
+    return risks
 
 
 def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | None:

--- a/tests/test_disease_risk.py
+++ b/tests/test_disease_risk.py
@@ -1,0 +1,14 @@
+from plant_engine import disease_monitor
+
+
+def test_estimate_disease_risk_high():
+    env = {"temperature": 25, "humidity": 90}
+    risk = disease_monitor.estimate_disease_risk("citrus", env)
+    assert risk["greasy_spot"] == "high"
+    assert risk["powdery_mildew"] == "high"
+
+
+def test_estimate_disease_risk_moderate():
+    env = {"temperature": 17, "humidity": 75}
+    risk = disease_monitor.estimate_disease_risk("tomato", env)
+    assert risk["blight"] == "moderate"


### PR DESCRIPTION
## Summary
- integrate new `disease_risk_factors.json` dataset
- export risk estimation helpers from `disease_monitor` and `__init__`
- test disease risk estimation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d1573d88330a97fb14a12dd472e