### PR TITLE
Refactor monitoring utilities and add tests

### DIFF
--- a/plant_engine/monitor_utils.py
+++ b/plant_engine/monitor_utils.py
@@ -1,0 +1,55 @@
+"""Generic helpers for pest and disease monitoring intervals."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Mapping
+
+from .utils import normalize_key
+
+__all__ = [
+    "get_interval",
+    "next_date",
+    "generate_schedule",
+]
+
+
+def get_interval(
+    data: Mapping[str, Mapping[str, int]],
+    plant_type: str,
+    stage: str | None = None,
+) -> int | None:
+    """Return monitoring interval in days for a plant stage."""
+    plant = data.get(normalize_key(plant_type), {})
+    if stage:
+        value = plant.get(normalize_key(stage))
+        if isinstance(value, (int, float)):
+            return int(value)
+    value = plant.get("optimal")
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def next_date(
+    data: Mapping[str, Mapping[str, int]],
+    plant_type: str,
+    stage: str | None,
+    last_date: date,
+) -> date | None:
+    """Return the next monitoring date based on ``last_date``."""
+    interval = get_interval(data, plant_type, stage)
+    if interval is None:
+        return None
+    return last_date + timedelta(days=interval)
+
+
+def generate_schedule(
+    data: Mapping[str, Mapping[str, int]],
+    plant_type: str,
+    stage: str | None,
+    start: date,
+    events: int,
+) -> list[date]:
+    """Return list of future monitoring dates."""
+    interval = get_interval(data, plant_type, stage)
+    if interval is None or events <= 0:
+        return []
+    return [start + timedelta(days=interval * i) for i in range(1, events + 1)]

--- a/tests/test_monitor_utils.py
+++ b/tests/test_monitor_utils.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+from plant_engine.monitor_utils import get_interval, next_date, generate_schedule
+
+DATA = {
+    "citrus": {"fruiting": 4, "optimal": 5},
+    "tomato": {"seedling": 2}
+}
+
+def test_get_interval():
+    assert get_interval(DATA, "citrus", "fruiting") == 4
+    assert get_interval(DATA, "citrus") == 5
+    assert get_interval(DATA, "tomato", "flowering") is None
+
+
+def test_next_date():
+    last = date(2023, 1, 1)
+    assert next_date(DATA, "citrus", "fruiting", last) == date(2023, 1, 5)
+    assert next_date(DATA, "unknown", None, last) is None
+
+
+def test_generate_schedule():
+    start = date(2023, 1, 1)
+    sched = generate_schedule(DATA, "citrus", "fruiting", start, 3)
+    assert sched == [date(2023, 1, 5), date(2023, 1, 9), date(2023, 1, 13)]
+    assert generate_schedule(DATA, "unknown", None, start, 2) == []


### PR DESCRIPTION
## Summary
- factor out duplicated monitoring interval helpers
- simplify pest and disease monitors using the shared utilities
- add unit tests for the new helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881411be4cc8330a4af6bda1b120149