### PR TITLE
Enhance environment manager with soil temperature support

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -65,6 +65,7 @@
   "soil_texture_parameters.json": "Typical sand, silt and clay percentages.",
   "soil_infiltration_rates.json": "Infiltration rates (mm/hr) by soil texture.",
   "soil_moisture_guidelines.json": "Recommended soil moisture percentages for common crops.",
+  "soil_temperature_guidelines.json": "Recommended soil temperature ranges for germination and growth stages.",
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",

--- a/data/soil_temperature_guidelines.json
+++ b/data/soil_temperature_guidelines.json
@@ -1,0 +1,10 @@
+{
+  "citrus": {
+    "optimal": [20, 28],
+    "germination": [25, 32]
+  },
+  "lettuce": {
+    "optimal": [16, 22],
+    "germination": [10, 22]
+  }
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -35,6 +35,7 @@ from plant_engine.environment_manager import (
     evaluate_humidity_stress,
     evaluate_ph_stress,
     evaluate_stress_conditions,
+    evaluate_soil_temperature_stress,
     score_environment,
     score_environment_series,
     score_environment_components,
@@ -50,6 +51,7 @@ from plant_engine.environment_manager import (
     summarize_environment,
     summarize_environment_series,
     clear_environment_cache,
+    get_target_soil_temperature,
 )
 
 
@@ -563,17 +565,29 @@ def test_optimize_environment_humidity_stress():
     assert result["humidity_stress"] == "high"
 
 
+def test_get_target_soil_temperature():
+    assert get_target_soil_temperature("citrus", "germination") == (25, 32)
+
+
+def test_evaluate_soil_temperature_stress():
+    assert evaluate_soil_temperature_stress(18, "citrus") == "cold"
+    assert evaluate_soil_temperature_stress(30, "citrus") == "hot"
+    assert evaluate_soil_temperature_stress(35, "citrus") == "hot"
+
+
 def test_evaluate_stress_conditions():
-    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling")
+    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling", 12)
     assert stress.heat is True
     assert stress.cold is False
     assert stress.light == "low"
     assert stress.wind is True
     assert stress.humidity is None
+    assert stress.soil_temp == "cold"
 
     stress_none = evaluate_stress_conditions(None, None, None, None, None, None, "citrus")
     assert stress_none.heat is None
     assert stress_none.humidity is None
+    assert stress_none.soil_temp is None
 
 
 def test_score_environment_components():


### PR DESCRIPTION
## Summary
- integrate new dataset for soil temperature ranges
- expose soil temperature guidelines and stress evaluation utilities
- extend `evaluate_stress_conditions` to handle soil temperature
- add tests for soil temperature helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688140ee9c548330961279d53cae9d8a