### PR TITLE
Improve dataset catalog env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ Call `plant_engine.utils.clear_dataset_cache()` if you modify these
 environment variables while the application is running so changes are
 immediately reflected.
 
+The :mod:`plant_engine.datasets` helpers that list or describe datasets also
+use these environment variables so custom directories appear in search results
+without additional configuration.
+
 The datasets are snapshots compiled from public resources. They may be outdated
 or incomplete and should only be used as a starting point for your own research.
 

--- a/tests/test_dataset_catalog_extra.py
+++ b/tests/test_dataset_catalog_extra.py
@@ -1,0 +1,39 @@
+import importlib
+import json
+
+import plant_engine.datasets as datasets
+
+
+def test_dataset_catalog_environment_dirs(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    extra = tmp_path / "extra"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    extra.mkdir()
+    overlay.mkdir()
+
+    (base / "base.json").write_text("{}")
+    (extra / "extra.json").write_text("{}")
+    (overlay / "overlay.json").write_text("{}")
+
+    (base / "dataset_catalog.json").write_text(json.dumps({"base.json": "b"}))
+    (extra / "dataset_catalog.json").write_text(json.dumps({"extra.json": "e"}))
+    (overlay / "dataset_catalog.json").write_text(json.dumps({"overlay.json": "o"}))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    monkeypatch.setenv("HORTICULTURE_EXTRA_DATA_DIRS", str(extra))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+
+    importlib.reload(datasets)
+
+    names = datasets.list_datasets()
+    assert set(names) == {"base.json", "extra.json", "overlay.json"}
+
+    desc = datasets.get_dataset_description("overlay.json")
+    assert desc == "o"
+
+    # reset module to default paths so other tests are unaffected
+    monkeypatch.delenv("HORTICULTURE_DATA_DIR", raising=False)
+    monkeypatch.delenv("HORTICULTURE_EXTRA_DATA_DIRS", raising=False)
+    monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR", raising=False)
+    importlib.reload(datasets)


### PR DESCRIPTION
## Summary
- support HORTICULTURE_* env vars in dataset catalog
- document dataset catalog env behaviour
- test dataset catalog with env directories

## Testing
- `pytest -q tests/test_dataset_catalog.py tests/test_dataset_catalog_extra.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68819315376c83308304db1a5b7ff604