### PR TITLE
Add germination dataset and helper function

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -14,6 +14,7 @@
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",
+  "germination_duration.json": "Typical days from sowing to germination by crop.",
   "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",
   "light_dli_guidelines.json": "Daily Light Integral targets for growth stages.",
   "vpd_guidelines.json": "Vapor pressure deficit targets for growth stages.",

--- a/data/germination_duration.json
+++ b/data/germination_duration.json
@@ -1,0 +1,7 @@
+{
+  "citrus": 14,
+  "lettuce": 7,
+  "tomato": 5,
+  "pepper": 7,
+  "arugula": 7
+}

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -8,11 +8,13 @@ from datetime import date, timedelta
 from .utils import load_dataset, normalize_key
 
 DATA_FILE = "growth_stages.json"
+GERMINATION_FILE = "germination_duration.json"
 
 
 
 # Load growth stage dataset once. ``load_dataset`` handles caching.
 _DATA: Dict[str, Dict[str, Any]] = load_dataset(DATA_FILE)
+_GERMINATION: Dict[str, int] = load_dataset(GERMINATION_FILE)
 
 
 
@@ -26,6 +28,7 @@ __all__ = [
     "stage_progress",
     "days_until_harvest",
     "predict_next_stage_date",
+    "get_germination_duration",
 ]
 
 
@@ -154,3 +157,12 @@ def predict_next_stage_date(
     if duration is None:
         return None
     return stage_start + timedelta(days=duration)
+
+
+def get_germination_duration(plant_type: str) -> int | None:
+    """Return default days to germination for ``plant_type`` if known."""
+
+    value = _GERMINATION.get(normalize_key(plant_type))
+    if isinstance(value, (int, float)):
+        return int(value)
+    return None

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -10,6 +10,7 @@ from plant_engine.growth_stage import (
     stage_progress,
     days_until_harvest,
     predict_next_stage_date,
+    get_germination_duration,
 )
 
 
@@ -87,5 +88,11 @@ def test_estimate_stage_from_date():
 
     with pytest.raises(ValueError):
         estimate_stage_from_date("tomato", cur, start)
+
+
+def test_get_germination_duration():
+    assert get_germination_duration("tomato") == 5
+    assert get_germination_duration("lettuce") == 7
+    assert get_germination_duration("unknown") is None
 
 


### PR DESCRIPTION
## Summary
- add new dataset `germination_duration.json`
- document new dataset in `dataset_catalog.json`
- load the dataset in `growth_stage` module and expose `get_germination_duration`
- test germination duration helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814d5f0bac8330b5fd638b73a293da