### PR TITLE
Improve environment temp normalization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -119,9 +119,9 @@ def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, f
             val = float(value)
         except (TypeError, ValueError):
             continue
-        if canonical == "temp_f":
+        if canonical in {"temp_f", "soil_temp_f"}:
             val = (val - 32) * 5 / 9
-            canonical = "temp_c"
+            canonical = canonical.replace("_f", "_c")
         normalized[canonical] = val
     return normalized
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -472,6 +472,11 @@ def test_normalize_environment_readings_temp_fahrenheit():
     result = normalize_environment_readings(data)
     assert result == {"temp_c": 30.0}
 
+def test_normalize_environment_readings_soil_temp_fahrenheit():
+    data = {"soil_temp_f": 77}
+    result = normalize_environment_readings(data)
+    assert result == {"soil_temp_c": 25.0}
+
 
 def test_normalize_environment_readings_unknown_key():
     result = normalize_environment_readings({"foo": 1})


### PR DESCRIPTION
## Summary
- convert soil temperature readings in Fahrenheit
- test soil temperature alias

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814d5bf09c833087f7f635a51cd44e