### PR TITLE
Fix UTC deprecation warnings

### DIFF
--- a/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
+++ b/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ def export_grafana_data(plant_id: str, base_path: str = "plants", output_path: s
     plant_dir = base_dir / plant_id
 
     data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "threshold_summary": {},
         "sensor_summary": {},
         "irrigation_summary": {},
@@ -64,7 +64,7 @@ def export_grafana_data(plant_id: str, base_path: str = "plants", output_path: s
             return []
 
     # Calculate cutoff for last 7 days
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     cutoff_time = now - timedelta(days=7)
 
     def _filter_last_7d(entries):

--- a/custom_components/horticulture_assistant/engine/report_packager.py
+++ b/custom_components/horticulture_assistant/engine/report_packager.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from statistics import mean
 
@@ -17,7 +17,7 @@ def _load_log(log_path):
         return []
 
 def _filter_last_24h(entries):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     threshold = now - timedelta(days=1)
     return [e for e in entries if 'timestamp' in e and datetime.fromisoformat(e['timestamp']) >= threshold]
 
@@ -32,7 +32,7 @@ def build_daily_report(plant_id: str, base_path: str = "plants", output_path: st
         "sensor_summary": {},
         "visual_summary": {},
         "yield": None,
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat()
     }
 
     # Load profile and current thresholds
@@ -89,7 +89,7 @@ def build_daily_report(plant_id: str, base_path: str = "plants", output_path: st
 
     # Ensure output path exists
     Path(output_path).mkdir(parents=True, exist_ok=True)
-    out_file = Path(output_path) / f"{plant_id}_{datetime.utcnow().date()}.json"
+    out_file = Path(output_path) / f"{plant_id}_{datetime.now(timezone.utc).date()}.json"
     try:
         with open(out_file, 'w', encoding='utf-8') as f:
             json.dump(report, f, indent=2)

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from statistics import mean
 
@@ -61,7 +61,7 @@ class DailyReport:
     predicted_harvest_date: str | None = None
     yield_: float | None = None
     remaining_yield_g: float | None = None
-    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
     def as_dict(self) -> dict:
         return asdict(self)
@@ -82,7 +82,7 @@ def _load_recent_entries(log_path: Path, hours: float = 24.0) -> list[dict]:
         _LOGGER.warning("Failed to read %s: %s", log_path, exc)
         return []
 
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     recent: list[dict] = []
     for entry in data:
         ts = entry.get("timestamp")
@@ -272,7 +272,7 @@ def run_daily_cycle(
     # Save the report to a JSON file with today's date
     output_dir = Path(output_path)
     output_dir.mkdir(parents=True, exist_ok=True)
-    out_file = output_dir / f"{plant_id}_{datetime.utcnow().date()}.json"
+    out_file = output_dir / f"{plant_id}_{datetime.now(timezone.utc).date()}.json"
     try:
         with open(out_file, "w", encoding="utf-8") as f:
             json.dump(report.as_dict(), f, indent=2)

--- a/tests/test_run_daily_cycle_nutrient_analysis.py
+++ b/tests/test_run_daily_cycle_nutrient_analysis.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from custom_components.horticulture_assistant.engine.run_daily_cycle import run_daily_cycle
 
 
@@ -13,7 +13,7 @@ def test_run_daily_cycle_nutrient_analysis(tmp_path):
     plant_dir.mkdir()
     log = [
         {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "nutrient_formulation": {"N": 50, "P": 20, "K": 40}
         }
     ]


### PR DESCRIPTION
## Summary
- use timezone-aware timestamps throughout report generation modules
- update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814acf5f488330af150e8ec7def192