### PR TITLE
Enhance environment manager with climate zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Key reference datasets reside in the `data/` directory:
 - `cold_stress_thresholds.json` – minimum temperature limits for cold stress
 - `humidity_actions.json` – actions to correct low or high humidity levels
 - `wind_stress_thresholds.json` – maximum safe wind speed before damage
+- `climate_zone_guidelines.json` – temperature and humidity ranges by climate zone
 - `nutrient_deficiency_treatments.json` – remedies for common nutrient shortages
 - `nutrient_surplus_actions.json` – steps to mitigate excess nutrient levels
 - `nutrient_interactions.json` – warning ratios for antagonistic nutrients

--- a/data/climate_zone_guidelines.json
+++ b/data/climate_zone_guidelines.json
@@ -1,0 +1,20 @@
+{
+  "tropical": {
+    "temp_c": [22, 32],
+    "humidity_pct": [70, 90],
+    "light_ppfd": [300, 600],
+    "co2_ppm": [800, 1200]
+  },
+  "temperate": {
+    "temp_c": [18, 28],
+    "humidity_pct": [60, 80],
+    "light_ppfd": [250, 500],
+    "co2_ppm": [600, 1000]
+  },
+  "arid": {
+    "temp_c": [15, 25],
+    "humidity_pct": [40, 60],
+    "light_ppfd": [200, 450],
+    "co2_ppm": [600, 1000]
+  }
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -75,6 +75,7 @@
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",
+  "climate_zone_guidelines.json": "Temperature and humidity targets for common climate zones.",
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
   "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",

--- a/tests/test_climate_guidelines.py
+++ b/tests/test_climate_guidelines.py
@@ -1,0 +1,17 @@
+from plant_engine.environment_manager import (
+    get_climate_guidelines,
+    recommend_climate_adjustments,
+)
+
+
+def test_get_climate_guidelines():
+    guide = get_climate_guidelines("temperate")
+    assert guide.temp_c == (18.0, 28.0)
+    assert guide.humidity_pct == (60.0, 80.0)
+
+
+def test_recommend_climate_adjustments():
+    env = {"temp_c": 30, "humidity_pct": 50}
+    rec = recommend_climate_adjustments(env, "temperate")
+    assert "temperature" in rec and rec["temperature"].startswith("lower")
+    assert "humidity" in rec and rec["humidity"].startswith("increase")


### PR DESCRIPTION
## Summary
- add `climate_zone_guidelines.json` dataset
- load and expose climate zone data in `environment_manager`
- new helpers `get_climate_guidelines` and `recommend_climate_adjustments`
- document new dataset
- test climate guideline helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881560d7eb08330b8692cb89a556c3e