### PR TITLE
Enhance environment manager with soil temperature data

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -65,6 +65,7 @@
   "soil_texture_parameters.json": "Typical sand, silt and clay percentages.",
   "soil_infiltration_rates.json": "Infiltration rates (mm/hr) by soil texture.",
   "soil_moisture_guidelines.json": "Recommended soil moisture percentages for common crops.",
+  "soil_temperature_guidelines.json": "Recommended soil temperature ranges for growth stages.",
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",

--- a/data/soil_temperature_guidelines.json
+++ b/data/soil_temperature_guidelines.json
@@ -1,0 +1,20 @@
+{
+  "citrus": {
+    "seedling": [20, 25],
+    "vegetative": [20, 30],
+    "fruiting": [22, 32],
+    "optimal": [20, 30]
+  },
+  "tomato": {
+    "seedling": [18, 24],
+    "vegetative": [20, 28],
+    "fruiting": [22, 26],
+    "optimal": [20, 26]
+  },
+  "lettuce": {
+    "seedling": [16, 22],
+    "vegetative": [18, 24],
+    "harvest": [18, 24],
+    "optimal": [18, 24]
+  }
+}

--- a/plant_engine/constants.py
+++ b/plant_engine/constants.py
@@ -32,6 +32,7 @@ DEFAULT_ENV: dict[str, float] = {
     "rh_pct": 65,
     "par_w_m2": 350,
     "wind_speed_m_s": 1.2,
+    "soil_temp_c": 22,
 }
 
 __all__ = ["STAGE_MULTIPLIERS", "get_stage_multiplier", "DEFAULT_ENV"]

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -35,6 +35,7 @@ from plant_engine.environment_manager import (
     evaluate_humidity_stress,
     evaluate_ph_stress,
     evaluate_stress_conditions,
+    evaluate_soil_temperature_stress,
     score_environment,
     score_environment_series,
     score_environment_components,
@@ -50,6 +51,7 @@ from plant_engine.environment_manager import (
     summarize_environment,
     summarize_environment_series,
     clear_environment_cache,
+    get_target_soil_temperature,
 )
 
 
@@ -564,16 +566,26 @@ def test_optimize_environment_humidity_stress():
 
 
 def test_evaluate_stress_conditions():
-    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling")
+    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, 15, "lettuce", "seedling")
     assert stress.heat is True
     assert stress.cold is False
     assert stress.light == "low"
     assert stress.wind is True
     assert stress.humidity is None
 
-    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, "citrus")
+    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, None, "citrus")
     assert stress_none.heat is None
     assert stress_none.humidity is None
+
+
+def test_get_target_soil_temperature():
+    assert get_target_soil_temperature("citrus", "seedling") == (20, 25)
+
+
+def test_evaluate_soil_temperature_stress():
+    assert evaluate_soil_temperature_stress(18, "citrus", "seedling") == "low"
+    assert evaluate_soil_temperature_stress(26, "citrus", "seedling") == "high"
+    assert evaluate_soil_temperature_stress(22, "citrus", "seedling") is None
 
 
 def test_score_environment_components():


### PR DESCRIPTION
## Summary
- add soil temperature guidelines dataset
- integrate soil temperature checks into `environment_manager`
- expose `get_target_soil_temperature` and `evaluate_soil_temperature_stress`
- support soil temperature aliases and default value
- test soil temperature stress logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688141105264833097599f47a5a09457