### PR TITLE
Improve dataset refresh and tests

### DIFF
--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -155,7 +155,11 @@ def list_datasets_by_category() -> Dict[str, List[str]]:
 
 
 def refresh_datasets() -> None:
-    """Clear cached dataset listings in the default catalog."""
+    """Clear cached dataset and catalog results."""
 
     DEFAULT_CATALOG.refresh()
+    # Also clear any cached dataset contents so reloading picks up changes
+    from .utils import clear_dataset_cache
+
+    clear_dataset_cache()
 

--- a/tests/test_dataset_refresh.py
+++ b/tests/test_dataset_refresh.py
@@ -1,0 +1,28 @@
+import json
+import importlib
+
+import plant_engine.utils as utils
+import plant_engine.datasets as datasets
+
+
+def test_refresh_datasets_reload(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    file = data_dir / "sample.json"
+    file.write_text(json.dumps({"a": 1}))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(utils)
+    importlib.reload(datasets)
+
+    assert utils.load_dataset("sample.json") == {"a": 1}
+
+    file.write_text(json.dumps({"a": 2}))
+
+    # Cached result should still return original value
+    assert utils.load_dataset("sample.json") == {"a": 1}
+
+    datasets.refresh_datasets()
+
+    # After refresh we should get the updated value
+    assert utils.load_dataset("sample.json") == {"a": 2}


### PR DESCRIPTION
## Summary
- refresh all cached datasets when calling `refresh_datasets`
- test that `refresh_datasets` invalidates cached data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f3cf70b48330be6c5a1df9afd3e3