### PR TITLE
Add growth stage helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ or incomplete and should only be used as a starting point for your own research.
   reports provide an estimated harvest date based on `growth_stages.json`.
 - **Stage Schedule Planner**: `build_stage_schedule` returns the expected start
   and end date of each growth stage when given a planting date.
+- **Stage Progress Remaining**: `days_until_next_stage` reports how many days
+  remain in the current stage based on `growth_stages.json`.
 - **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to
   expected totals from `yield_estimates.json`.
   Daily reports now expose this value under `remaining_yield_g` for quick

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -122,7 +122,11 @@ from .companion_manager import (
     recommend_companions,
     recommend_antagonists,
 )
-from .growth_stage import get_stage_info, list_growth_stages
+from .growth_stage import (
+    get_stage_info,
+    list_growth_stages,
+    days_until_next_stage,
+)
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
 from .report import DailyReport
@@ -301,6 +305,7 @@ __all__ = [
     "recommend_antagonists",
     "get_stage_info",
     "list_growth_stages",
+    "days_until_next_stage",
     "build_stage_schedule",
     "estimate_rootzone_depth",
     "estimate_water_capacity",

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -159,6 +159,37 @@ def predict_next_stage_date(
     return stage_start + timedelta(days=duration)
 
 
+def days_until_next_stage(
+    plant_type: str, current_stage: str, days_elapsed: int
+) -> int | None:
+    """Return days remaining in ``current_stage`` for ``plant_type``.
+
+    Parameters
+    ----------
+    plant_type : str
+        Crop identifier for growth stage lookup.
+    current_stage : str
+        Name of the current stage.
+    days_elapsed : int
+        Days spent in the current stage so far.
+
+    Returns
+    -------
+    int | None
+        Number of days until the next stage begins or ``None`` if the
+        duration is unknown.
+    """
+
+    if days_elapsed < 0:
+        raise ValueError("days_elapsed must be non-negative")
+
+    duration = get_stage_duration(plant_type, current_stage)
+    if duration is None:
+        return None
+    remaining = duration - days_elapsed
+    return max(0, remaining)
+
+
 def get_germination_duration(plant_type: str) -> int | None:
     """Return default days to germination for ``plant_type`` if known."""
 

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -11,6 +11,7 @@ from plant_engine.growth_stage import (
     days_until_harvest,
     predict_next_stage_date,
     get_germination_duration,
+    days_until_next_stage,
 )
 
 
@@ -94,5 +95,15 @@ def test_get_germination_duration():
     assert get_germination_duration("tomato") == 5
     assert get_germination_duration("lettuce") == 7
     assert get_germination_duration("unknown") is None
+
+
+def test_days_until_next_stage():
+    # stage duration for tomato seedling is 30 days
+    assert days_until_next_stage("tomato", "seedling", 10) == 20
+    # when elapsed exceeds duration the remaining time is zero
+    assert days_until_next_stage("tomato", "seedling", 40) == 0
+    assert days_until_next_stage("unknown", "seedling", 5) is None
+    with pytest.raises(ValueError):
+        days_until_next_stage("tomato", "seedling", -1)
 
 


### PR DESCRIPTION
## Summary
- add `days_until_next_stage` utility in plant_engine
- re-export helper from package
- document stage progress helper in README
- test `days_until_next_stage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881560a2ed083308f0a131968c5bb1e