### PR TITLE
Improve pest monitoring validation and tests

### DIFF
--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -109,6 +109,8 @@ def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Di
     thresholds = get_pest_thresholds(plant_type)
     pressure: Dict[str, bool] = {}
     for pest, count in observations.items():
+        if count < 0:
+            raise ValueError("pest counts must be non-negative")
         key = normalize_key(pest)
         thresh = thresholds.get(key)
         if thresh is None:
@@ -185,6 +187,8 @@ def classify_pest_severity(
     thresholds = get_pest_thresholds(plant_type)
     severity: Dict[str, str] = {}
     for pest, count in observations.items():
+        if count < 0:
+            raise ValueError("pest counts must be non-negative")
         key = normalize_key(pest)
         thresh = thresholds.get(key)
         if thresh is None:

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -668,3 +668,8 @@ def test_co2_price_and_cost():
     grams, cost = recommend_co2_injection_with_cost(300, "citrus", "seedling", 100.0, "cartridge")
     assert grams > 0
     assert cost == estimate_co2_cost(grams, "cartridge")
+
+
+def test_estimate_co2_cost_negative():
+    with pytest.raises(ValueError):
+        estimate_co2_cost(-5, "bulk_tank")

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -1,4 +1,5 @@
 from datetime import date
+import pytest
 from plant_engine.pest_monitor import (
     list_supported_plants,
     get_pest_thresholds,
@@ -58,6 +59,13 @@ def test_classify_pest_severity():
     severity = classify_pest_severity("citrus", obs)
     assert severity["aphids"] == "low"
     assert severity["scale"] == "severe"
+
+
+def test_negative_counts_raise():
+    with pytest.raises(ValueError):
+        assess_pest_pressure("citrus", {"aphids": -1})
+    with pytest.raises(ValueError):
+        classify_pest_severity("citrus", {"aphids": -2})
 
 
 def test_generate_pest_report():


### PR DESCRIPTION
## Summary
- validate pest count inputs in pest monitor
- test that invalid pest counts raise `ValueError`
- test negative CO₂ cost

## Testing
- `pytest tests/test_pest_monitor.py::test_negative_counts_raise -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814144d32883308bda51751e39802c