### PR TITLE
Add companion planting module

### DIFF
--- a/data/companion_plants.json
+++ b/data/companion_plants.json
@@ -1,0 +1,10 @@
+{
+  "tomato": {
+    "companions": ["basil", "marigold"],
+    "antagonists": ["fennel", "corn"]
+  },
+  "cucumber": {
+    "companions": ["nasturtium", "radish"],
+    "antagonists": ["sage", "potato"]
+  }
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -80,5 +80,6 @@
   "products_index.jsonl": "Compact index of WSDA fertilizer products (JSON Lines).",
   "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient.",
   "fertigation_intervals.json": "Recommended days between fertigation events per stage.",
-  "emitter_flow_rates.json": "Typical emitter flow rates in L/h."
+  "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
+  "companion_plants.json": "Companion planting recommendations."
 }

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -109,6 +109,12 @@ from .bioinoculant_manager import (
     list_supported_plants as list_bio_plants,
     get_recommended_inoculants,
 )
+from .companion_manager import (
+    list_supported_plants as list_companion_plants,
+    get_companion_info,
+    recommend_companions,
+    recommend_antagonists,
+)
 from .growth_stage import get_stage_info, list_growth_stages
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
@@ -276,6 +282,10 @@ __all__ = [
     "get_micro_levels",
     "list_bio_plants",
     "get_recommended_inoculants",
+    "list_companion_plants",
+    "get_companion_info",
+    "recommend_companions",
+    "recommend_antagonists",
     "get_stage_info",
     "list_growth_stages",
     "build_stage_schedule",

--- a/plant_engine/companion_manager.py
+++ b/plant_engine/companion_manager.py
@@ -1,0 +1,33 @@
+from typing import Dict, List
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "companion_plants.json"
+_DATA: Dict[str, Dict[str, List[str]]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_companion_info",
+    "recommend_companions",
+    "recommend_antagonists",
+]
+
+
+def list_supported_plants() -> List[str]:
+    """Return plant types with companion planting info."""
+    return list_dataset_entries(_DATA)
+
+
+def get_companion_info(plant_type: str) -> Dict[str, List[str]]:
+    """Return companion planting data for ``plant_type``."""
+    return _DATA.get(normalize_key(plant_type), {})
+
+
+def recommend_companions(plant_type: str) -> List[str]:
+    """Return recommended companion plants for ``plant_type``."""
+    return get_companion_info(plant_type).get("companions", [])
+
+
+def recommend_antagonists(plant_type: str) -> List[str]:
+    """Return plants to avoid near ``plant_type``."""
+    return get_companion_info(plant_type).get("antagonists", [])

--- a/tests/test_companion_manager.py
+++ b/tests/test_companion_manager.py
@@ -1,0 +1,28 @@
+from plant_engine.companion_manager import (
+    list_supported_plants,
+    get_companion_info,
+    recommend_companions,
+    recommend_antagonists,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+    assert "cucumber" in plants
+
+
+def test_get_companion_info():
+    info = get_companion_info("tomato")
+    assert info["companions"] == ["basil", "marigold"]
+    assert "fennel" in info["antagonists"]
+
+
+def test_recommend_companions():
+    assert "basil" in recommend_companions("tomato")
+    assert recommend_companions("unknown") == []
+
+
+def test_recommend_antagonists():
+    assert "sage" in recommend_antagonists("cucumber")
+    assert recommend_antagonists("unknown") == []


### PR DESCRIPTION
## Summary
- integrate companion planting dataset
- support recommending companion and antagonist plants
- expose companion APIs in plant engine
- test companion manager functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814ae9dc3083309ffbaf0a397b3bf9