### PR TITLE
Add canopy area dataset with transpiration integration

### DIFF
--- a/data/canopy_area_guidelines.json
+++ b/data/canopy_area_guidelines.json
@@ -1,0 +1,7 @@
+{
+  "tomato": 0.3,
+  "lettuce": 0.1,
+  "citrus": 0.5,
+  "basil": 0.05,
+  "strawberry": 0.15
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -80,5 +80,6 @@
   "products_index.jsonl": "Compact index of WSDA fertilizer products (JSON Lines).",
   "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient.",
   "fertigation_intervals.json": "Recommended days between fertigation events per stage.",
-  "emitter_flow_rates.json": "Typical emitter flow rates in L/h."
+  "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
+  "canopy_area_guidelines.json": "Typical plant canopy area in square meters."
 }

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -80,6 +80,10 @@ from .rootzone_model import (
     estimate_infiltration_time,
     RootZone,
 )
+from .canopy_manager import (
+    list_supported_plants as list_canopy_plants,
+    get_default_canopy_area,
+)
 from .soil_manager import (
     list_supported_plants as list_soil_plants,
     get_soil_targets,
@@ -346,6 +350,8 @@ __all__ = [
     "DailyReport",
     "load_profile",
     "TranspirationMetrics",
+    "list_canopy_plants",
+    "get_default_canopy_area",
     "STAGE_MULTIPLIERS",
     "get_stage_multiplier",
     "DEFAULT_ENV",

--- a/plant_engine/canopy_manager.py
+++ b/plant_engine/canopy_manager.py
@@ -1,0 +1,26 @@
+"""Helpers for retrieving typical plant canopy area."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "canopy_area_guidelines.json"
+
+_DATA: Dict[str, float] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_default_canopy_area"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with canopy area data."""
+    return list_dataset_entries(_DATA)
+
+
+def get_default_canopy_area(plant_type: str) -> float:
+    """Return typical canopy area (m²) for ``plant_type`` or 0.25."""
+    area = _DATA.get(normalize_key(plant_type))
+    try:
+        return float(area) if area is not None else 0.25
+    except (TypeError, ValueError):
+        return 0.25

--- a/plant_engine/compute_transpiration.py
+++ b/plant_engine/compute_transpiration.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass
 from typing import Dict, Mapping, Iterable
 
 from .utils import load_dataset, normalize_key
+from .canopy_manager import get_default_canopy_area
 from .constants import DEFAULT_ENV
 
 from plant_engine.et_model import calculate_et0, calculate_eta
@@ -75,7 +76,13 @@ def compute_transpiration(plant_profile: Mapping, env_data: Mapping) -> Dict[str
             kc = 1.0
     et_actual = calculate_eta(et0, kc)
 
-    canopy_m2 = plant_profile.get("canopy_m2", 0.25)
+    canopy_m2 = plant_profile.get("canopy_m2")
+    if canopy_m2 is None:
+        plant_type = plant_profile.get("plant_type")
+        if plant_type:
+            canopy_m2 = get_default_canopy_area(plant_type)
+        else:
+            canopy_m2 = 0.25
     mm_per_day = et_actual
     ml_per_day = mm_per_day * MM_TO_ML_PER_M2 * canopy_m2
 

--- a/tests/test_canopy_manager.py
+++ b/tests/test_canopy_manager.py
@@ -1,0 +1,13 @@
+from plant_engine.canopy_manager import list_supported_plants, get_default_canopy_area
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+    assert isinstance(plants, list)
+
+
+def test_get_default_canopy_area():
+    assert get_default_canopy_area("tomato") == 0.3
+    # Unknown plant returns default
+    assert get_default_canopy_area("unknown") == 0.25

--- a/tests/test_compute_transpiration.py
+++ b/tests/test_compute_transpiration.py
@@ -58,3 +58,15 @@ def test_compute_transpiration_missing_env_defaults():
     result = compute_transpiration(profile, {"temp_c": 25})
     # Ensure calculation succeeded and returned positive transpiration
     assert result["transpiration_ml_day"] > 0
+
+
+def test_compute_transpiration_dataset_canopy():
+    from plant_engine.canopy_manager import get_default_canopy_area
+
+    profile = {"plant_type": "tomato", "stage": "vegetative"}
+    env = {"temp_c": 25, "rh_pct": 50, "par_w_m2": 400}
+    expected = compute_transpiration(
+        {**profile, "canopy_m2": get_default_canopy_area("tomato")}, env
+    )
+    result = compute_transpiration(profile, env)
+    assert result == expected


### PR DESCRIPTION
## Summary
- add `canopy_area_guidelines.json` dataset and catalog entry
- provide `canopy_manager` utility module for canopy defaults
- integrate canopy lookup into transpiration calculations
- expose new helpers from `plant_engine.__init__`
- test canopy manager and default transpiration behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814ad4318c833098c0275ae5e9380e