### PR TITLE
Enhance dataset utilities with search capability

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -1,7 +1,7 @@
 """Plant engine package utilities."""
 
 from .utils import load_json, save_json
-from .datasets import list_datasets, get_dataset_description
+from .datasets import list_datasets, get_dataset_description, search_datasets
 from .environment_manager import (
     get_environmental_targets,
     recommend_environment_adjustments,
@@ -203,6 +203,7 @@ __all__ = [
     "save_json",
     "list_datasets",
     "get_dataset_description",
+    "search_datasets",
     "get_environmental_targets",
     "recommend_environment_adjustments",
     "optimize_environment",

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -9,7 +9,12 @@ from typing import Dict, List
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 CATALOG_FILE = DATA_DIR / "dataset_catalog.json"
 
-__all__ = ["list_datasets", "get_dataset_description", "list_dataset_info"]
+__all__ = [
+    "list_datasets",
+    "get_dataset_description",
+    "list_dataset_info",
+    "search_datasets",
+]
 
 
 @lru_cache(maxsize=None)
@@ -51,4 +56,19 @@ def list_dataset_info() -> Dict[str, str]:
     names = list_datasets()
     catalog = _load_catalog()
     return {n: catalog.get(n, "") for n in names}
+
+
+def search_datasets(term: str) -> Dict[str, str]:
+    """Return datasets matching ``term`` in the name or description."""
+
+    if not term:
+        return {}
+
+    term = term.lower()
+    info = list_dataset_info()
+    result: Dict[str, str] = {}
+    for name, desc in info.items():
+        if term in name.lower() or term in desc.lower():
+            result[name] = desc
+    return result
 

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -1,4 +1,8 @@
-from plant_engine.datasets import list_datasets, get_dataset_description
+from plant_engine.datasets import (
+    list_datasets,
+    get_dataset_description,
+    search_datasets,
+)
 
 
 def test_list_datasets_contains_known():
@@ -32,3 +36,16 @@ def test_get_dataset_description():
 
     desc6 = get_dataset_description("soil_moisture_guidelines.json")
     assert "moisture" in desc6
+
+
+def test_search_datasets():
+    results = search_datasets("irrigation")
+    assert "irrigation_guidelines.json" in results
+    assert "irrigation_intervals.json" in results
+    assert all(
+        "irrigation" in name or "irrigation" in desc.lower()
+        for name, desc in results.items()
+    )
+
+    empty = search_datasets("does-not-exist")
+    assert empty == {}


### PR DESCRIPTION
## Summary
- expose a new `search_datasets` helper to locate datasets by name or description
- re-export the helper from `plant_engine`
- test the new search functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814adcc7808330862c0707cdf2d7a7