### PR TITLE
Enhance environment guidelines with climate support

### DIFF
--- a/tests/test_climate_guidelines.py
+++ b/tests/test_climate_guidelines.py
@@ -1,6 +1,9 @@
 from plant_engine.environment_manager import (
     get_climate_guidelines,
+    get_combined_environment_guidelines,
+    get_combined_environmental_targets,
     recommend_climate_adjustments,
+    get_environmental_targets,
 )
 
 
@@ -15,3 +18,16 @@ def test_recommend_climate_adjustments():
     rec = recommend_climate_adjustments(env, "temperate")
     assert "temperature" in rec and rec["temperature"].startswith("lower")
     assert "humidity" in rec and rec["humidity"].startswith("increase")
+
+
+def test_get_combined_environment_guidelines():
+    guide = get_combined_environment_guidelines("citrus", "seedling", "temperate")
+    assert guide.temp_c == (22, 26)
+    assert guide.light_ppfd == (250, 300)
+    assert guide.co2_ppm == (600, 600)
+
+
+def test_get_combined_environmental_targets_default():
+    combined = get_combined_environmental_targets("citrus", "seedling")
+    plant_only = get_environmental_targets("citrus", "seedling")
+    assert combined == plant_only


### PR DESCRIPTION
## Summary
- add utility to combine plant and climate environment guidelines
- expose new helpers in environment manager API
- test combined guideline helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881932e05148330ad05860462a244ec