### PR TITLE
Improve fertilizer data and helper

### DIFF
--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -18,6 +18,7 @@ from plant_engine.utils import load_dataset
 DATA_FILE = "fertilizers/fertilizer_products.json"
 PRICE_FILE = "fertilizers/fertilizer_prices.json"
 SOLUBILITY_FILE = "fertilizer_solubility.json"
+APPLICATION_FILE = "fertilizers/fertilizer_application_methods.json"
 
 
 @dataclass(frozen=True)
@@ -55,6 +56,12 @@ def _price_map() -> Dict[str, float]:
 def _solubility_map() -> Dict[str, float]:
     """Return maximum solubility (g/L) for each fertilizer."""
     return load_dataset(SOLUBILITY_FILE)
+
+
+@lru_cache(maxsize=None)
+def _application_method_map() -> Dict[str, str]:
+    """Return recommended application method for each fertilizer."""
+    return load_dataset(APPLICATION_FILE)
 
 
 MOLAR_MASS_CONVERSIONS = {
@@ -479,6 +486,7 @@ __all__ = [
     "get_product_info",
     "find_products",
     "calculate_mix_ppm",
+    "get_application_method",
 ]
 
 
@@ -507,4 +515,10 @@ def find_products(term: str) -> list[str]:
         if term in pid.lower() or term in name:
             results.append(pid)
     return sorted(results)
+
+
+def get_application_method(fertilizer_id: str) -> str | None:
+    """Return recommended application method for ``fertilizer_id``."""
+
+    return _application_method_map().get(fertilizer_id)
 

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -78,6 +78,7 @@
   "climate_zone_guidelines.json": "Temperature and humidity targets for common climate zones.",
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
+  "fertilizers/fertilizer_application_methods.json": "Recommended application methods for each fertilizer product.",
   "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
   "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
   "wsda_fertilizer_database.json": "Full WSDA fertilizer product database for nutrient lookups.",

--- a/data/fertilizers/fertilizer_application_methods.json
+++ b/data/fertilizers/fertilizer_application_methods.json
@@ -1,0 +1,5 @@
+{
+  "foxfarm_grow_big": "soil drench",
+  "magriculture": "foliar",
+  "intrepid_granular_potash_0_0_60": "broadcast"
+}

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -31,6 +31,7 @@ check_solubility_limits = fert_mod.check_solubility_limits
 estimate_cost_per_nutrient = fert_mod.estimate_cost_per_nutrient
 calculate_fertilizer_ppm = fert_mod.calculate_fertilizer_ppm
 calculate_mass_for_target_ppm = fert_mod.calculate_mass_for_target_ppm
+get_application_method = fert_mod.get_application_method
 
 
 def test_convert_guaranteed_analysis():
@@ -226,4 +227,10 @@ def test_calculate_mass_for_target_ppm():
         calculate_mass_for_target_ppm("unknown", "N", 10, 1)
     with pytest.raises(KeyError):
         calculate_mass_for_target_ppm("foxfarm_grow_big", "X", 10, 1)
+
+
+def test_get_application_method():
+    assert get_application_method("foxfarm_grow_big") == "soil drench"
+    assert get_application_method("magriculture") == "foliar"
+    assert get_application_method("unknown") is None
 


### PR DESCRIPTION
## Summary
- add fertilizer application methods dataset
- support looking up application methods in `fertilizer_formulator`
- expose `get_application_method` via API and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815c475e0883308a2760c59f1ae661