### PR TITLE
Add stage task dataset and utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -14,6 +14,7 @@
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",
   "growth_stages.json": "Expected duration and notes for each growth stage.",
+  "stage_tasks.json": "Common tasks to perform during each growth stage.",
   "germination_duration.json": "Typical days from sowing to germination by crop.",
   "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",
   "light_dli_guidelines.json": "Daily Light Integral targets for growth stages.",

--- a/data/stage_tasks.json
+++ b/data/stage_tasks.json
@@ -1,0 +1,13 @@
+{
+  "tomato": {
+    "seedling": ["Transplant seedlings to larger pots", "Provide 16h of light"],
+    "vegetative": ["Prune side shoots", "Apply balanced fertilizer"],
+    "flowering": ["Reduce nitrogen levels", "Increase phosphorus"],
+    "fruiting": ["Support heavy clusters", "Maintain high potassium"]
+  },
+  "lettuce": {
+    "seedling": ["Thin seedlings", "Keep soil evenly moist"],
+    "vegetative": ["Apply nitrogen source", "Monitor for pests"],
+    "harvest": ["Harvest outer leaves", "Watch for bolting"]
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -128,6 +128,11 @@ from .growth_stage import (
     list_growth_stages,
     days_until_next_stage,
 )
+from .stage_tasks import (
+    list_supported_plants as list_task_plants,
+    get_stage_tasks,
+    generate_task_schedule,
+)
 from .harvest_planner import build_stage_schedule
 from .guidelines import get_guideline_summary
 from .report import DailyReport
@@ -309,6 +314,9 @@ __all__ = [
     "get_stage_info",
     "list_growth_stages",
     "days_until_next_stage",
+    "list_task_plants",
+    "get_stage_tasks",
+    "generate_task_schedule",
     "build_stage_schedule",
     "estimate_rootzone_depth",
     "estimate_water_capacity",

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Mapping, Tuple, Iterable
 
 RangeTuple = Tuple[float, float]
 
-from .utils import load_dataset, normalize_key, list_dataset_entries
+from .utils import load_dataset, normalize_key, list_dataset_entries, parse_range
 from . import ph_manager, water_quality
 from .compute_transpiration import compute_transpiration
 
@@ -65,15 +65,6 @@ _ALIAS_MAP: Dict[str, str] = {
 }
 
 
-def _parse_range(value: Iterable[float]) -> RangeTuple | None:
-    """Return a normalized (min, max) tuple or ``None`` if invalid."""
-    try:
-        low, high = value
-        low = float(low)
-        high = float(high)
-    except (TypeError, ValueError, Exception):
-        return None
-    return (low, high)
 
 
 @dataclass(slots=True, frozen=True)
@@ -104,10 +95,10 @@ def get_environment_guidelines(
     if not isinstance(data, Mapping):
         data = {}
     return EnvironmentGuidelines(
-        temp_c=_parse_range(data.get("temp_c")),
-        humidity_pct=_parse_range(data.get("humidity_pct")),
-        light_ppfd=_parse_range(data.get("light_ppfd")),
-        co2_ppm=_parse_range(data.get("co2_ppm")),
+        temp_c=parse_range(data.get("temp_c")),
+        humidity_pct=parse_range(data.get("humidity_pct")),
+        light_ppfd=parse_range(data.get("light_ppfd")),
+        co2_ppm=parse_range(data.get("co2_ppm")),
     )
 
 
@@ -119,10 +110,10 @@ def get_climate_guidelines(zone: str) -> EnvironmentGuidelines:
     if not isinstance(data, Mapping):
         data = {}
     return EnvironmentGuidelines(
-        temp_c=_parse_range(data.get("temp_c")),
-        humidity_pct=_parse_range(data.get("humidity_pct")),
-        light_ppfd=_parse_range(data.get("light_ppfd")),
-        co2_ppm=_parse_range(data.get("co2_ppm")),
+        temp_c=parse_range(data.get("temp_c")),
+        humidity_pct=parse_range(data.get("humidity_pct")),
+        light_ppfd=parse_range(data.get("light_ppfd")),
+        co2_ppm=parse_range(data.get("co2_ppm")),
     )
 
 

--- a/plant_engine/health_report.py
+++ b/plant_engine/health_report.py
@@ -11,6 +11,7 @@ from . import (
     pest_manager,
     disease_manager,
     growth_stage,
+    stage_tasks,
 )
 
 
@@ -46,6 +47,7 @@ def generate_health_report(
     pest_actions = pest_manager.recommend_treatments(plant_type, pests)
     disease_actions = disease_manager.recommend_treatments(plant_type, diseases)
     stage_info = growth_stage.get_stage_info(plant_type, stage)
+    tasks = stage_tasks.get_stage_tasks(plant_type, stage)
 
     return {
         "environment": env_opt,
@@ -56,6 +58,7 @@ def generate_health_report(
         "pest_actions": pest_actions,
         "disease_actions": disease_actions,
         "stage_info": stage_info,
+        "stage_tasks": tasks,
     }
 
 __all__ = ["generate_health_report"]

--- a/plant_engine/stage_tasks.py
+++ b/plant_engine/stage_tasks.py
@@ -1,0 +1,68 @@
+"""Stage-specific task recommendations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Dict, Iterable, List, Tuple
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "stage_tasks.json"
+
+_DATA: Dict[str, Dict[str, List[str]]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_stage_tasks",
+    "generate_task_schedule",
+    "TaskScheduleEntry",
+]
+
+
+@dataclass(slots=True, frozen=True)
+class TaskScheduleEntry:
+    """Single task schedule record."""
+
+    date: date
+    tasks: List[str]
+
+    def as_tuple(self) -> Tuple[str, List[str]]:
+        return self.date.isoformat(), list(self.tasks)
+
+
+def list_supported_plants() -> List[str]:
+    """Return plant types with task definitions."""
+
+    return list_dataset_entries(_DATA)
+
+
+def get_stage_tasks(plant_type: str, stage: str) -> List[str]:
+    """Return task list for a plant stage."""
+
+    return list(
+        _DATA.get(normalize_key(plant_type), {}).get(normalize_key(stage), [])
+    )
+
+
+def generate_task_schedule(
+    plant_type: str,
+    stage: str,
+    start: date,
+    days: int,
+    interval: int = 7,
+) -> List[TaskScheduleEntry]:
+    """Return repeating task schedule for the duration of a stage."""
+
+    if days <= 0:
+        raise ValueError("days must be positive")
+    if interval <= 0:
+        raise ValueError("interval must be positive")
+
+    tasks = get_stage_tasks(plant_type, stage)
+    schedule: List[TaskScheduleEntry] = []
+    current = start
+    while current < start + timedelta(days=days):
+        schedule.append(TaskScheduleEntry(current, tasks))
+        current += timedelta(days=interval)
+    return schedule

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "clear_dataset_cache",
     "normalize_key",
     "list_dataset_entries",
+    "parse_range",
     "deep_update",
 ]
 
@@ -137,3 +138,13 @@ def list_dataset_entries(dataset: Mapping[str, Any]) -> list[str]:
     """Return sorted top-level keys from a dataset mapping."""
 
     return sorted(str(k) for k in dataset.keys())
+
+
+def parse_range(value: Iterable[float]) -> tuple[float, float] | None:
+    """Return a normalized ``(min, max)`` tuple or ``None`` if invalid."""
+
+    try:
+        low, high = value
+        return float(low), float(high)
+    except (TypeError, ValueError, Exception):
+        return None

--- a/tests/test_health_report.py
+++ b/tests/test_health_report.py
@@ -17,6 +17,7 @@ def test_generate_health_report():
     assert report["deficiency_treatments"]
     assert report["pest_actions"]["aphids"].startswith("Apply")
     assert report["disease_actions"]["root rot"].startswith("Ensure")
+    assert isinstance(report["stage_tasks"], list)
 
 
 def test_generate_health_report_with_water():

--- a/tests/test_stage_tasks.py
+++ b/tests/test_stage_tasks.py
@@ -1,0 +1,28 @@
+from datetime import date
+
+from plant_engine.stage_tasks import (
+    get_stage_tasks,
+    list_supported_plants,
+    generate_task_schedule,
+)
+
+
+def test_get_stage_tasks():
+    tasks = get_stage_tasks("tomato", "seedling")
+    assert "Transplant seedlings to larger pots" in tasks
+    assert get_stage_tasks("unknown", "seedling") == []
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+    assert "lettuce" in plants
+
+
+def test_generate_task_schedule():
+    schedule = generate_task_schedule(
+        "tomato", "vegetative", date(2025, 1, 1), days=15, interval=7
+    )
+    assert len(schedule) == 3
+    assert schedule[0].tasks
+    assert schedule[0].date == date(2025, 1, 1)


### PR DESCRIPTION
## Summary
- create `stage_tasks.json` dataset with task recommendations
- expose new `stage_tasks` module with helpers
- hook stage tasks into health report
- export tasks utilities from package
- share parse_range util for environment manager
- add unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815c94b60483308ba7403ef045b35d