### PR TITLE
Add soil microbe dataset and guideline integration

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -75,5 +75,6 @@
   "wsda_fertilizer_database.json": "Full WSDA fertilizer product database for nutrient lookups.",
   "products_index.jsonl": "Compact index of WSDA fertilizer products (JSON Lines).",
   "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient.",
-  "fertigation_intervals.json": "Recommended days between fertigation events per stage."
+  "fertigation_intervals.json": "Recommended days between fertigation events per stage.",
+  "soil_microbe_guidelines.json": "Beneficial soil microorganisms for each crop."
 }

--- a/data/soil_microbe_guidelines.json
+++ b/data/soil_microbe_guidelines.json
@@ -1,0 +1,6 @@
+{
+  "citrus": ["Trichoderma harzianum", "Bacillus subtilis"],
+  "lettuce": ["Bacillus amyloliquefaciens", "Azotobacter chroococcum"],
+  "strawberry": ["Trichoderma harzianum", "Pseudomonas fluorescens"],
+  "tomato": ["Azospirillum brasilense", "Bacillus megaterium"]
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -103,6 +103,10 @@ from .micro_manager import (
     calculate_deficiencies as calculate_micro_deficiencies,
     calculate_surplus as calculate_micro_surplus,
 )
+from .soil_microbe_manager import (
+    list_supported_plants as list_microbe_plants,
+    get_recommended_microbes,
+)
 from .growth_stage import get_stage_info, list_growth_stages
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
@@ -266,6 +270,8 @@ __all__ = [
     "score_nutrient_levels",
     "list_micro_plants",
     "get_micro_levels",
+    "list_microbe_plants",
+    "get_recommended_microbes",
     "get_stage_info",
     "list_growth_stages",
     "build_stage_schedule",

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -16,6 +16,7 @@ from . import (
     ec_manager,
     irrigation_manager,
     growth_stage,
+    soil_microbe_manager,
 )
 
 __all__ = ["GuidelineSummary", "get_guideline_summary"]
@@ -33,6 +34,7 @@ class GuidelineSummary:
     disease_prevention: Dict[str, str]
     pest_thresholds: Dict[str, int] = dataclass_field(default_factory=dict)
     beneficial_insects: Dict[str, list[str]] = dataclass_field(default_factory=dict)
+    beneficial_microbes: List[str] = dataclass_field(default_factory=list)
     ph_range: List[float] = dataclass_field(default_factory=list)
     ec_range: List[float] = dataclass_field(default_factory=list)
     irrigation_volume_ml: float | None = None
@@ -55,6 +57,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
 
     thresholds = pest_monitor.get_pest_thresholds(plant_type)
     beneficial = {p: pest_manager.get_beneficial_insects(p) for p in thresholds}
+    microbes = soil_microbe_manager.get_recommended_microbes(plant_type)
 
     summary = GuidelineSummary(
         environment=environment_manager.get_environmental_targets(plant_type, stage),
@@ -65,6 +68,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         disease_prevention=disease_manager.get_disease_prevention(plant_type),
         pest_thresholds=thresholds,
         beneficial_insects=beneficial,
+        beneficial_microbes=microbes,
         ph_range=ph_manager.get_ph_range(plant_type, stage),
         ec_range=list(ec_manager.get_ec_range(plant_type, stage) or []),
         irrigation_volume_ml=(

--- a/plant_engine/soil_microbe_manager.py
+++ b/plant_engine/soil_microbe_manager.py
@@ -1,0 +1,26 @@
+"""Lookup beneficial soil microorganisms for crops."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, List
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "soil_microbe_guidelines.json"
+
+# cache dataset on first load
+_DATA: Dict[str, List[str]] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_recommended_microbes"]
+
+
+def list_supported_plants() -> List[str]:
+    """Return all plant types with microbe recommendations."""
+    return list_dataset_entries(_DATA)
+
+
+@lru_cache(maxsize=None)
+def get_recommended_microbes(plant_type: str) -> List[str]:
+    """Return beneficial microbes recommended for ``plant_type``."""
+    microbes = _DATA.get(normalize_key(plant_type), [])
+    return [str(m) for m in microbes]

--- a/tests/test_soil_microbe_manager.py
+++ b/tests/test_soil_microbe_manager.py
@@ -1,0 +1,13 @@
+from plant_engine import soil_microbe_manager as sm
+
+
+def test_list_supported_plants():
+    plants = sm.list_supported_plants()
+    assert "citrus" in plants
+    assert "tomato" in plants
+
+
+def test_get_recommended_microbes():
+    microbes = sm.get_recommended_microbes("lettuce")
+    assert "Azotobacter chroococcum" in microbes
+    assert len(microbes) == 2


### PR DESCRIPTION
## Summary
- add new `soil_microbe_guidelines.json` dataset for beneficial microbes
- expose soil microbe info via new `soil_microbe_manager`
- include microbe recommendations in guideline summaries
- list microbe helpers in package API
- document dataset in catalog
- test new microbe manager

## Testing
- `pytest tests/test_soil_microbe_manager.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881414b465083309b76509280ec8f91