### PR TITLE
Add rotation guidance module

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -89,6 +89,7 @@
   "fertigation_recipes.json": "Recommended grams per liter of fertilizer products for each stage.",
   "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
   "companion_plants.json": "Companion planting recommendations.",
+  "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/rotation_guidance.json
+++ b/data/rotation_guidance.json
@@ -1,0 +1,5 @@
+{
+  "tomato": {"family": "solanaceae", "years": 3},
+  "lettuce": {"family": "asteraceae", "years": 2},
+  "cucumber": {"family": "cucurbitaceae", "years": 3}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -130,6 +130,11 @@ from .companion_manager import (
     recommend_companions,
     recommend_antagonists,
 )
+from .rotation_manager import (
+    list_supported_plants as list_rotation_plants,
+    get_rotation_info,
+    recommended_rotation_years,
+)
 from .growth_stage import (
     get_stage_info,
     list_growth_stages,
@@ -324,6 +329,9 @@ __all__ = [
     "get_companion_info",
     "recommend_companions",
     "recommend_antagonists",
+    "list_rotation_plants",
+    "get_rotation_info",
+    "recommended_rotation_years",
     "get_stage_info",
     "list_growth_stages",
     "days_until_next_stage",

--- a/plant_engine/rotation_manager.py
+++ b/plant_engine/rotation_manager.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any, List
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "rotation_guidance.json"
+
+_DATA: Dict[str, Dict[str, Any]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_rotation_info",
+    "recommended_rotation_years",
+    "RotationInfo",
+]
+
+
+@dataclass(slots=True, frozen=True)
+class RotationInfo:
+    """Rotation guidance for a crop."""
+
+    family: str | None = None
+    years: int | None = None
+
+
+def list_supported_plants() -> List[str]:
+    """Return plant types with rotation guidance defined."""
+    return list_dataset_entries(_DATA)
+
+
+def get_rotation_info(plant_type: str) -> RotationInfo:
+    """Return :class:`RotationInfo` for ``plant_type``."""
+    info = _DATA.get(normalize_key(plant_type), {})
+    family = info.get("family")
+    years = info.get("years")
+    return RotationInfo(
+        family=str(family) if family is not None else None,
+        years=int(years) if isinstance(years, (int, float)) else None,
+    )
+
+
+def recommended_rotation_years(plant_type: str) -> int | None:
+    """Return recommended years before replanting the same crop."""
+    info = get_rotation_info(plant_type)
+    return info.years
+

--- a/tests/test_rotation_manager.py
+++ b/tests/test_rotation_manager.py
@@ -1,0 +1,22 @@
+from plant_engine.rotation_manager import (
+    list_supported_plants,
+    get_rotation_info,
+    recommended_rotation_years,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+
+
+def test_get_rotation_info():
+    info = get_rotation_info("tomato")
+    assert info.family == "solanaceae"
+    assert info.years == 3
+
+
+def test_recommended_rotation_years():
+    assert recommended_rotation_years("lettuce") == 2
+    assert recommended_rotation_years("unknown") is None
+


### PR DESCRIPTION
## Summary
- add basic rotation_guidance.json dataset
- integrate rotation manager module for crop rotation info
- expose rotation APIs via plant_engine package
- document new dataset in dataset catalog
- test rotation manager utilities

## Testing
- `pytest -k rotation_manager -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881932a3ea88330bfa5b826daebf220