### PR TITLE
Add foliar spray volume support

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -39,6 +39,7 @@
   "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",
   "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
   "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",
+  "foliar_spray_volume.json": "Recommended foliar spray volume per plant in mL.",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",

--- a/data/foliar_spray_volume.json
+++ b/data/foliar_spray_volume.json
@@ -1,0 +1,4 @@
+{
+  "tomato": {"vegetative": 50, "flowering": 60, "optimal": 55},
+  "lettuce": {"vegetative": 30, "optimal": 30}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -75,6 +75,8 @@ from .fertigation import (
     generate_cycle_fertigation_plan,
     generate_cycle_fertigation_plan_with_cost,
     recommend_stock_solution_injection,
+    get_foliar_spray_volume,
+    estimate_spray_solution_volume,
 )
 from .rootzone_model import (
     estimate_rootzone_depth,
@@ -274,6 +276,8 @@ __all__ = [
     "generate_cycle_fertigation_plan",
     "generate_cycle_fertigation_plan_with_cost",
     "recommend_stock_solution_injection",
+    "get_foliar_spray_volume",
+    "estimate_spray_solution_volume",
     "calculate_deficiencies",
     "calculate_micro_deficiencies",
     "get_deficiency_treatment",

--- a/tests/test_foliar_spray_volume.py
+++ b/tests/test_foliar_spray_volume.py
@@ -1,0 +1,19 @@
+from plant_engine.fertigation import (
+    get_foliar_spray_volume,
+    estimate_spray_solution_volume,
+)
+
+
+def test_get_foliar_spray_volume():
+    assert get_foliar_spray_volume("tomato", "vegetative") == 50
+    assert get_foliar_spray_volume("tomato", "flowering") == 60
+    assert get_foliar_spray_volume("tomato") == 55
+    assert get_foliar_spray_volume("unknown") is None
+
+
+def test_estimate_spray_solution_volume():
+    vol = estimate_spray_solution_volume(10, "tomato", "vegetative")
+    assert vol == 0.5
+    assert estimate_spray_solution_volume(5, "lettuce") == 0.15
+    assert estimate_spray_solution_volume(3, "unknown") is None
+


### PR DESCRIPTION
## Summary
- add foliar_spray_volume dataset and document in catalog
- expose foliar spray volume helpers in fertigation API
- export new helpers via plant_engine package
- test foliar spray volume helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881531879b08330b4aac10e064ded54