### PR TITLE
Add pesticide harvest adjustment helper

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -47,6 +47,7 @@ from .pest_monitor import (
 from .pesticide_manager import (
     get_withdrawal_days,
     earliest_harvest_date,
+    adjust_harvest_date,
 )
 from .disease_monitor import (
     get_disease_thresholds,
@@ -370,6 +371,7 @@ __all__ = [
     "get_guideline_summary",
     "get_withdrawal_days",
     "earliest_harvest_date",
+    "adjust_harvest_date",
     "DailyReport",
     "load_profile",
     "TranspirationMetrics",

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -1,6 +1,10 @@
 import datetime
 
-from plant_engine.pesticide_manager import get_withdrawal_days, earliest_harvest_date
+from plant_engine.pesticide_manager import (
+    get_withdrawal_days,
+    earliest_harvest_date,
+    adjust_harvest_date,
+)
 
 
 def test_get_withdrawal_days_known():
@@ -17,3 +21,11 @@ def test_earliest_harvest_date():
     harvest = earliest_harvest_date("spinosad", date)
     assert harvest == date + datetime.timedelta(days=1)
     assert earliest_harvest_date("foo", date) is None
+
+
+def test_adjust_harvest_date():
+    start = datetime.date(2024, 5, 1)
+    application = datetime.date(2024, 7, 29)
+    adjusted = adjust_harvest_date("lettuce", start, "imidacloprid", application)
+    expected = earliest_harvest_date("imidacloprid", application)
+    assert adjusted == expected


### PR DESCRIPTION
## Summary
- export `adjust_harvest_date` in the package
- implement `adjust_harvest_date` in `pesticide_manager`
- test harvest date adjustments for withdrawal periods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881561468b883308214e45b0ba722c3