### PR TITLE
Enhance daily report with stage progress

### DIFF
--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -28,6 +28,7 @@ def test_run_daily_cycle_extended(tmp_path):
     assert report["beneficial_insects"]["aphids"][0] == "ladybugs"
     assert report["pest_severity"]["aphids"] == "moderate"
     assert report["predicted_harvest_date"] == "2025-05-01"
+    assert report["stage_progress_pct"] is not None
     assert "environment_optimization" in report
     assert "fertigation_schedule" in report
     assert "fertigation_cost" in report

--- a/tests/test_run_daily_cycle_utils.py
+++ b/tests/test_run_daily_cycle_utils.py
@@ -1,0 +1,12 @@
+import json
+from datetime import datetime, timedelta, timezone
+from custom_components.horticulture_assistant.engine.run_daily_cycle import _load_recent_entries
+
+def test_load_recent_entries(tmp_path):
+    log = tmp_path / "log.json"
+    now = datetime.now(timezone.utc)
+    old = {"timestamp": (now - timedelta(hours=30)).isoformat(), "v": 1}
+    recent = {"timestamp": (now - timedelta(hours=5)).isoformat(), "v": 2}
+    log.write_text(json.dumps([old, recent]))
+    result = _load_recent_entries(log, hours=24)
+    assert result == [recent]


### PR DESCRIPTION
## Summary
- refactor log entry loader for clarity
- track stage progress percentage in daily reports
- test utility for recent log filtering
- cover new field in daily cycle tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688155ffdc448330b67e045771f2e0fd