### PR TITLE
Add plant profile listing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,18 @@ for pid, result in profiles.items():
     print(pid, result.loaded, result.issues)
 ```
 
+To quickly discover which profiles exist without loading them, use the
+`list_available_profiles` helper:
+
+```python
+from custom_components.horticulture_assistant.utils.plant_profile_loader import (
+    list_available_profiles,
+)
+
+ids = list_available_profiles()
+print(ids)
+```
+
 ## Troubleshooting
 - **Sensors show `unavailable`**: verify the entity IDs and that the devices are reporting to Home Assistant.
 - **Config flow fails**: check the logs for JSON errors in your plant profiles or missing permissions.

--- a/custom_components/horticulture_assistant/utils/plant_profile_loader.py
+++ b/custom_components/horticulture_assistant/utils/plant_profile_loader.py
@@ -171,3 +171,33 @@ def load_profile(
         return load_profile_by_id(plant_id, base_dir)
     _LOGGER.error("No plant_id or path specified for loading profile")
     return {}
+
+
+def list_available_profiles(base_dir: str | Path | None = None) -> list[str]:
+    """Return all plant IDs with a profile file in ``base_dir``.
+
+    The helper scans for ``*.json``, ``*.yaml`` and ``*.yml`` files and
+    returns their stem names sorted alphabetically. When the directory does
+    not exist an empty list is returned.
+    """
+
+    directory = Path(base_dir) if base_dir else DEFAULT_BASE_DIR
+    if not directory.is_dir():
+        return []
+
+    plant_ids: set[str] = set()
+    for entry in directory.iterdir():
+        if not entry.is_file():
+            continue
+        if entry.suffix.lower() in {".json", ".yaml", ".yml"}:
+            plant_ids.add(entry.stem)
+
+    return sorted(plant_ids)
+
+
+__all__ = [
+    "load_profile_from_path",
+    "load_profile_by_id",
+    "load_profile",
+    "list_available_profiles",
+]

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -60,3 +60,14 @@ def test_load_profile_missing(tmp_path):
     finally:
         loader.DEFAULT_BASE_DIR = orig
     assert profile == {}
+
+
+def test_list_available_profiles(tmp_path):
+    plants = tmp_path / "profiles"
+    plants.mkdir()
+    (plants / "one.json").write_text("{}")
+    (plants / "two.yaml").write_text("general: {}")
+    (plants / "skip.txt").write_text("bad")
+
+    result = loader.list_available_profiles(plants)
+    assert result == ["one", "two"]


### PR DESCRIPTION
## Summary
- add `list_available_profiles` utility for discovering profile IDs
- document helper in README
- test new profile loader functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814ac368188330b1f0476eda997538