### PR TITLE
Add fertilizer cost per liter helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ or incomplete and should only be used as a starting point for your own research.
   schedule along with an estimated dollar cost based on fertilizer prices.
 - **Per-Plant Cost**: `estimate_mix_cost_per_plant` divides the total mix cost
   by plant count for precise budgeting.
+- **Cost Per Liter**: `estimate_mix_cost_per_liter` helps compare fertilizer
+  schedules by normalizing cost to the total solution volume.
 - **Mix Nutrient Totals**: `calculate_mix_nutrients` reports the elemental
   nutrient amounts contributed by each fertilizer mix in milligrams.
 - **Solution Weight Estimate**: `estimate_solution_mass` adds fertilizer mass to

--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -398,6 +398,23 @@ def estimate_solution_mass(schedule: Mapping[str, float], volume_l: float) -> fl
     return round(volume_l + fertilizer_mass_kg, 3)
 
 
+def estimate_mix_cost_per_liter(
+    schedule: Mapping[str, float], volume_l: float
+) -> float:
+    """Return cost per liter of solution for ``schedule`` and ``volume_l``.
+
+    This helper builds on :func:`estimate_mix_cost` to expose the relative cost
+    of a fertilizer schedule for the given solution volume. ``volume_l`` must be
+    positive.
+    """
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    total = estimate_mix_cost(schedule)
+    return round(total / volume_l, 4)
+
+
 def check_solubility_limits(schedule: Mapping[str, float], volume_l: float) -> Dict[str, float]:
     """Return grams per liter exceeding solubility limits.
 
@@ -468,6 +485,7 @@ __all__ = [
     "calculate_fertilizer_ppm",
     "estimate_mix_cost",
     "estimate_mix_cost_per_plant",
+    "estimate_mix_cost_per_liter",
     "estimate_cost_breakdown",
     "calculate_mix_nutrients",
     "calculate_mix_density",

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -21,6 +21,7 @@ calculate_fertilizer_nutrients_from_mass = fert_mod.calculate_fertilizer_nutrien
 calculate_fertilizer_cost_from_mass = fert_mod.calculate_fertilizer_cost_from_mass
 estimate_mix_cost = fert_mod.estimate_mix_cost
 estimate_mix_cost_per_plant = fert_mod.estimate_mix_cost_per_plant
+estimate_mix_cost_per_liter = fert_mod.estimate_mix_cost_per_liter
 estimate_cost_breakdown = fert_mod.estimate_cost_breakdown
 find_products = fert_mod.find_products
 calculate_mix_nutrients = fert_mod.calculate_mix_nutrients
@@ -201,6 +202,15 @@ def test_estimate_mix_cost_per_plant():
     assert per_plant == round(total / 5, 4)
     with pytest.raises(ValueError):
         estimate_mix_cost_per_plant(mix, 0)
+
+
+def test_estimate_mix_cost_per_liter():
+    mix = {"foxfarm_grow_big": 20}
+    total = estimate_mix_cost(mix)
+    cost_per_l = estimate_mix_cost_per_liter(mix, 10)
+    assert cost_per_l == round(total / 10, 4)
+    with pytest.raises(ValueError):
+        estimate_mix_cost_per_liter(mix, 0)
 
 
 def test_estimate_solution_mass():


### PR DESCRIPTION
## Summary
- expose new `estimate_mix_cost_per_liter` helper for fertilizer scheduling
- document helper in README
- test new helper

## Testing
- `pytest tests/test_fertilizer_formulator.py::test_estimate_mix_cost_per_liter -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815ca95d008330bf50a61c2cb41901