### PR TITLE
Add bioinoculant dataset and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Key reference datasets reside in the `data/` directory:
 - `disease_prevention.json` – cultural practices to prevent common diseases
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
+- `bioinoculant_guidelines.json` – microbial inoculant suggestions by crop
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage
 - `ipm_guidelines.json` – integrated pest management practices by crop
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
@@ -269,6 +270,9 @@ or incomplete and should only be used as a starting point for your own research.
   provide recommended application spacing using `fertigation_intervals.json`.
 - **Beneficial Insect Suggestions**: Daily reports list natural predators for
   observed pests using `beneficial_insects.json`.
+- **Bioinoculant Recommendations**: `get_recommended_inoculants` returns
+  microbial products that enhance nutrient uptake based on
+  `bioinoculant_guidelines.json`.
 - **Biological Control Helper**: `recommend_biological_controls` suggests
   beneficial insects to deploy when pest thresholds are exceeded.
 - **IPM Guidance**: `recommend_ipm_actions` returns cultural practices and

--- a/data/bioinoculant_guidelines.json
+++ b/data/bioinoculant_guidelines.json
@@ -1,0 +1,13 @@
+{
+  "tomato": [
+    "Trichoderma harzianum",
+    "Bacillus subtilis"
+  ],
+  "lettuce": [
+    "Azospirillum brasilense"
+  ],
+  "cucumber": [
+    "Pseudomonas fluorescens",
+    "Trichoderma viride"
+  ]
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -29,6 +29,7 @@
   "root_depth_guidelines.json": "Typical maximum root depth per crop.",
   "plant_density_guidelines.json": "Recommended plant spacing for common crops.",
   "beneficial_insects.json": "Natural predators for common greenhouse pests.",
+  "bioinoculant_guidelines.json": "Recommended microbial inoculants for improved nutrient uptake.",
   "crop_coefficients.json": "Crop coefficients for evapotranspiration models.",
   "disease_thresholds.json": "Severity thresholds triggering treatments.",
   "ec_guidelines.json": "Electrical conductivity ranges for nutrient solutions.",

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -103,6 +103,10 @@ from .micro_manager import (
     calculate_deficiencies as calculate_micro_deficiencies,
     calculate_surplus as calculate_micro_surplus,
 )
+from .bioinoculant_manager import (
+    list_supported_plants as list_bio_plants,
+    get_recommended_inoculants,
+)
 from .growth_stage import get_stage_info, list_growth_stages
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
@@ -266,6 +270,8 @@ __all__ = [
     "score_nutrient_levels",
     "list_micro_plants",
     "get_micro_levels",
+    "list_bio_plants",
+    "get_recommended_inoculants",
     "get_stage_info",
     "list_growth_stages",
     "build_stage_schedule",

--- a/plant_engine/bioinoculant_manager.py
+++ b/plant_engine/bioinoculant_manager.py
@@ -1,0 +1,26 @@
+"""Helpers for recommending microbial inoculants by crop."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "bioinoculant_guidelines.json"
+
+_DATA: Dict[str, List[str]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_recommended_inoculants",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return all plant types with bioinoculant recommendations."""
+    return list_dataset_entries(_DATA)
+
+
+def get_recommended_inoculants(plant_type: str) -> List[str]:
+    """Return microbial inoculants recommended for ``plant_type``."""
+    return _DATA.get(normalize_key(plant_type), [])

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -9,6 +9,7 @@ from . import (
     environment_manager,
     nutrient_manager,
     micro_manager,
+    bioinoculant_manager,
     pest_manager,
     pest_monitor,
     disease_manager,
@@ -33,6 +34,7 @@ class GuidelineSummary:
     disease_prevention: Dict[str, str]
     pest_thresholds: Dict[str, int] = dataclass_field(default_factory=dict)
     beneficial_insects: Dict[str, list[str]] = dataclass_field(default_factory=dict)
+    bioinoculants: List[str] = dataclass_field(default_factory=list)
     ph_range: List[float] = dataclass_field(default_factory=list)
     ec_range: List[float] = dataclass_field(default_factory=list)
     irrigation_volume_ml: float | None = None
@@ -65,6 +67,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         disease_prevention=disease_manager.get_disease_prevention(plant_type),
         pest_thresholds=thresholds,
         beneficial_insects=beneficial,
+        bioinoculants=bioinoculant_manager.get_recommended_inoculants(plant_type),
         ph_range=ph_manager.get_ph_range(plant_type, stage),
         ec_range=list(ec_manager.get_ec_range(plant_type, stage) or []),
         irrigation_volume_ml=(

--- a/tests/test_bioinoculant_manager.py
+++ b/tests/test_bioinoculant_manager.py
@@ -1,0 +1,12 @@
+from plant_engine import bioinoculant_manager as bio
+
+
+def test_list_supported_plants():
+    plants = bio.list_supported_plants()
+    assert "tomato" in plants
+
+
+def test_get_recommended_inoculants():
+    rec = bio.get_recommended_inoculants("tomato")
+    assert "Trichoderma harzianum" in rec
+    assert bio.get_recommended_inoculants("unknown") == []

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -13,6 +13,7 @@ def test_get_guideline_summary():
     assert data["micronutrients"] == {}
     assert data["pest_thresholds"]["aphids"] == 5
     assert "ladybugs" in data["beneficial_insects"]["aphids"]
+    assert data["bioinoculants"] == []
     assert data["irrigation_volume_ml"] == 300
     assert "irrigation_interval_days" in data
 
@@ -20,4 +21,8 @@ def test_get_guideline_summary():
 def test_guideline_summary_no_stage():
     data = get_guideline_summary("citrus")
     assert "stages" in data and "vegetative" in data["stages"]
+
+def test_guideline_summary_bioinoculants():
+    data = get_guideline_summary("tomato", "fruiting")
+    assert "Trichoderma harzianum" in data["bioinoculants"]
 


### PR DESCRIPTION
## Summary
- include new `bioinoculant_guidelines.json` data file
- expose bioinoculant information via new `bioinoculant_manager`
- surface recommendations in guideline summaries
- document new dataset and helper
- test bioinoculant manager and guideline updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688140dbe8348330a6a3f4e7eec36df2