### PR TITLE
Improve performance with caching and slots

### DIFF
--- a/plant_engine/compute_transpiration.py
+++ b/plant_engine/compute_transpiration.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from functools import lru_cache
 from typing import Dict, Mapping, Iterable
 
 from .utils import load_dataset, normalize_key
@@ -24,7 +25,7 @@ __all__ = [
 MM_TO_ML_PER_M2 = 1000
 
 
-@dataclass
+@dataclass(slots=True)
 class TranspirationMetrics:
     """Container for ET and transpiration calculations."""
 
@@ -37,8 +38,12 @@ class TranspirationMetrics:
         return asdict(self)
 
 
+@lru_cache(maxsize=None)
 def lookup_crop_coefficient(plant_type: str, stage: str | None = None) -> float:
-    """Return Kc value from :data:`crop_coefficients.json` or ``1.0``."""
+    """Return crop coefficient for ``plant_type`` and ``stage``.
+
+    Results are cached to avoid repeated dataset lookups.
+    """
     plant = _KC_DATA.get(normalize_key(plant_type))
     if not plant:
         return 1.0

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -75,7 +75,7 @@ def _parse_range(value: Iterable[float]) -> RangeTuple | None:
     return (low, high)
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True, frozen=True)
 class EnvironmentGuidelines:
     """Environmental target ranges for a plant stage."""
 
@@ -279,7 +279,7 @@ def actual_vapor_pressure(temp_c: float, humidity_pct: float) -> float:
     return saturation_vapor_pressure(temp_c) * humidity_pct / 100
 
 
-@dataclass
+@dataclass(slots=True)
 class EnvironmentMetrics:
     """Calculated environmental metrics."""
 
@@ -296,7 +296,7 @@ class EnvironmentMetrics:
         return asdict(self)
 
 
-@dataclass
+@dataclass(slots=True)
 class EnvironmentOptimization:
     """Consolidated environment optimization result."""
 
@@ -1204,8 +1204,12 @@ def recommend_co2_injection(
     return calculate_co2_injection(current_ppm, target, volume_m3)
 
 
+@lru_cache(maxsize=None)
 def get_co2_price(method: str) -> float:
-    """Return price per kg of CO₂ for ``method``."""
+    """Return price per kg of CO₂ for ``method``.
+
+    The result is cached for efficiency.
+    """
     try:
         return float(_CO2_PRICES.get(normalize_key(method), 0.0))
     except (TypeError, ValueError):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,29 @@
+from plant_engine.compute_transpiration import lookup_crop_coefficient
+from plant_engine.environment_manager import (
+    get_co2_price,
+    EnvironmentGuidelines,
+    EnvironmentMetrics,
+    EnvironmentOptimization,
+)
+
+
+def test_lookup_crop_coefficient_cache():
+    lookup_crop_coefficient.cache_clear()
+    lookup_crop_coefficient("lettuce", "vegetative")
+    hits = lookup_crop_coefficient.cache_info().hits
+    lookup_crop_coefficient("lettuce", "vegetative")
+    assert lookup_crop_coefficient.cache_info().hits == hits + 1
+
+
+def test_get_co2_price_cache():
+    get_co2_price.cache_clear()
+    get_co2_price("tank")
+    hits = get_co2_price.cache_info().hits
+    get_co2_price("tank")
+    assert get_co2_price.cache_info().hits == hits + 1
+
+
+def test_dataclass_slots():
+    assert hasattr(EnvironmentGuidelines, "__slots__")
+    assert hasattr(EnvironmentMetrics, "__slots__")
+    assert hasattr(EnvironmentOptimization, "__slots__")


### PR DESCRIPTION
## Summary
- optimize dataclasses used for environment metrics with `slots`
- cache crop coefficient and CO₂ price lookups
- test dataclass slots and cache usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814dac7d388330a0781bc56972664b