### PR TITLE
Add nutrient uptake schedule helper

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -210,6 +210,7 @@ from .nutrient_budget import (
     estimate_required_nutrients,
 )
 from .compute_transpiration import TranspirationMetrics
+from .nutrient_schedule import generate_daily_uptake_plan
 
 # Run functions should be imported explicitly to avoid heavy imports at package
 # initialization time.
@@ -277,6 +278,7 @@ __all__ = [
     "estimate_cycle_cost",
     "generate_cycle_fertigation_plan",
     "generate_cycle_fertigation_plan_with_cost",
+    "generate_daily_uptake_plan",
     "recommend_stock_solution_injection",
     "get_foliar_spray_volume",
     "estimate_spray_solution_volume",

--- a/plant_engine/nutrient_schedule.py
+++ b/plant_engine/nutrient_schedule.py
@@ -1,0 +1,39 @@
+"""Helpers to build daily nutrient uptake schedules."""
+
+from typing import Dict, Mapping
+
+from .growth_stage import list_growth_stages, get_stage_duration
+from .irrigation_manager import get_daily_irrigation_target
+from .fertigation import estimate_daily_nutrient_uptake
+
+__all__ = ["generate_daily_uptake_plan"]
+
+
+def generate_daily_uptake_plan(plant_type: str) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """Return daily nutrient uptake plan for the crop cycle.
+
+    Parameters
+    ----------
+    plant_type : str
+        Name of the plant type as defined in the datasets.
+
+    Returns
+    -------
+    Dict[str, Dict[int, Dict[str, float]]]
+        Mapping of stage name to a daily schedule. Each schedule maps the
+        day number (starting at ``1``) to nutrient uptake values in
+        milligrams per plant.
+    """
+
+    plan: Dict[str, Dict[int, Dict[str, float]]] = {}
+    for stage in list_growth_stages(plant_type):
+        duration = get_stage_duration(plant_type, stage)
+        if not duration:
+            continue
+        daily_ml = get_daily_irrigation_target(plant_type, stage)
+        daily_uptake = estimate_daily_nutrient_uptake(plant_type, stage, daily_ml)
+        stage_plan: Dict[int, Dict[str, float]] = {}
+        for day in range(1, duration + 1):
+            stage_plan[day] = dict(daily_uptake)
+        plan[stage] = stage_plan
+    return plan

--- a/tests/test_nutrient_schedule.py
+++ b/tests/test_nutrient_schedule.py
@@ -1,0 +1,12 @@
+from plant_engine.nutrient_schedule import generate_daily_uptake_plan
+
+
+def test_generate_daily_uptake_plan_strawberry():
+    plan = generate_daily_uptake_plan("strawberry")
+    assert "vegetative" in plan
+    veg = plan["vegetative"]
+    assert len(veg) == 60
+    first_day = veg[1]
+    assert first_day["N"] == 14.0
+    assert first_day["P"] == 6.0
+    assert first_day["K"] == 16.0


### PR DESCRIPTION
## Summary
- add `nutrient_schedule` module to build daily nutrient uptake schedules
- expose new helper via package init
- test daily uptake schedule generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881561685388330b6f6a86a3487f9fa