### PR TITLE
Add per-nutrient NUE helper

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -249,6 +249,7 @@ from .nutrient_budget import (
     estimate_required_nutrients,
 )
 from .compute_transpiration import TranspirationMetrics
+from .nutrient_efficiency import calculate_nue, calculate_nue_for_nutrient
 from .nutrient_schedule import generate_daily_uptake_plan
 
 # Run functions should be imported explicitly to avoid heavy imports at package
@@ -440,6 +441,8 @@ __all__ = [
     "DailyReport",
     "load_profile",
     "TranspirationMetrics",
+    "calculate_nue",
+    "calculate_nue_for_nutrient",
     "STAGE_MULTIPLIERS",
     "get_stage_multiplier",
     "DEFAULT_ENV",

--- a/tests/test_nutrient_efficiency_single.py
+++ b/tests/test_nutrient_efficiency_single.py
@@ -1,0 +1,29 @@
+import json
+import plant_engine.nutrient_efficiency as ne
+
+def setup_data(tmp_path):
+    nutrient_dir = tmp_path / "nutes"
+    yield_dir = tmp_path / "yield"
+    nutrient_dir.mkdir()
+    yield_dir.mkdir()
+    nutrient_log = {"records": [{"nutrients_mg": {"N": 1000, "K": 500}}, {"nutrients_mg": {"N": 500}}]}
+    (nutrient_dir / "plant.json").write_text(json.dumps(nutrient_log))
+    yield_data = {"harvests": [{"yield_grams": 2000}]}
+    (yield_dir / "plant.json").write_text(json.dumps(yield_data))
+    return nutrient_dir, yield_dir
+
+def test_calculate_nue_for_nutrient(tmp_path, monkeypatch):
+    n_dir, y_dir = setup_data(tmp_path)
+    monkeypatch.setattr(ne, "NUTRIENT_DIR", str(n_dir))
+    monkeypatch.setattr(ne, "YIELD_DIR", str(y_dir))
+    nue_n = ne.calculate_nue_for_nutrient("plant", "N")
+    nue_k = ne.calculate_nue_for_nutrient("plant", "K")
+    assert round(nue_n, 2) == 1333.33  # 2kg yield / 1.5g N
+    assert round(nue_k, 2) == 4000.0   # 2kg yield / 0.5g K
+
+def test_calculate_nue_for_nutrient_missing(tmp_path, monkeypatch):
+    n_dir, y_dir = setup_data(tmp_path)
+    monkeypatch.setattr(ne, "NUTRIENT_DIR", str(n_dir))
+    monkeypatch.setattr(ne, "YIELD_DIR", str(y_dir))
+    assert ne.calculate_nue_for_nutrient("plant", "Ca") is None
+


### PR DESCRIPTION
## Summary
- expose nutrient use efficiency functions via `__init__`
- refactor NUE calculations into helper and add `calculate_nue_for_nutrient`
- test NUE helper functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688216323624833098c45bd1cbf7b453