### PR TITLE
Add nutrient status classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ applying it to your plants.
 - Stage-adjusted nutrient targets
 - Leaf tissue analysis with nutrient balance scoring
 - Nutrient deficiency severity and treatment recommendations
+- Combined deficiency/toxicity nutrient status classification
 - Automated deficiency action recommendations in daily reports
 - Example crop profiles for strawberries, basil, spinach and more
 - Helper functions to list known pests and diseases by crop

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -202,6 +202,7 @@ from .toxicity_manager import (
     get_toxicity_thresholds,
     check_toxicities,
 )
+from .nutrient_status import classify_nutrient_status
 from .ph_manager import (
     list_supported_plants as list_ph_plants,
     get_ph_range,
@@ -395,6 +396,7 @@ __all__ = [
     "list_toxicity_plants",
     "get_toxicity_thresholds",
     "check_toxicities",
+    "classify_nutrient_status",
     "get_guideline_summary",
     "get_withdrawal_days",
     "earliest_harvest_date",

--- a/plant_engine/nutrient_status.py
+++ b/plant_engine/nutrient_status.py
@@ -1,0 +1,56 @@
+"""Utilities for classifying nutrient levels.
+
+This module combines deficiency and toxicity checks to provide a simple
+status label for each nutrient. Possible labels are ``"adequate"``,
+``"mild deficiency"``, ``"moderate deficiency"``, ``"severe deficiency``" and
+``"excessive"``.
+"""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .nutrient_manager import get_all_recommended_levels
+from .deficiency_manager import (
+    calculate_deficiencies,
+    classify_deficiency_levels,
+)
+from .toxicity_manager import check_toxicities
+
+__all__ = ["classify_nutrient_status"]
+
+def classify_nutrient_status(
+    current_levels: Mapping[str, float], plant_type: str, stage: str
+) -> Dict[str, str]:
+    """Return classification of nutrient levels for a plant stage.
+
+    Parameters
+    ----------
+    current_levels : Mapping[str, float]
+        Current nutrient concentrations in ppm.
+    plant_type : str
+        Crop identifier for guideline lookups.
+    stage : str
+        Growth stage used for nutrient targets.
+
+    Returns
+    -------
+    Dict[str, str]
+        Mapping of nutrient codes to status labels.
+    """
+
+    recommended = get_all_recommended_levels(plant_type, stage)
+    deficits = calculate_deficiencies(current_levels, plant_type, stage)
+    severity = classify_deficiency_levels(deficits)
+    toxic = check_toxicities(current_levels, plant_type)
+
+    status: Dict[str, str] = {}
+    for nutrient in recommended:
+        if nutrient in toxic:
+            status[nutrient] = "excessive"
+            continue
+        level = severity.get(nutrient)
+        if level:
+            status[nutrient] = f"{level} deficiency"
+        else:
+            status[nutrient] = "adequate"
+    return status

--- a/tests/test_nutrient_status.py
+++ b/tests/test_nutrient_status.py
@@ -1,0 +1,11 @@
+from plant_engine.nutrient_status import classify_nutrient_status
+
+
+def test_classify_nutrient_status():
+    current = {"N": 60, "P": 20, "K": 351, "Ca": 60}
+    status = classify_nutrient_status(current, "tomato", "fruiting")
+    assert status["N"] == "moderate deficiency"
+    assert status["P"] == "severe deficiency"
+    assert status["K"] == "excessive"
+    assert status["Ca"] == "adequate"
+


### PR DESCRIPTION
## Summary
- implement `classify_nutrient_status` helper to evaluate deficiencies and toxicities
- expose helper via package __init__
- document new feature in README
- test nutrient status classification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818f19b8008330a4415ad000184ab9