### PR TITLE
Refactor dataset utilities and expand catalog

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -84,5 +84,9 @@
   "fertigation_intervals.json": "Recommended days between fertigation events per stage.",
   "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
   "companion_plants.json": "Companion planting recommendations.",
+  "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
+  "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
+  "cold_stress_thresholds.json": "Temperature levels causing cold stress.",
+  "disease_monitoring_intervals.json": "Recommended days between disease scouting events.",
   "reference_et0.json": "Monthly reference ET0 values in mm/day"
 }

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -1,7 +1,14 @@
-"""Helpers for discovering and describing bundled datasets."""
+"""Dataset discovery utilities.
+
+This module exposes helpers for listing available JSON datasets bundled with
+the project. A :class:`DatasetCatalog` dataclass manages dataset paths and uses
+``lru_cache`` so repeated lookups avoid hitting the filesystem.
+"""
+
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List
@@ -10,6 +17,7 @@ DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 CATALOG_FILE = DATA_DIR / "dataset_catalog.json"
 
 __all__ = [
+    "DatasetCatalog",
     "list_datasets",
     "get_dataset_description",
     "list_dataset_info",
@@ -17,58 +25,85 @@ __all__ = [
 ]
 
 
-@lru_cache(maxsize=None)
+@dataclass(slots=True, frozen=True)
+class DatasetCatalog:
+    """Helper object for discovering bundled datasets."""
+
+    base_dir: Path = DATA_DIR
+    catalog_file: Path = CATALOG_FILE
+
+    @lru_cache(maxsize=None)
+    def list_datasets(self) -> List[str]:
+        """Return relative paths of available JSON datasets."""
+
+        datasets: List[str] = []
+        for path in self.base_dir.rglob("*.json"):
+            if path.name == self.catalog_file.name:
+                continue
+            datasets.append(path.relative_to(self.base_dir).as_posix())
+
+        return sorted(datasets)
+
+    @lru_cache(maxsize=None)
+    def _load_catalog(self) -> Dict[str, str]:
+        if self.catalog_file.exists():
+            with open(self.catalog_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    return {str(k): str(v) for k, v in data.items()}
+        return {}
+
+    def get_description(self, name: str) -> str | None:
+        """Return the human readable description for ``name`` if known."""
+
+        return self._load_catalog().get(name)
+
+    @lru_cache(maxsize=None)
+    def list_info(self) -> Dict[str, str]:
+        """Return mapping of dataset names to descriptions."""
+
+        names = self.list_datasets()
+        catalog = self._load_catalog()
+        return {n: catalog.get(n, "") for n in names}
+
+    def search(self, term: str) -> Dict[str, str]:
+        """Return datasets matching ``term`` in the name or description."""
+
+        if not term:
+            return {}
+
+        term = term.lower()
+        info = self.list_info()
+        result: Dict[str, str] = {}
+        for name, desc in info.items():
+            if term in name.lower() or term in desc.lower():
+                result[name] = desc
+        return result
+
+
+DEFAULT_CATALOG = DatasetCatalog()
+
+
 def list_datasets() -> List[str]:
-    """Return relative paths of available JSON datasets.
+    """Return relative paths of available JSON datasets."""
 
-    Files within subdirectories of :data:`DATA_DIR` are included so long as
-    they end with ``.json``. The catalog file itself is excluded.
-    """
-
-    datasets: List[str] = []
-    for path in DATA_DIR.rglob("*.json"):
-        if path.name == CATALOG_FILE.name:
-            continue
-        datasets.append(path.relative_to(DATA_DIR).as_posix())
-
-    return sorted(datasets)
-
-
-@lru_cache(maxsize=None)
-def _load_catalog() -> Dict[str, str]:
-    if CATALOG_FILE.exists():
-        with open(CATALOG_FILE, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            if isinstance(data, dict):
-                return {str(k): str(v) for k, v in data.items()}
-    return {}
+    return DEFAULT_CATALOG.list_datasets()
 
 
 def get_dataset_description(name: str) -> str | None:
     """Return the human readable description for ``name`` if known."""
-    return _load_catalog().get(name)
+
+    return DEFAULT_CATALOG.get_description(name)
 
 
-@lru_cache(maxsize=None)
 def list_dataset_info() -> Dict[str, str]:
     """Return mapping of dataset names to descriptions."""
 
-    names = list_datasets()
-    catalog = _load_catalog()
-    return {n: catalog.get(n, "") for n in names}
+    return DEFAULT_CATALOG.list_info()
 
 
 def search_datasets(term: str) -> Dict[str, str]:
     """Return datasets matching ``term`` in the name or description."""
 
-    if not term:
-        return {}
-
-    term = term.lower()
-    info = list_dataset_info()
-    result: Dict[str, str] = {}
-    for name, desc in info.items():
-        if term in name.lower() or term in desc.lower():
-            result[name] = desc
-    return result
+    return DEFAULT_CATALOG.search(term)
 

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -10,6 +10,7 @@ def test_list_datasets_contains_known():
     assert "nutrient_guidelines.json" in datasets
     assert "irrigation_intervals.json" in datasets
     assert "soil_moisture_guidelines.json" in datasets
+    assert "disease_monitoring_intervals.json" in datasets
     assert "reference_et0.json" in datasets
     assert "dataset_catalog.json" not in datasets
 
@@ -38,8 +39,11 @@ def test_get_dataset_description():
     desc6 = get_dataset_description("soil_moisture_guidelines.json")
     assert "moisture" in desc6
 
-    desc7 = get_dataset_description("reference_et0.json")
-    assert "ET0" in desc7 or "et0" in desc7.lower()
+    desc7 = get_dataset_description("disease_monitoring_intervals.json")
+    assert "disease" in desc7
+
+    desc8 = get_dataset_description("reference_et0.json")
+    assert "ET0" in desc8 or "et0" in desc8.lower()
 
 
 def test_search_datasets():


### PR DESCRIPTION
## Summary
- refactor `plant_engine.datasets` into a `DatasetCatalog` helper class
- expose wrapper functions for existing API
- document additional datasets in `dataset_catalog.json`
- test coverage for new catalog entries

## Testing
- `pytest -q tests/test_dataset_catalog.py -s`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881532a614c8330b9904f1bc5f3b53d