### PR TITLE
Refactor dataset utilities

### DIFF
--- a/plant_engine/disease_manager.py
+++ b/plant_engine/disease_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "disease_guidelines.json"
 PREVENTION_FILE = "disease_prevention.json"
@@ -17,7 +17,7 @@ _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with disease guidelines."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_disease_guidelines(plant_type: str) -> Dict[str, str]:

--- a/plant_engine/ec_manager.py
+++ b/plant_engine/ec_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Dict, Tuple
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "ec_guidelines.json"
 
@@ -24,7 +24,7 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return plant types with EC guidelines."""
-    return sorted(_data().keys())
+    return list_dataset_entries(_data())
 
 
 def get_ec_range(plant_type: str, stage: str | None = None) -> Tuple[float, float] | None:

--- a/plant_engine/nutrient_availability.py
+++ b/plant_engine/nutrient_availability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Dict, Iterable, Tuple
 
-from .utils import load_dataset
+from .utils import load_dataset, list_dataset_entries
 
 DATA_FILE = "nutrient_availability_ph.json"
 
@@ -23,7 +23,7 @@ Range = Tuple[float, float]
 @lru_cache(maxsize=None)
 def list_supported_nutrients() -> list[str]:
     """Return nutrient codes with availability data."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 @lru_cache(maxsize=None)

--- a/plant_engine/nutrient_interactions.py
+++ b/plant_engine/nutrient_interactions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Mapping
 
-from .utils import load_dataset
+from .utils import load_dataset, list_dataset_entries
 
 _Pair = tuple[str, str]
 
@@ -38,7 +38,7 @@ __all__ = [
 
 def list_interactions() -> list[str]:
     """Return all defined nutrient interaction pairs."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_interaction_info(pair: str) -> Dict[str, object]:

--- a/plant_engine/nutrient_uptake.py
+++ b/plant_engine/nutrient_uptake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .utils import load_dataset
+from .utils import load_dataset, list_dataset_entries
 
 DATA_FILE = "nutrient_uptake.json"
 
@@ -20,7 +20,7 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with uptake data."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_daily_uptake(plant_type: str, stage: str) -> Dict[str, float]:

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
@@ -21,7 +21,7 @@ _IPM: Dict[str, Dict[str, str]] = load_dataset(IPM_FILE)
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with pest guidelines."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_pest_guidelines(plant_type: str) -> Dict[str, str]:

--- a/plant_engine/ph_manager.py
+++ b/plant_engine/ph_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset
+from .utils import load_dataset, list_dataset_entries
 
 DATA_FILE = "ph_guidelines.json"
 ADJUST_FILE = "ph_adjustment_factors.json"
@@ -29,7 +29,7 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with pH guidelines."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_ph_range(plant_type: str, stage: str | None = None) -> list[float]:

--- a/plant_engine/plant_density.py
+++ b/plant_engine/plant_density.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "plant_density_guidelines.json"
 
@@ -14,7 +14,7 @@ __all__ = ["list_supported_plants", "get_spacing_cm", "plants_per_area"]
 
 def list_supported_plants() -> list[str]:
     """Return plant types with spacing guidelines."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_spacing_cm(plant_type: str) -> float | None:

--- a/plant_engine/pruning_manager.py
+++ b/plant_engine/pruning_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Dict
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "pruning_guidelines.json"
 INTERVAL_FILE = "pruning_intervals.json"
@@ -24,7 +24,7 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return all plant types with pruning data."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def list_stages(plant_type: str) -> list[str]:

--- a/plant_engine/thermal_time.py
+++ b/plant_engine/thermal_time.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "gdd_requirements.json"
 
@@ -31,7 +31,7 @@ def calculate_gdd(temp_min_c: float, temp_max_c: float, base_temp_c: float = 10.
 
 def list_supported_plants() -> list[str]:
     """Return plant types with GDD data."""
-    return sorted(_DATA.keys())
+    return list_dataset_entries(_DATA)
 
 
 def get_stage_gdd_requirement(plant_type: str, stage: str) -> int | None:


### PR DESCRIPTION
## Summary
- remove duplicated sorting helpers across plant modules
- re-use list_dataset_entries for dataset listing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688192f288b48330b328fd975da1cd20