### PR TITLE
Refactor fertilizer utilities

### DIFF
--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -33,6 +33,7 @@ estimate_cost_per_nutrient = fert_mod.estimate_cost_per_nutrient
 calculate_fertilizer_ppm = fert_mod.calculate_fertilizer_ppm
 calculate_mass_for_target_ppm = fert_mod.calculate_mass_for_target_ppm
 get_application_method = fert_mod.get_application_method
+CATALOG = fert_mod.CATALOG
 
 
 def test_convert_guaranteed_analysis():
@@ -243,4 +244,11 @@ def test_get_application_method():
     assert get_application_method("foxfarm_grow_big") == "soil drench"
     assert get_application_method("magriculture") == "foliar"
     assert get_application_method("unknown") is None
+
+
+def test_catalog_lists_products():
+    ids = CATALOG.list_products()
+    assert "foxfarm_grow_big" in ids
+    info = CATALOG.get_product_info("foxfarm_grow_big")
+    assert info.product_name
 


### PR DESCRIPTION
## Summary
- introduce `FertilizerCatalog` for cached access to fertilizer datasets
- use catalog in fertilizer helper functions
- expose catalog via module constant
- test catalog helpers

## Testing
- `pytest -q tests/test_fertilizer_formulator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f3c5dac48330add6c59b4389d2ef