### PR TITLE
Add light stress thresholds dataset and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Key reference datasets reside in the `data/` directory:
 - `heat_stress_thresholds.json` – heat index limits used for stress warnings
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress
 - `humidity_actions.json` – actions to correct low or high humidity levels
+- `light_stress_thresholds.json` – DLI limits used for light stress warnings
 - `wind_stress_thresholds.json` – maximum safe wind speed before damage
 - `nutrient_deficiency_treatments.json` – remedies for common nutrient shortages
 - `nutrient_surplus_actions.json` – steps to mitigate excess nutrient levels

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -41,6 +41,7 @@
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",
   "humidity_actions.json": "Recommended actions for low or high humidity.",
+  "light_stress_thresholds.json": "DLI limits causing light stress warnings.",
   "nutrient_deficiency_symptoms.json": "Visual cues for nutrient deficiencies.",
   "nutrient_deficiency_treatments.json": "Corrective actions for deficiencies.",
   "nutrient_deficiency_thresholds.json": "Deficiency ppm thresholds for severity classification.",

--- a/data/light_stress_thresholds.json
+++ b/data/light_stress_thresholds.json
@@ -1,0 +1,8 @@
+{
+  "default": [5, 25],
+  "lettuce": [8, 14],
+  "tomato": [18, 32],
+  "citrus": [12, 35],
+  "strawberry": [10, 20],
+  "basil": [12, 25]
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -515,6 +515,18 @@ def test_evaluate_light_stress():
     assert evaluate_light_stress(11, "lettuce", "seedling") is None
     assert evaluate_light_stress(10, "unknown") is None
 
+def test_get_light_stress_thresholds():
+    from plant_engine import environment_manager as em
+
+    thresh = em.get_light_stress_thresholds("lettuce")
+    assert thresh == (8.0, 14.0)
+    assert em.get_light_stress_thresholds("unknown") == (5.0, 25.0)
+
+def test_evaluate_light_stress_no_stage():
+    assert evaluate_light_stress(6, "lettuce") == "low"
+    assert evaluate_light_stress(16, "lettuce") == "high"
+    assert evaluate_light_stress(12, "lettuce") is None
+
 
 def test_optimize_environment_light_stress():
     result = optimize_environment({"dli": 8}, "lettuce", "seedling")


### PR DESCRIPTION
## Summary
- add `light_stress_thresholds.json` for DLI limits
- document new dataset in README and dataset catalog
- integrate new thresholds in `environment_manager`
- expose `get_light_stress_thresholds` and expand light-stress evaluation
- test new helper and stage-less light stress evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688140d689bc83309a407ec0e24cde38