### PR TITLE
Add disease risk estimation utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -13,6 +13,7 @@
   "ipm_guidelines.json": "Integrated pest management practices by crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
+  "disease_risk_factors.json": "Environmental conditions that favor common plant diseases.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",
   "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",
   "light_dli_guidelines.json": "Daily Light Integral targets for growth stages.",

--- a/data/disease_risk_factors.json
+++ b/data/disease_risk_factors.json
@@ -1,0 +1,9 @@
+{
+  "citrus": {
+    "citrus_greening": {"humidity_pct": [80, 100], "temp_c": [20, 32]},
+    "root_rot": {"humidity_pct": [70, 100], "temp_c": [18, 28]}
+  },
+  "tomato": {
+    "blight": {"humidity_pct": [70, 100], "temp_c": [15, 25]}
+  }
+}

--- a/tests/test_disease_monitor.py
+++ b/tests/test_disease_monitor.py
@@ -4,6 +4,7 @@ from plant_engine.disease_monitor import (
     assess_disease_pressure,
     classify_disease_severity,
     recommend_threshold_actions,
+    estimate_disease_risk,
     generate_disease_report,
     get_monitoring_interval,
     next_monitor_date,
@@ -43,6 +44,19 @@ def test_generate_disease_report():
     assert report["thresholds_exceeded"]["citrus_greening"] is True
     assert "citrus greening" in report["treatments"]
     assert "root rot" in report["prevention"]
+
+
+def test_estimate_disease_risk():
+    env = {"humidity": 85, "temperature": 26}
+    risk = estimate_disease_risk("citrus", env)
+    assert risk["citrus_greening"] == "high"
+
+
+def test_generate_disease_report_with_environment():
+    obs = {"citrus greening": 1}
+    env = {"humidity": 85, "temperature": 26}
+    report = generate_disease_report("citrus", obs, environment=env)
+    assert report["risk_levels"]["citrus_greening"] == "high"
 
 
 def test_get_monitoring_interval():


### PR DESCRIPTION
## Summary
- add new `disease_risk_factors.json` dataset and entry in catalog
- expand `disease_monitor` with risk estimation helper and report output
- update unit tests for new features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881411815fc833098f2687c42c77f85