### PR TITLE
Add pesticide withdrawal calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Key reference datasets reside in the `data/` directory:
 - `nutrient_leaching_rates.json` – estimated fraction of nutrients lost to leaching
 - `yield/` – per‑plant yield logs created during operation
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations
+- `pesticide_withdrawal_days.json` – required wait time before harvest after pesticide use
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
 - `dataset_catalog.json` – short descriptions of the bundled datasets for quick reference

--- a/data/pesticide_withdrawal_days.json
+++ b/data/pesticide_withdrawal_days.json
@@ -1,0 +1,6 @@
+{
+  "imidacloprid": 7,
+  "spinosad": 1,
+  "pyrethrin": 0,
+  "sulfur": 0
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -44,6 +44,10 @@ from .pest_monitor import (
     assess_pest_pressure,
     recommend_threshold_actions,
 )
+from .pesticide_manager import (
+    get_withdrawal_days,
+    earliest_harvest_date,
+)
 from .disease_monitor import (
     get_disease_thresholds,
     assess_disease_pressure,
@@ -354,6 +358,8 @@ __all__ = [
     "get_toxicity_thresholds",
     "check_toxicities",
     "get_guideline_summary",
+    "get_withdrawal_days",
+    "earliest_harvest_date",
     "DailyReport",
     "load_profile",
     "TranspirationMetrics",

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -1,0 +1,38 @@
+"""Utilities for pesticide withdrawal periods."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Dict
+
+from .utils import load_dataset
+
+DATA_FILE = "pesticide_withdrawal_days.json"
+
+# Cached withdrawal data mapping product names to waiting days
+_DATA: Dict[str, int] = load_dataset(DATA_FILE)
+
+__all__ = ["get_withdrawal_days", "earliest_harvest_date"]
+
+
+def get_withdrawal_days(product: str) -> int | None:
+    """Return required waiting days after applying ``product``.
+
+    Parameters
+    ----------
+    product: str
+        Pesticide or treatment identifier.
+
+    Returns
+    -------
+    int | None
+        Days to wait before harvesting or ``None`` if unknown.
+    """
+    return _DATA.get(product.lower())
+
+
+def earliest_harvest_date(product: str, application_date: date) -> date | None:
+    """Return earliest harvest date after pesticide application."""
+    days = get_withdrawal_days(product)
+    if days is None:
+        return None
+    return application_date + timedelta(days=days)

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -1,0 +1,19 @@
+import datetime
+
+from plant_engine.pesticide_manager import get_withdrawal_days, earliest_harvest_date
+
+
+def test_get_withdrawal_days_known():
+    assert get_withdrawal_days("spinosad") == 1
+    assert get_withdrawal_days("imidacloprid") == 7
+
+
+def test_get_withdrawal_days_unknown():
+    assert get_withdrawal_days("foo") is None
+
+
+def test_earliest_harvest_date():
+    date = datetime.date(2024, 6, 1)
+    harvest = earliest_harvest_date("spinosad", date)
+    assert harvest == date + datetime.timedelta(days=1)
+    assert earliest_harvest_date("foo", date) is None


### PR DESCRIPTION
## Summary
- add `pesticide_withdrawal_days.json` dataset
- expose new `pesticide_manager` helper to track harvest waiting periods
- export helper via `plant_engine.__init__`
- document new dataset in README
- test pesticide withdrawal utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68814d517fec83309359eb8ae6f71445