### PR TITLE
Improve thermal time utils and approval manager

### DIFF
--- a/data/gdd_requirements.json
+++ b/data/gdd_requirements.json
@@ -13,5 +13,23 @@
     "vegetative": 300,
     "flowering": 450,
     "fruiting": 600
+  },
+  "tomato": {
+    "vegetative": 300,
+    "flowering": 450,
+    "fruiting": 700
+  },
+  "pepper": {
+    "vegetative": 350,
+    "flowering": 500,
+    "fruiting": 700
+  },
+  "basil": {
+    "vegetative": 200,
+    "harvest": 300
+  },
+  "spinach": {
+    "vegetative": 150,
+    "harvest": 250
   }
 }

--- a/tests/test_thermal_time.py
+++ b/tests/test_thermal_time.py
@@ -23,3 +23,9 @@ def test_accumulate_gdd_series():
     series = [(10, 20)] * 5
     total = thermal_time.accumulate_gdd_series(series, base_temp_c=10)
     assert total == 25.0
+
+
+def test_estimate_days_to_stage():
+    temps = [(20, 30)] * 60
+    days = thermal_time.estimate_days_to_stage("tomato", "fruiting", temps)
+    assert isinstance(days, int) and 0 < days <= 60

--- a/tests/test_threshold_approval_manager.py
+++ b/tests/test_threshold_approval_manager.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from custom_components.horticulture_assistant.utils import threshold_approval_manager as tam
+
+
+class DummyConfig:
+    def __init__(self, base: Path):
+        self._base = Path(base)
+
+    def path(self, *parts: str) -> str:
+        return str(self._base.joinpath(*parts))
+
+
+class DummyHass:
+    def __init__(self, base: Path):
+        self.config = DummyConfig(base)
+
+
+def test_apply_threshold_approvals(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    plants_dir = tmp_path / "plants"
+    data_dir.mkdir()
+    plants_dir.mkdir()
+
+    pending = {
+        "plant1": {
+            "changes": {
+                "light": {"previous_value": 100, "proposed_value": 150, "status": "approved"},
+                "humidity": {"previous_value": 50, "proposed_value": 55, "status": "pending"},
+            }
+        }
+    }
+    (data_dir / "pending_approvals.json").write_text(json.dumps(pending))
+
+    profile = {"thresholds": {"light": 100, "humidity": 50}}
+    (plants_dir / "plant1.json").write_text(json.dumps(profile))
+
+    hass = DummyHass(tmp_path)
+
+    tam.apply_threshold_approvals(hass)
+
+    updated = json.loads((plants_dir / "plant1.json").read_text())
+    assert updated["thresholds"]["light"] == 150
+    assert updated["thresholds"]["humidity"] == 50
+
+    remaining = json.loads((data_dir / "pending_approvals.json").read_text())
+    assert "light" not in remaining["plant1"]["changes"]


### PR DESCRIPTION
## Summary
- expand GDD requirements dataset
- add `estimate_days_to_stage` helper in `thermal_time`
- refactor `threshold_approval_manager` into smaller helpers
- add unit tests for new approval manager logic
- update thermal time tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688153124ca083309662482085a5b58b