### PR TITLE
Add irrigation duration estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Key reference datasets reside in the `data/` directory:
 - `irrigation_guidelines.json` – default daily irrigation volume per plant stage
 - `water_usage_guidelines.json` – estimated daily water use by crop stage
 - `irrigation_efficiency.json` – efficiency factors for common irrigation methods
+- `emitter_flow_rates.json` – typical emitter flow rates (L/h) for irrigation time estimates
 - `foliar_feed_guidelines.json` – recommended nutrient ppm for foliar sprays
 - `foliar_feed_intervals.json` – suggested days between foliar applications
 - `nutrient_leaching_rates.json` – estimated fraction of nutrients lost to leaching
@@ -244,6 +245,7 @@ or incomplete and should only be used as a starting point for your own research.
   milliliters per plant based on `irrigation_guidelines.json`. The `get_daily_water_use` helper provides similar estimates from `water_usage_guidelines.json`.
 - **Irrigation Efficiency**: `adjust_irrigation_for_efficiency` scales volumes
   based on delivery method using `irrigation_efficiency.json`.
+- **Irrigation Duration Estimate**: `estimate_irrigation_time` uses `emitter_flow_rates.json` to predict how long a watering event will take.
 - **Irrigation Schedule Efficiency**: `generate_irrigation_schedule` accepts a
   `method` parameter to automatically apply those efficiency factors.
 - **Fertigation Planning**: `generate_fertigation_plan` produces a day-by-day

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -75,5 +75,6 @@
   "wsda_fertilizer_database.json": "Full WSDA fertilizer product database for nutrient lookups.",
   "products_index.jsonl": "Compact index of WSDA fertilizer products (JSON Lines).",
   "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient.",
-  "fertigation_intervals.json": "Recommended days between fertigation events per stage."
+  "fertigation_intervals.json": "Recommended days between fertigation events per stage.",
+  "emitter_flow_rates.json": "Typical emitter flow rates in L/h."
 }

--- a/data/emitter_flow_rates.json
+++ b/data/emitter_flow_rates.json
@@ -1,0 +1,5 @@
+{
+  "drip": 4.0,
+  "micro_sprinkler": 8.0,
+  "sprinkler": 10.0
+}

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -11,6 +11,7 @@ from plant_engine.irrigation_manager import (
     list_supported_plants,
     generate_irrigation_schedule,
     adjust_irrigation_for_efficiency,
+    estimate_irrigation_time,
     generate_env_irrigation_schedule,
     generate_precipitation_schedule,
     get_rain_capture_efficiency,
@@ -241,3 +242,14 @@ def test_generate_precipitation_schedule():
     # Second day no rain -> irrigation required
     assert schedule[2] > 0.0
 
+
+def test_estimate_irrigation_time():
+    # 4 L/h emitter with 2 emitters -> 8 L/h -> 8000 mL/h
+    hrs = estimate_irrigation_time(4000, "drip", emitters=2)
+    assert hrs == 0.5
+    # unknown emitter returns 0.0
+    assert estimate_irrigation_time(1000, "unknown") == 0.0
+    with pytest.raises(ValueError):
+        estimate_irrigation_time(-1, "drip")
+    with pytest.raises(ValueError):
+        estimate_irrigation_time(1000, "drip", emitters=0)


### PR DESCRIPTION
## Summary
- provide emitter flow rate dataset
- support estimating irrigation time in irrigation manager
- document emitter flow dataset and helper usage
- test new irrigation time helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814140a9c083308f04907654709d7e