### PR TITLE
Enhance pest data integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Key reference datasets reside in the `data/` directory:
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `pest_prevention.json` – cultural practices to deter common pests
+- `pest_resistance_ratings.json` – relative resistance scores (1‑5) by crop and pest
 - `bioinoculant_guidelines.json` – microbial inoculant suggestions by crop
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage
 - `ipm_guidelines.json` – integrated pest management practices by crop

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -97,5 +97,6 @@
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",
   "disease_monitoring_intervals.json": "Recommended days between disease scouting events.",
   "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
+  "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
   "reference_et0.json": "Monthly reference ET0 values in mm/day"
 }

--- a/data/pest_resistance_ratings.json
+++ b/data/pest_resistance_ratings.json
@@ -1,0 +1,5 @@
+{
+  "citrus": {"aphids": 3, "scale": 2},
+  "tomato": {"aphids": 2, "whiteflies": 4},
+  "lettuce": {"aphids": 3}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -291,6 +291,7 @@ __all__ = [
     "recommend_pest_treatments",
     "get_pest_prevention",
     "recommend_pest_prevention",
+    "get_pest_resistance",
     "list_pest_plants",
     "get_pest_thresholds",
     "assess_pest_pressure",

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -9,6 +9,7 @@ DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
 PREVENTION_FILE = "pest_prevention.json"
 IPM_FILE = "ipm_guidelines.json"
+RESISTANCE_FILE = "pest_resistance_ratings.json"
 
 
 
@@ -17,6 +18,7 @@ _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
 _BENEFICIALS: Dict[str, List[str]] = load_dataset(BENEFICIAL_FILE)
 _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 _IPM: Dict[str, Dict[str, str]] = load_dataset(IPM_FILE)
+_RESISTANCE: Dict[str, Dict[str, float]] = load_dataset(RESISTANCE_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -32,6 +34,19 @@ def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
 def list_known_pests(plant_type: str) -> list[str]:
     """Return all pests with guidelines for ``plant_type``."""
     return sorted(get_pest_guidelines(plant_type).keys())
+
+
+def get_pest_resistance(plant_type: str, pest: str) -> float | None:
+    """Return relative resistance rating of a plant to ``pest``.
+
+    Ratings are arbitrary scores (1-5) where higher values indicate
+    greater natural resistance. ``None`` is returned when no rating is
+    defined for the plant/pest combination.
+    """
+
+    data = _RESISTANCE.get(normalize_key(plant_type), {})
+    value = data.get(normalize_key(pest))
+    return float(value) if isinstance(value, (int, float)) else None
 
 
 def recommend_treatments(plant_type: str, pests: Iterable[str]) -> Dict[str, str]:
@@ -135,5 +150,6 @@ __all__ = [
     "recommend_prevention",
     "get_ipm_guidelines",
     "recommend_ipm_actions",
+    "get_pest_resistance",
     "build_pest_management_plan",
 ]

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -76,3 +76,10 @@ def test_build_pest_management_plan():
     assert plan["aphids"]["treatment"].startswith("Apply insecticidal")
     assert "ladybugs" in plan["aphids"]["beneficials"]
     assert plan["unknown"]["treatment"] == "No guideline available"
+
+
+def test_get_pest_resistance():
+    from plant_engine.pest_manager import get_pest_resistance
+
+    assert get_pest_resistance("citrus", "aphids") == 3.0
+    assert get_pest_resistance("citrus", "unknown") is None


### PR DESCRIPTION
## Summary
- add new `pest_resistance_ratings.json` dataset
- expose pest resistance lookup from `pest_manager`
- export new helper via package `__init__`
- document dataset in README
- test pest resistance helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882162eef5c83308a62537a40c3eb24