### PR TITLE
Add soil salinity guidelines and stress checks

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -69,6 +69,7 @@
   "soil_infiltration_rates.json": "Infiltration rates (mm/hr) by soil texture.",
   "soil_moisture_guidelines.json": "Recommended soil moisture percentages for common crops.",
   "soil_temperature_guidelines.json": "Recommended soil temperature ranges for germination and growth stages.",
+  "soil_ec_guidelines.json": "Recommended soil salinity EC ranges for common crops.",
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",

--- a/data/soil_ec_guidelines.json
+++ b/data/soil_ec_guidelines.json
@@ -1,0 +1,17 @@
+{
+  "citrus": {
+    "optimal": [1.0, 2.0],
+    "seedling": [0.8, 1.5],
+    "fruiting": [1.2, 2.2]
+  },
+  "lettuce": {
+    "optimal": [0.8, 1.2],
+    "seedling": [0.6, 1.0],
+    "harvest": [1.0, 1.5]
+  },
+  "tomato": {
+    "optimal": [1.2, 2.0],
+    "seedling": [0.8, 1.5],
+    "fruiting": [1.5, 2.5]
+  }
+}

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -27,6 +27,7 @@ QUALITY_THRESHOLDS_FILE = "environment_quality_thresholds.json"
 CO2_PRICE_FILE = "co2_prices.json"
 MOISTURE_DATA_FILE = "soil_moisture_guidelines.json"
 SOIL_TEMP_DATA_FILE = "soil_temperature_guidelines.json"
+SOIL_EC_DATA_FILE = "soil_ec_guidelines.json"
 
 # map of dataset keys to human readable labels used when recommending
 # adjustments. defined here once to avoid recreating each call.
@@ -153,6 +154,7 @@ __all__ = [
     "get_target_co2",
     "get_target_soil_moisture",
     "get_target_soil_temperature",
+    "get_target_soil_ec",
     "calculate_co2_injection",
     "recommend_co2_injection",
     "get_co2_price",
@@ -171,6 +173,7 @@ __all__ = [
     "evaluate_humidity_stress",
     "evaluate_moisture_stress",
     "evaluate_soil_temperature_stress",
+    "evaluate_soil_ec_stress",
     "get_humidity_action",
     "recommend_humidity_action",
     "evaluate_ph_stress",
@@ -210,6 +213,7 @@ _QUALITY_THRESHOLDS: Dict[str, float] = load_dataset(QUALITY_THRESHOLDS_FILE)
 _CO2_PRICES: Dict[str, float] = load_dataset(CO2_PRICE_FILE)
 _MOISTURE_DATA: Dict[str, Any] = load_dataset(MOISTURE_DATA_FILE)
 _SOIL_TEMP_DATA: Dict[str, Any] = load_dataset(SOIL_TEMP_DATA_FILE)
+_SOIL_EC_DATA: Dict[str, Any] = load_dataset(SOIL_EC_DATA_FILE)
 
 
 def get_score_weight(metric: str) -> float:
@@ -312,6 +316,7 @@ class EnvironmentOptimization:
     humidity_stress: str | None = None
     moisture_stress: str | None = None
     ph_stress: str | None = None
+    soil_ec_stress: str | None = None
     quality: str | None = None
     score: float | None = None
     water_quality: WaterQualityInfo | None = None
@@ -342,6 +347,7 @@ class EnvironmentOptimization:
             "humidity_stress": self.humidity_stress,
             "moisture_stress": self.moisture_stress,
             "ph_stress": self.ph_stress,
+            "soil_ec_stress": self.soil_ec_stress,
             "quality": self.quality,
             "score": self.score,
             "water_quality": self.water_quality.as_dict() if self.water_quality else None,
@@ -360,6 +366,7 @@ class StressFlags:
     moisture: str | None
     ph: str | None
     soil_temp: str | None = None
+    soil_ec: str | None = None
 
     def as_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -990,6 +997,12 @@ def get_target_soil_temperature(plant_type: str, stage: str | None = None) -> Ra
     return _lookup_range(_SOIL_TEMP_DATA, plant_type, stage)
 
 
+def get_target_soil_ec(plant_type: str, stage: str | None = None) -> RangeTuple | None:
+    """Return recommended soil EC range for a plant stage."""
+
+    return _lookup_range(_SOIL_EC_DATA, plant_type, stage)
+
+
 def evaluate_soil_temperature_stress(
     soil_temp_c: float | None, plant_type: str, stage: str | None = None
 ) -> str | None:
@@ -1007,6 +1020,26 @@ def evaluate_soil_temperature_stress(
         return "cold"
     if soil_temp_c > high:
         return "hot"
+    return None
+
+
+def evaluate_soil_ec_stress(
+    soil_ec_ds_m: float | None, plant_type: str, stage: str | None = None
+) -> str | None:
+    """Return 'low' or 'high' if soil EC is outside the target range."""
+
+    if soil_ec_ds_m is None:
+        return None
+
+    target = get_target_soil_ec(plant_type, stage)
+    if not target:
+        return None
+
+    low, high = target
+    if soil_ec_ds_m < low:
+        return "low"
+    if soil_ec_ds_m > high:
+        return "high"
     return None
 
 
@@ -1040,6 +1073,7 @@ def evaluate_stress_conditions(
     plant_type: str,
     stage: str | None = None,
     soil_temp_c: float | None = None,
+    soil_ec_ds_m: float | None = None,
 ) -> StressFlags:
     """Return consolidated stress flags for current conditions."""
 
@@ -1052,6 +1086,7 @@ def evaluate_stress_conditions(
         moisture=evaluate_moisture_stress(moisture_pct, plant_type, stage),
         ph=evaluate_ph_stress(ph, plant_type, stage),
         soil_temp=evaluate_soil_temperature_stress(soil_temp_c, plant_type, stage),
+        soil_ec=evaluate_soil_ec_stress(soil_ec_ds_m, plant_type, stage),
     )
 
 
@@ -1312,6 +1347,8 @@ def optimize_environment(
         readings.get("soil_moisture_pct"),
         plant_type,
         stage,
+        readings.get("soil_temp_c"),
+        readings.get("ec"),
     )
 
     quality = classify_environment_quality(readings, plant_type, stage)
@@ -1341,6 +1378,7 @@ def optimize_environment(
         humidity_stress=stress.humidity,
         moisture_stress=stress.moisture,
         ph_stress=stress.ph,
+        soil_ec_stress=stress.soil_ec,
         quality=quality,
         score=score,
         water_quality=wq,
@@ -1392,6 +1430,8 @@ def summarize_environment(
         readings.get("soil_moisture_pct"),
         plant_type,
         stage,
+        readings.get("soil_temp_c"),
+        readings.get("ec"),
     )
 
     water_info = None

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -36,6 +36,7 @@ from plant_engine.environment_manager import (
     evaluate_ph_stress,
     evaluate_stress_conditions,
     evaluate_soil_temperature_stress,
+    evaluate_soil_ec_stress,
     score_environment,
     score_environment_series,
     score_environment_components,
@@ -52,6 +53,7 @@ from plant_engine.environment_manager import (
     summarize_environment_series,
     clear_environment_cache,
     get_target_soil_temperature,
+    get_target_soil_ec,
 )
 
 
@@ -573,6 +575,16 @@ def test_evaluate_soil_temperature_stress():
     assert evaluate_soil_temperature_stress(18, "citrus") == "cold"
     assert evaluate_soil_temperature_stress(30, "citrus") == "hot"
     assert evaluate_soil_temperature_stress(35, "citrus") == "hot"
+
+
+def test_get_target_soil_ec():
+    assert get_target_soil_ec("lettuce", "seedling") == (0.6, 1.0)
+
+
+def test_evaluate_soil_ec_stress():
+    assert evaluate_soil_ec_stress(0.5, "lettuce", "seedling") == "low"
+    assert evaluate_soil_ec_stress(1.1, "lettuce", "seedling") == "high"
+    assert evaluate_soil_ec_stress(0.8, "lettuce", "seedling") is None
 
 
 def test_evaluate_stress_conditions():


### PR DESCRIPTION
## Summary
- include soil EC dataset and register in dataset catalog
- extend environment manager to handle soil EC ranges
- evaluate soil EC stress in environment summaries
- cover new behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814ac6cee48330b5a1a83c1cb0600c