### PR TITLE
Enhance environment utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **CO₂ Injection Calculator**: `calculate_co2_injection` estimates the grams of CO₂ needed to hit the target range based on greenhouse volume.
 - **Environment Summary**: `summarize_environment` returns the quality rating
   alongside recommended adjustments and calculated metrics in one step.
+- **Advanced Setpoints**: `suggest_environment_setpoints_advanced` derives
+  humidity targets from VPD guidelines when direct values are unavailable.
 - **Water Quality Scoring**: `score_water_quality` evaluates irrigation water and
   returns a 0‑100 rating based on toxicity thresholds.
 - **Guideline Summary**: `get_guideline_summary` consolidates environment,

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -135,6 +135,7 @@ __all__ = [
     "score_environment_series",
     "score_environment_components",
     "suggest_environment_setpoints",
+    "suggest_environment_setpoints_advanced",
     "saturation_vapor_pressure",
     "actual_vapor_pressure",
     "calculate_vpd",
@@ -669,6 +670,32 @@ def suggest_environment_setpoints(
     for key, bounds in targets.items():
         if isinstance(bounds, (list, tuple)) and len(bounds) == 2:
             setpoints[key] = round((bounds[0] + bounds[1]) / 2, 2)
+    return setpoints
+
+
+def suggest_environment_setpoints_advanced(
+    plant_type: str, stage: str | None = None
+) -> Dict[str, float]:
+    """Return midpoint setpoints with VPD fallback for humidity."""
+
+    setpoints = suggest_environment_setpoints(plant_type, stage)
+    if "humidity_pct" not in setpoints:
+        targets = get_environmental_targets(plant_type, stage)
+        temp = targets.get("temp_c")
+        vpd = get_target_vpd(plant_type, stage)
+        if (
+            isinstance(temp, (list, tuple))
+            and len(temp) == 2
+            and vpd is not None
+        ):
+            temp_mid = (float(temp[0]) + float(temp[1])) / 2
+            vpd_mid = (vpd[0] + vpd[1]) / 2
+            try:
+                setpoints["humidity_pct"] = humidity_for_target_vpd(
+                    temp_mid, vpd_mid
+                )
+            except ValueError:
+                pass
     return setpoints
 
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -4,6 +4,7 @@ from plant_engine.environment_manager import (
     get_environmental_targets,
     recommend_environment_adjustments,
     suggest_environment_setpoints,
+    suggest_environment_setpoints_advanced,
     saturation_vapor_pressure,
     actual_vapor_pressure,
     calculate_vpd,
@@ -109,6 +110,21 @@ def test_suggest_environment_setpoints():
     assert setpoints["humidity_pct"] == 70
     assert setpoints["light_ppfd"] == 225
     assert setpoints["co2_ppm"] == 500
+
+
+def test_suggest_environment_setpoints_advanced_vpd_fallback(monkeypatch):
+    import plant_engine.environment_manager as em
+
+    monkeypatch.setattr(
+        em,
+        "get_environmental_targets",
+        lambda *a, **k: {"temp_c": [20, 24]},
+    )
+    monkeypatch.setattr(em, "get_target_vpd", lambda *a, **k: (0.8, 1.2))
+
+    result = suggest_environment_setpoints_advanced("foo", "bar")
+    expected = em.humidity_for_target_vpd(22.0, 1.0)
+    assert result["humidity_pct"] == expected
 
 
 def test_vapor_pressure_helpers():


### PR DESCRIPTION
## Summary
- extend environment utilities with `suggest_environment_setpoints_advanced`
- document the new helper in the feature list
- test humidity fallback behaviour using VPD guidelines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814d547d148330a48f810e9a1df67e