### PR TITLE
Add HVAC energy estimation utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Key reference datasets reside in the `data/` directory:
 - `water_usage_guidelines.json` – estimated daily water use by crop stage
 - `irrigation_efficiency.json` – efficiency factors for common irrigation methods
 - `emitter_flow_rates.json` – typical emitter flow rates (L/h) for irrigation time estimates
+- `hvac_energy_coefficients.json` – kWh usage per degree-day for heating and cooling
 - `foliar_feed_guidelines.json` – recommended nutrient ppm for foliar sprays
 - `foliar_feed_intervals.json` – suggested days between foliar applications
 - `nutrient_leaching_rates.json` – estimated fraction of nutrients lost to leaching

--- a/data/hvac_energy_coefficients.json
+++ b/data/hvac_energy_coefficients.json
@@ -1,0 +1,4 @@
+{
+  "heating": {"kwh_per_degree_day": 0.5},
+  "cooling": {"kwh_per_degree_day": 0.4}
+}

--- a/plant_engine/energy_manager.py
+++ b/plant_engine/energy_manager.py
@@ -1,0 +1,44 @@
+"""Energy usage estimation utilities for HVAC systems."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "hvac_energy_coefficients.json"
+
+# Cache dataset via load_dataset
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "get_energy_coefficient",
+    "estimate_hvac_energy",
+]
+
+
+@lru_cache(maxsize=None)
+def get_energy_coefficient(system: str) -> float:
+    """Return kWh per degree-day coefficient for an HVAC ``system``."""
+    entry = _DATA.get(normalize_key(system), {})
+    try:
+        return float(entry.get("kwh_per_degree_day", 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def estimate_hvac_energy(
+    current_temp_c: float,
+    target_temp_c: float,
+    hours: float,
+    system: str,
+) -> float:
+    """Return estimated kWh to maintain ``target_temp_c`` for ``hours``."""
+    if hours <= 0:
+        raise ValueError("hours must be positive")
+    coeff = get_energy_coefficient(system)
+    if coeff <= 0:
+        return 0.0
+    degree_hours = abs(target_temp_c - current_temp_c) * hours
+    kwh = degree_hours * (coeff / 24)
+    return round(kwh, 2)

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -1,0 +1,20 @@
+import pytest
+
+from plant_engine.energy_manager import get_energy_coefficient, estimate_hvac_energy
+
+
+def test_get_energy_coefficient():
+    assert get_energy_coefficient("heating") == 0.5
+    assert get_energy_coefficient("cooling") == 0.4
+    assert get_energy_coefficient("unknown") == 0.0
+
+
+def test_estimate_hvac_energy():
+    # 2 degree difference for 12 hours with coefficient 0.5 kWh/degree-day
+    kwh = estimate_hvac_energy(18, 20, 12, "heating")
+    assert kwh == pytest.approx(0.5 * (2 * 12 / 24), 0.01)
+
+
+def test_estimate_hvac_energy_invalid_hours():
+    with pytest.raises(ValueError):
+        estimate_hvac_energy(18, 20, 0, "heating")


### PR DESCRIPTION
## Summary
- document new energy dataset in `README`
- add `hvac_energy_coefficients.json` dataset
- add `energy_manager` module for HVAC energy calculations
- test energy manager utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68819303f1d48330b66d9604d25951e2