### PR TITLE
Enhance fertilizer formulator with ppm helper

### DIFF
--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -148,6 +148,18 @@ def calculate_fertilizer_nutrients_from_mass(
     return {element: round(grams * pct * 1000, 2) for element, pct in ga.items()}
 
 
+def calculate_fertilizer_ppm(
+    fertilizer_id: str, grams: float, volume_l: float
+) -> Dict[str, float]:
+    """Return nutrient ppm for ``grams`` dissolved in ``volume_l`` solution."""
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    nutrients = calculate_fertilizer_nutrients_from_mass(fertilizer_id, grams)
+    return {n: round(mg / volume_l, 2) for n, mg in nutrients.items()}
+
+
 def calculate_fertilizer_cost_from_mass(fertilizer_id: str, grams: float) -> float:
     """Return estimated cost for ``grams`` of fertilizer product."""
 
@@ -374,6 +386,7 @@ __all__ = [
     "convert_guaranteed_analysis",
     "calculate_fertilizer_cost",
     "calculate_fertilizer_cost_from_mass",
+    "calculate_fertilizer_ppm",
     "estimate_mix_cost",
     "estimate_cost_breakdown",
     "calculate_mix_nutrients",

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -27,6 +27,7 @@ calculate_mix_ppm = fert_mod.calculate_mix_ppm
 calculate_mix_density = fert_mod.calculate_mix_density
 check_solubility_limits = fert_mod.check_solubility_limits
 estimate_cost_per_nutrient = fert_mod.estimate_cost_per_nutrient
+calculate_fertilizer_ppm = fert_mod.calculate_fertilizer_ppm
 
 
 def test_convert_guaranteed_analysis():
@@ -179,4 +180,13 @@ def test_estimate_cost_per_nutrient():
 
     with pytest.raises(KeyError):
         estimate_cost_per_nutrient("unknown")
+
+
+def test_calculate_fertilizer_ppm():
+    ppm = calculate_fertilizer_ppm("foxfarm_grow_big", 9.6, 10)
+    reference = calculate_mix_ppm({"foxfarm_grow_big": 9.6}, 10)
+    assert ppm == reference
+
+    with pytest.raises(ValueError):
+        calculate_fertilizer_ppm("foxfarm_grow_big", 9.6, 0)
 


### PR DESCRIPTION
## Summary
- add `calculate_fertilizer_ppm` helper to fertilizer formulator
- expose the helper via `__all__`
- cover new behavior with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881415581508330a62947f8b971d874