### PR TITLE
Add silicon nutrient module

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -87,6 +87,7 @@
   "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
   "companion_plants.json": "Companion planting recommendations.",
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
+  "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",
   "disease_monitoring_intervals.json": "Recommended days between disease scouting events.",

--- a/data/silicon_guidelines.json
+++ b/data/silicon_guidelines.json
@@ -1,0 +1,10 @@
+{
+  "lettuce": {
+    "seedling": {"Si": 20},
+    "harvest": {"Si": 30}
+  },
+  "tomato": {
+    "vegetative": {"Si": 35},
+    "fruiting": {"Si": 40}
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -113,6 +113,12 @@ from .micro_manager import (
     calculate_deficiencies as calculate_micro_deficiencies,
     calculate_surplus as calculate_micro_surplus,
 )
+from .silicon_manager import (
+    list_supported_plants as list_silicon_plants,
+    get_recommended_levels as get_silicon_levels,
+    calculate_deficiencies as calculate_silicon_deficiencies,
+    calculate_surplus as calculate_silicon_surplus,
+)
 from .bioinoculant_manager import (
     list_supported_plants as list_bio_plants,
     get_recommended_inoculants,
@@ -300,6 +306,10 @@ __all__ = [
     "score_nutrient_levels",
     "list_micro_plants",
     "get_micro_levels",
+    "list_silicon_plants",
+    "get_silicon_levels",
+    "calculate_silicon_deficiencies",
+    "calculate_silicon_surplus",
     "list_bio_plants",
     "get_recommended_inoculants",
     "list_companion_plants",

--- a/plant_engine/silicon_manager.py
+++ b/plant_engine/silicon_manager.py
@@ -1,0 +1,61 @@
+"""Simple utilities for silicon nutrient guidance."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "silicon_guidelines.json"
+
+_DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_recommended_levels",
+    "calculate_deficiencies",
+    "calculate_surplus",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plants with silicon guidelines."""
+    return list_dataset_entries(_DATA)
+
+
+def get_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return recommended silicon ppm levels for a plant stage."""
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return {}
+    return plant.get(normalize_key(stage), {})
+
+
+def calculate_deficiencies(
+    current_levels: Mapping[str, float],
+    plant_type: str,
+    stage: str,
+) -> Dict[str, float]:
+    """Return silicon deficit compared to guidelines."""
+    target = get_recommended_levels(plant_type, stage)
+    deficits: Dict[str, float] = {}
+    for nutrient, rec in target.items():
+        diff = round(rec - current_levels.get(nutrient, 0.0), 2)
+        if diff > 0:
+            deficits[nutrient] = diff
+    return deficits
+
+
+def calculate_surplus(
+    current_levels: Mapping[str, float],
+    plant_type: str,
+    stage: str,
+) -> Dict[str, float]:
+    """Return surplus silicon ppm above recommended levels."""
+    target = get_recommended_levels(plant_type, stage)
+    surplus: Dict[str, float] = {}
+    for nutrient, rec in target.items():
+        diff = round(current_levels.get(nutrient, 0.0) - rec, 2)
+        if diff > 0:
+            surplus[nutrient] = diff
+    return surplus

--- a/tests/test_silicon_manager.py
+++ b/tests/test_silicon_manager.py
@@ -1,0 +1,18 @@
+import plant_engine.silicon_manager as si
+
+
+def test_silicon_guidelines():
+    levels = si.get_recommended_levels("lettuce", "seedling")
+    assert levels["Si"] == 20
+
+
+def test_silicon_deficiencies():
+    current = {"Si": 10}
+    defs = si.calculate_deficiencies(current, "lettuce", "seedling")
+    assert defs["Si"] == 10
+
+
+def test_silicon_surplus():
+    current = {"Si": 50}
+    surplus = si.calculate_surplus(current, "tomato", "fruiting")
+    assert surplus["Si"] == 10


### PR DESCRIPTION
## Summary
- include silicon guidelines dataset
- add silicon manager module
- hook into plant_engine package
- document dataset in catalog
- test silicon manager behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815cb1fe5c83308ac9d39555578ca3