### PR TITLE
Add stage notes helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ or incomplete and should only be used as a starting point for your own research.
   reports provide an estimated harvest date based on `growth_stages.json`.
 - **Stage Schedule Planner**: `build_stage_schedule` returns the expected start
   and end date of each growth stage when given a planting date.
+- **Stage Notes Lookup**: `get_stage_notes` fetches the notes string for any
+  stage entry in `growth_stages.json`.
 - **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to
   expected totals from `yield_estimates.json`.
   Daily reports now expose this value under `remaining_yield_g` for quick

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -122,7 +122,7 @@ from .companion_manager import (
     recommend_companions,
     recommend_antagonists,
 )
-from .growth_stage import get_stage_info, list_growth_stages
+from .growth_stage import get_stage_info, get_stage_notes, list_growth_stages
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
 from .report import DailyReport
@@ -300,6 +300,7 @@ __all__ = [
     "recommend_companions",
     "recommend_antagonists",
     "get_stage_info",
+    "get_stage_notes",
     "list_growth_stages",
     "build_stage_schedule",
     "estimate_rootzone_depth",

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -29,6 +29,7 @@ __all__ = [
     "days_until_harvest",
     "predict_next_stage_date",
     "get_germination_duration",
+    "get_stage_notes",
 ]
 
 
@@ -50,6 +51,14 @@ def get_stage_duration(plant_type: str, stage: str) -> int | None:
     if isinstance(duration, (int, float)):
         return int(duration)
     return None
+
+
+def get_stage_notes(plant_type: str, stage: str) -> str | None:
+    """Return optional notes for ``plant_type`` and ``stage``."""
+
+    info = get_stage_info(plant_type, stage)
+    notes = info.get("notes")
+    return str(notes) if isinstance(notes, str) else None
 
 
 def estimate_stage_from_age(plant_type: str, days_since_start: int) -> str | None:

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -11,6 +11,7 @@ from plant_engine.growth_stage import (
     days_until_harvest,
     predict_next_stage_date,
     get_germination_duration,
+    get_stage_notes,
 )
 
 
@@ -94,5 +95,10 @@ def test_get_germination_duration():
     assert get_germination_duration("tomato") == 5
     assert get_germination_duration("lettuce") == 7
     assert get_germination_duration("unknown") is None
+
+
+def test_get_stage_notes():
+    assert get_stage_notes("tomato", "flowering") == "Reduce nitrogen, increase phosphorus."
+    assert get_stage_notes("tomato", "unknown") is None
 
 


### PR DESCRIPTION
## Summary
- expose `get_stage_notes` in `growth_stage` to fetch notes from dataset
- export new helper via `plant_engine.__init__`
- document Stage Notes feature in README
- add tests for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881560dfb3c8330858749d06a5167ef