### PR TITLE
Improve guideline summaries with pest prevention data

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Key reference datasets reside in the `data/` directory:
 - `disease_prevention.json` – cultural practices to prevent common diseases
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
+- `pest_prevention.json` – cultural practices to deter common pests
 - `bioinoculant_guidelines.json` – microbial inoculant suggestions by crop
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage
 - `ipm_guidelines.json` – integrated pest management practices by crop

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -32,6 +32,8 @@ class GuidelineSummary:
     pest_guidelines: Dict[str, str]
     disease_guidelines: Dict[str, str]
     disease_prevention: Dict[str, str]
+    pest_prevention: Dict[str, str] = dataclass_field(default_factory=dict)
+    ipm_guidelines: Dict[str, str] = dataclass_field(default_factory=dict)
     pest_thresholds: Dict[str, int] = dataclass_field(default_factory=dict)
     beneficial_insects: Dict[str, list[str]] = dataclass_field(default_factory=dict)
     bioinoculants: List[str] = dataclass_field(default_factory=list)
@@ -63,6 +65,8 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         nutrients=nutrient_manager.get_recommended_levels(plant_type, stage) if stage else {},
         micronutrients=micro_manager.get_recommended_levels(plant_type, stage) if stage else {},
         pest_guidelines=pest_manager.get_pest_guidelines(plant_type),
+        pest_prevention=pest_manager.get_pest_prevention(plant_type),
+        ipm_guidelines=pest_manager.get_ipm_guidelines(plant_type),
         disease_guidelines=disease_manager.get_disease_guidelines(plant_type),
         disease_prevention=disease_manager.get_disease_prevention(plant_type),
         pest_thresholds=thresholds,

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -14,6 +14,8 @@ def test_get_guideline_summary():
     assert data["pest_thresholds"]["aphids"] == 5
     assert "ladybugs" in data["beneficial_insects"]["aphids"]
     assert data["bioinoculants"] == []
+    assert "aphids" in data["pest_prevention"]
+    assert "general" in data["ipm_guidelines"]
     assert data["irrigation_volume_ml"] == 300
     assert "irrigation_interval_days" in data
 


### PR DESCRIPTION
## Summary
- include pest prevention and IPM guidance in `get_guideline_summary`
- update tests for new summary fields
- document `pest_prevention.json` in dataset list

## Testing
- `pytest tests/test_guidelines.py::test_get_guideline_summary -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881930f77e88330a2726da518721735