### PR TITLE
Refactor automation cycle and dataset catalog

### DIFF
--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -8,12 +8,14 @@ the project. A :class:`DatasetCatalog` dataclass manages dataset paths and uses
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List
 
-DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+from .utils import _data_dir, _extra_dirs, _overlay_dir
+
+DATA_DIR = _data_dir()
 CATALOG_FILE = DATA_DIR / "dataset_catalog.json"
 
 __all__ = [
@@ -30,29 +32,44 @@ __all__ = [
 class DatasetCatalog:
     """Helper object for discovering bundled datasets."""
 
-    base_dir: Path = DATA_DIR
-    catalog_file: Path = CATALOG_FILE
+    base_dir: Path = field(default_factory=_data_dir)
+    extra_dirs: tuple[Path, ...] = field(default_factory=lambda: tuple(_extra_dirs()))
+    overlay_dir: Path | None = field(default_factory=_overlay_dir)
+    catalog_file: Path = field(default_factory=lambda: _data_dir() / "dataset_catalog.json")
 
     @lru_cache(maxsize=None)
     def list_datasets(self) -> List[str]:
         """Return relative paths of available JSON datasets."""
 
-        datasets: List[str] = []
-        for path in self.base_dir.rglob("*.json"):
-            if path.name == self.catalog_file.name:
-                continue
-            datasets.append(path.relative_to(self.base_dir).as_posix())
+        paths = [self.base_dir, *self.extra_dirs]
+        if self.overlay_dir:
+            paths.append(self.overlay_dir)
 
-        return sorted(datasets)
+        found: dict[str, None] = {}
+        for base in paths:
+            for path in base.rglob("*.json"):
+                if path.name == "dataset_catalog.json":
+                    continue
+                rel = path.relative_to(base).as_posix()
+                found[rel] = None
+
+        return sorted(found.keys())
 
     @lru_cache(maxsize=None)
     def _load_catalog(self) -> Dict[str, str]:
-        if self.catalog_file.exists():
-            with open(self.catalog_file, "r", encoding="utf-8") as f:
+        catalogs: Dict[str, str] = {}
+        paths = [self.base_dir, *self.extra_dirs]
+        if self.overlay_dir:
+            paths.append(self.overlay_dir)
+        for base in paths:
+            path = base / "dataset_catalog.json"
+            if not path.exists():
+                continue
+            with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                if isinstance(data, dict):
-                    return {str(k): str(v) for k, v in data.items()}
-        return {}
+            if isinstance(data, dict):
+                catalogs.update({str(k): str(v) for k, v in data.items()})
+        return catalogs
 
     def get_description(self, name: str) -> str | None:
         """Return the human readable description for ``name`` if known."""
@@ -95,6 +112,14 @@ class DatasetCatalog:
             paths.sort()
         return categories
 
+    def refresh(self) -> None:
+        """Clear cached results so subsequent calls reload data."""
+
+        self.list_datasets.cache_clear()
+        self._load_catalog.cache_clear()
+        self.list_info.cache_clear()
+        self.list_by_category.cache_clear()
+
 
 DEFAULT_CATALOG = DatasetCatalog()
 
@@ -127,4 +152,10 @@ def list_datasets_by_category() -> Dict[str, List[str]]:
     """Return dataset names grouped by top-level directory."""
 
     return DEFAULT_CATALOG.list_by_category()
+
+
+def refresh_datasets() -> None:
+    """Clear cached dataset listings in the default catalog."""
+
+    DEFAULT_CATALOG.refresh()
 


### PR DESCRIPTION
## Summary
- refactor irrigation automation cycle with helper functions
- extend DatasetCatalog to support env directories and cache refresh
- add dataset catalog tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881930a08a08330bd3636506d99f730