### PR TITLE
Refactor fertilizer inventory and add tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/fertilizer_inventory.py
+++ b/custom_components/horticulture_assistant/utils/fertilizer_inventory.py
@@ -1,88 +1,116 @@
-from typing import Dict, List, Optional
+"""Simple fertilizer inventory tracking utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Dict, List, Optional
 
 
+@dataclass
+class FertilizerListing:
+    """External price listing for a fertilizer product."""
+
+    product_id: str
+    cost_per_unit: float
+    vendor: str | None = None
+    unit: str = "g"
+
+
+@dataclass
+class PriceEntry:
+    """Historical price information."""
+
+    vendor: str
+    unit_price: float
+    size: str
+    date: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class UsageRecord:
+    """Record of fertilizer usage."""
+
+    amount_used: float
+    unit: str
+    zone: str
+    date: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
 class FertilizerProduct:
-    def __init__(
+    """Representation of a fertilizer with pricing and usage details."""
+
+    product_id: str
+    name: str
+    form: str
+    unit: str
+    derived_from: Dict[str, float]
+    ph: float | None = None
+    ec: float | None = None
+    temp_sensitive_ingredients: List[str] = field(default_factory=list)
+    expiration: datetime | None = None
+    manufactured: datetime | None = None
+    price_history: List[PriceEntry] = field(default_factory=list)
+    usage_log: List[UsageRecord] = field(default_factory=list)
+
+    def add_price_entry(
         self,
-        product_id: str,
-        name: str,
-        form: str,  # "liquid" or "solid"
-        unit: str,  # e.g., "L", "mL", "kg", "g", "oz", "gal"
-        derived_from: Dict[str, float],
-        ph: Optional[float] = None,
-        ec: Optional[float] = None,
-        temp_sensitive_ingredients: Optional[List[str]] = None,
-        expiration: Optional[datetime] = None,
-        manufactured: Optional[datetime] = None,
-    ):
-        self.product_id = product_id
-        self.name = name
-        self.form = form
-        self.unit = unit
-        self.derived_from = derived_from  # {"Ammonium Nitrate": 120.0, "Magnesium Sulfate Heptahydrate": 1000.0}
-        self.ph = ph
-        self.ec = ec
-        self.expiration = expiration
-        self.manufactured = manufactured
-        self.temp_sensitive_ingredients = temp_sensitive_ingredients or []
-
-        self.price_history: List[Dict] = []  # [{"vendor": "HydroWorld", "unit_price": 18.99, "size": "1L", "date": datetime}]
-        self.usage_log: List[Dict] = []  # [{"date": datetime, "amount_used": 200, "unit": "mL", "zone": "GH1"}]
-
-    def add_price_entry(self, vendor: str, unit_price: float, size: str, date: Optional[datetime] = None):
-        entry = {
-            "vendor": vendor,
-            "unit_price": round(unit_price, 2),
-            "size": size,
-            "date": date or datetime.now()
-        }
+        vendor: str,
+        unit_price: float,
+        size: str,
+        date: Optional[datetime] = None,
+    ) -> None:
+        entry = PriceEntry(vendor=vendor, unit_price=round(unit_price, 2), size=size, date=date or datetime.now())
         self.price_history.append(entry)
 
-    def log_usage(self, amount_used: float, unit: str, zone: str):
-        self.usage_log.append({
-            "date": datetime.now(),
-            "amount_used": amount_used,
-            "unit": unit,
-            "zone": zone
-        })
+    def log_usage(self, amount_used: float, unit: str, zone: str) -> None:
+        self.usage_log.append(UsageRecord(amount_used=amount_used, unit=unit, zone=zone))
 
-    def get_latest_price(self) -> Optional[Dict]:
+    def get_latest_price(self) -> Optional[PriceEntry]:
         if not self.price_history:
             return None
-        return sorted(self.price_history, key=lambda x: x["date"], reverse=True)[0]
+        return sorted(self.price_history, key=lambda x: x.date, reverse=True)[0]
 
     def is_expired(self) -> bool:
         return self.expiration is not None and datetime.now() > self.expiration
 
     def needs_temp_protection(self, current_temp: float) -> bool:
-        return any([
-            ingr for ingr in self.temp_sensitive_ingredients
-            if current_temp < 5 or current_temp > 30  # default temp sensitivity bounds
-        ])
+        return any(current_temp < 5 or current_temp > 30 for _ in self.temp_sensitive_ingredients)
 
 
+@dataclass
 class FertilizerInventory:
-    def __init__(self):
-        self.products: Dict[str, FertilizerProduct] = {}
+    """Container for :class:`FertilizerProduct` objects."""
 
-    def add_product(self, product: FertilizerProduct):
+    products: Dict[str, FertilizerProduct] = field(default_factory=dict)
+
+    def add_product(self, product: FertilizerProduct) -> None:
         self.products[product.product_id] = product
 
     def get_product(self, product_id: str) -> Optional[FertilizerProduct]:
         return self.products.get(product_id)
 
-    def remove_product(self, product_id: str):
-        if product_id in self.products:
-            del self.products[product_id]
+    def remove_product(self, product_id: str) -> None:
+        self.products.pop(product_id, None)
 
     def find_by_name(self, name: str) -> List[FertilizerProduct]:
-        return [prod for prod in self.products.values() if name.lower() in prod.name.lower()]
+        query = name.lower()
+        return [prod for prod in self.products.values() if query in prod.name.lower()]
 
     def find_expiring_products(self, days_before_expiry: int = 30) -> List[FertilizerProduct]:
-        today = datetime.now()
-        threshold = today.replace(hour=0, minute=0, second=0, microsecond=0)
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         return [
-            p for p in self.products.values()
-            if p.expiration and (p.expiration - threshold).days <= days_before_expiry
+            p
+            for p in self.products.values()
+            if p.expiration and (p.expiration - today).days <= days_before_expiry
         ]
+
+
+__all__ = [
+    "FertilizerListing",
+    "PriceEntry",
+    "UsageRecord",
+    "FertilizerProduct",
+    "FertilizerInventory",
+]

--- a/tests/test_fertilizer_inventory.py
+++ b/tests/test_fertilizer_inventory.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+
+from custom_components.horticulture_assistant.utils.fertilizer_inventory import (
+    FertilizerProduct,
+    FertilizerInventory,
+    FertilizerListing,
+)
+
+
+def test_inventory_basic_operations():
+    product = FertilizerProduct(
+        product_id="grow",
+        name="Grow",
+        form="liquid",
+        unit="L",
+        derived_from={"N": 0.05},
+        expiration=datetime.now() + timedelta(days=10),
+    )
+    inv = FertilizerInventory()
+    inv.add_product(product)
+
+    assert inv.get_product("grow") is product
+    assert inv.find_by_name("grow") == [product]
+    assert inv.find_expiring_products() == [product]
+
+    inv.remove_product("grow")
+    assert inv.get_product("grow") is None
+
+
+def test_product_price_and_usage():
+    product = FertilizerProduct(
+        product_id="test",
+        name="Test",
+        form="solid",
+        unit="g",
+        derived_from={},
+    )
+    product.add_price_entry("A", 1.0, "1kg")
+    product.add_price_entry("B", 2.0, "1kg")
+    latest = product.get_latest_price()
+    assert latest.vendor == "B"
+
+    product.log_usage(100, "g", "GH1")
+    assert len(product.usage_log) == 1
+    assert not product.is_expired()
+
+


### PR DESCRIPTION
## Summary
- refactor fertilizer inventory utilities
- add dataclasses for product tracking and pricing
- add tests for fertilizer inventory features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814d608b508330aa01f051180165e0