### PR TITLE
Add integrated monitoring schedule helper

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -56,6 +56,7 @@ from .disease_monitor import (
     estimate_disease_risk,
     generate_disease_report,
 )
+from .integrated_monitor import generate_integrated_monitoring_schedule
 from .disease_manager import (
     get_disease_guidelines,
     recommend_treatments as recommend_disease_treatments,
@@ -263,6 +264,7 @@ __all__ = [
     "recommend_disease_threshold_actions",
     "estimate_disease_risk",
     "generate_disease_report",
+    "generate_integrated_monitoring_schedule",
     "recommend_fertigation_schedule",
     "recommend_correction_schedule",
     "get_fertilizer_purity",

--- a/plant_engine/integrated_monitor.py
+++ b/plant_engine/integrated_monitor.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Utilities for combined pest and disease monitoring schedules."""
+
+from datetime import date
+from typing import List
+
+from . import pest_monitor, disease_monitor
+
+__all__ = ["generate_integrated_monitoring_schedule"]
+
+
+def generate_integrated_monitoring_schedule(
+    plant_type: str,
+    stage: str | None,
+    start: date,
+    events: int,
+) -> List[date]:
+    """Return merged pest and disease monitoring dates.
+
+    The schedule combines pest and disease intervals, sorted and deduplicated.
+    Only the first ``events`` dates are returned.
+    """
+    if events <= 0:
+        return []
+
+    pest = pest_monitor.generate_monitoring_schedule(plant_type, stage, start, events)
+    disease = disease_monitor.generate_monitoring_schedule(plant_type, stage, start, events)
+    combined = sorted(set(pest + disease))
+    return combined[:events]

--- a/tests/test_integrated_monitor.py
+++ b/tests/test_integrated_monitor.py
@@ -1,0 +1,19 @@
+from datetime import date
+
+from plant_engine.integrated_monitor import generate_integrated_monitoring_schedule
+
+
+def test_generate_integrated_monitoring_schedule():
+    start = date(2023, 1, 1)
+    sched = generate_integrated_monitoring_schedule("citrus", "fruiting", start, 4)
+    assert sched == [
+        date(2023, 1, 4),
+        date(2023, 1, 5),
+        date(2023, 1, 7),
+        date(2023, 1, 9),
+    ]
+
+
+def test_generate_integrated_monitoring_schedule_unknown():
+    start = date(2023, 1, 1)
+    assert generate_integrated_monitoring_schedule("unknown", None, start, 3) == []


### PR DESCRIPTION
## Summary
- provide utility for combined pest/disease monitoring dates
- expose helper from package API
- test integrated monitoring schedule calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815324255c8330afbf7acf32a7c095