### PR TITLE
Add nutrient product recommendation utility

### DIFF
--- a/plant_engine/wsda_lookup.py
+++ b/plant_engine/wsda_lookup.py
@@ -19,6 +19,7 @@ __all__ = [
     "search_products",
     "list_product_names",
     "list_product_numbers",
+    "recommend_products_for_nutrient",
 ]
 
 @dataclass(frozen=True)
@@ -141,3 +142,22 @@ def list_product_numbers() -> List[str]:
     """Return all WSDA product numbers sorted alphabetically."""
     _, numbers = _build_indexes()
     return sorted(numbers.keys())
+
+
+def recommend_products_for_nutrient(nutrient: str, limit: int = 5) -> List[str]:
+    """Return product names with the highest percentage of ``nutrient``.
+
+    The search is case-insensitive and results are sorted by nutrient
+    concentration in descending order.
+    """
+    n = nutrient.upper().strip()
+    names, _ = _build_indexes()
+    ranked = []
+    for prod in names.values():
+        value = prod.analysis.get(n)
+        if value is not None:
+            ranked.append((prod.name, value))
+
+    ranked.sort(key=lambda x: x[1], reverse=True)
+    return [name for name, _ in ranked[: max(limit, 0)]]
+

--- a/tests/test_wsda_lookup.py
+++ b/tests/test_wsda_lookup.py
@@ -15,6 +15,7 @@ get_product_analysis_by_number = wsda.get_product_analysis_by_number
 search_products = wsda.search_products
 list_product_names = wsda.list_product_names
 list_product_numbers = wsda.list_product_numbers
+recommend_products_for_nutrient = wsda.recommend_products_for_nutrient
 
 
 def test_lookup_by_name():
@@ -61,3 +62,11 @@ def test_list_product_names_contains_known():
 def test_list_product_numbers_contains_known():
     numbers = list_product_numbers()
     assert "(#4083-0001)" in numbers
+
+
+def test_recommend_products_for_nutrient():
+    top = recommend_products_for_nutrient("K", limit=3)
+    assert len(top) == 3
+    first = get_product_analysis_by_name(top[0]).get("K")
+    second = get_product_analysis_by_name(top[1]).get("K")
+    assert first >= second


### PR DESCRIPTION
## Summary
- enhance WSDA lookup helpers with new `recommend_products_for_nutrient`
- test the new feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815c30e5308330834529365f19360f