### PR TITLE
Improve environment sensors and setpoint suggestions

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -671,12 +671,26 @@ def score_overall_environment(
 def suggest_environment_setpoints(
     plant_type: str, stage: str | None = None
 ) -> Dict[str, float]:
-    """Return midpoint setpoints for temperature, humidity, light and CO₂."""
+    """Return midpoint setpoints for key environment parameters."""
+
     targets = get_environmental_targets(plant_type, stage)
     setpoints: Dict[str, float] = {}
     for key, bounds in targets.items():
         if isinstance(bounds, (list, tuple)) and len(bounds) == 2:
             setpoints[key] = round((bounds[0] + bounds[1]) / 2, 2)
+
+    soil = get_target_soil_moisture(plant_type, stage)
+    if soil:
+        setpoints["soil_moisture_pct"] = round((soil[0] + soil[1]) / 2, 2)
+
+    soil_temp = get_target_soil_temperature(plant_type, stage)
+    if soil_temp:
+        setpoints["soil_temp_c"] = round((soil_temp[0] + soil_temp[1]) / 2, 2)
+
+    soil_ec = get_target_soil_ec(plant_type, stage)
+    if soil_ec:
+        setpoints["soil_ec"] = round((soil_ec[0] + soil_ec[1]) / 2, 2)
+
     return setpoints
 
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -112,6 +112,9 @@ def test_suggest_environment_setpoints():
     assert setpoints["humidity_pct"] == 70
     assert setpoints["light_ppfd"] == 225
     assert setpoints["co2_ppm"] == 500
+    assert setpoints["soil_moisture_pct"] == 40
+    assert setpoints["soil_temp_c"] == 24
+    assert setpoints["soil_ec"] == 1.15
 
 
 def test_suggest_environment_setpoints_advanced_vpd_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- refactor environment score/quality sensors into a reusable base class
- include soil metrics when suggesting environment setpoints
- update tests for new setpoint behaviour

## Testing
- `pytest -q`
- `pytest tests/test_environment_manager.py::test_suggest_environment_setpoints -q`

------
https://chatgpt.com/codex/tasks/task_e_688156109c848330a346c9a573a7d5b5