### PR TITLE
Enhance disease monitoring with risk estimation

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -12,6 +12,7 @@
   "pest_monitoring_intervals.json": "Recommended days between scouting events.",
   "ipm_guidelines.json": "Integrated pest management practices by crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
+  "disease_risk_factors.json": "Environmental factors increasing disease risk.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",
   "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",

--- a/data/disease_risk_factors.json
+++ b/data/disease_risk_factors.json
@@ -1,0 +1,9 @@
+{
+  "citrus": {
+    "citrus_greening": {"humidity_pct": [40, 80], "temp_c": [20, 35]},
+    "root_rot": {"humidity_pct": [70, 100], "temp_c": [15, 25]}
+  },
+  "tomato": {
+    "blight": {"humidity_pct": [70, 100], "temp_c": [18, 28]}
+  }
+}

--- a/plant_engine/disease_monitor.py
+++ b/plant_engine/disease_monitor.py
@@ -7,14 +7,17 @@ from typing import Dict, Mapping
 
 from .utils import load_dataset, normalize_key, list_dataset_entries
 from .disease_manager import recommend_treatments, recommend_prevention
+from . import environment_manager
 
 DATA_FILE = "disease_thresholds.json"
 MONITOR_INTERVAL_FILE = "disease_monitoring_intervals.json"
+RISK_DATA_FILE = "disease_risk_factors.json"
 
 # Cached dataset
 _THRESHOLDS: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
 # Recommended days between scouting events per plant stage
 _MONITOR_INTERVALS: Dict[str, Dict[str, int]] = load_dataset(MONITOR_INTERVAL_FILE)
+_RISK_FACTORS: Dict[str, Dict[str, Dict[str, list]]] = load_dataset(RISK_DATA_FILE)
 
 __all__ = [
     "list_supported_plants",
@@ -25,6 +28,7 @@ __all__ = [
     "get_monitoring_interval",
     "next_monitor_date",
     "generate_monitoring_schedule",
+    "estimate_disease_risk",
     "generate_disease_report",
     "DiseaseReport",
 ]
@@ -80,6 +84,39 @@ def recommend_threshold_actions(plant_type: str, observations: Mapping[str, int]
     if not exceeded:
         return {}
     return recommend_treatments(plant_type, exceeded)
+
+
+def estimate_disease_risk(
+    plant_type: str, environment: Mapping[str, float]
+) -> Dict[str, str]:
+    """Return disease risk levels based on environmental conditions."""
+
+    factors = _RISK_FACTORS.get(normalize_key(plant_type), {})
+    if not factors:
+        return {}
+
+    readings = environment_manager.normalize_environment_readings(environment)
+    risks: Dict[str, str] = {}
+    for disease, reqs in factors.items():
+        matches = 0
+        total = 0
+        for key, (low, high) in reqs.items():
+            total += 1
+            value = readings.get(key)
+            if value is None:
+                continue
+            if low <= value <= high:
+                matches += 1
+        if total == 0:
+            continue
+        if matches == 0:
+            level = "low"
+        elif matches < total:
+            level = "moderate"
+        else:
+            level = "high"
+        risks[disease] = level
+    return risks
 
 
 def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | None:

--- a/tests/test_disease_risk.py
+++ b/tests/test_disease_risk.py
@@ -1,0 +1,15 @@
+from plant_engine import disease_monitor
+
+
+def test_estimate_disease_risk_high():
+    env = {"temperature": 22, "humidity": 75}
+    risk = disease_monitor.estimate_disease_risk("citrus", env)
+    assert risk["citrus_greening"] == "high"
+    assert risk["root_rot"] == "high"
+
+
+def test_estimate_disease_risk_moderate():
+    env = {"temperature": 18, "humidity": 50}
+    risk = disease_monitor.estimate_disease_risk("citrus", env)
+    assert risk["citrus_greening"] == "moderate"
+    assert risk["root_rot"] == "moderate"


### PR DESCRIPTION
## Summary
- add `disease_risk_factors.json` dataset
- register dataset in catalog
- extend `disease_monitor` with `estimate_disease_risk`
- test disease risk estimation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688140e557fc8330b26050bc65f5b526