### PR TITLE
Enhance pest management data

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Key reference datasets reside in the `data/` directory:
 - `yield/` – per‑plant yield logs created during operation
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations
 - `pesticide_withdrawal_days.json` – required wait time before harvest after pesticide use
+- `organic_pest_controls.json` – organic treatment options for common pests
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
 - `products_index.jsonl` – compact summary of WSDA products for fast searches (use `wsda_product_index`)

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -92,6 +92,7 @@
   "companion_plants.json": "Companion planting recommendations.",
   "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
+  "organic_pest_controls.json": "Organic treatment options for common pests.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",

--- a/data/organic_pest_controls.json
+++ b/data/organic_pest_controls.json
@@ -1,0 +1,7 @@
+{
+  "aphids": "Apply neem oil or insecticidal soap weekly.",
+  "scale": "Use horticultural oil spray during dormancy.",
+  "spider mites": "Knock off with water and apply insecticidal soap.",
+  "slugs": "Set beer traps or use iron phosphate bait.",
+  "leaf miners": "Remove affected leaves and introduce beneficial wasps."
+}

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -9,6 +9,7 @@ DATA_FILE = "pest_guidelines.json"
 BENEFICIAL_FILE = "beneficial_insects.json"
 PREVENTION_FILE = "pest_prevention.json"
 IPM_FILE = "ipm_guidelines.json"
+ORGANIC_FILE = "organic_pest_controls.json"
 
 
 
@@ -17,6 +18,7 @@ _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
 _BENEFICIALS: Dict[str, List[str]] = load_dataset(BENEFICIAL_FILE)
 _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 _IPM: Dict[str, Dict[str, str]] = load_dataset(IPM_FILE)
+_ORGANIC: Dict[str, str] = load_dataset(ORGANIC_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -51,6 +53,16 @@ def get_beneficial_insects(pest: str) -> List[str]:
 def recommend_beneficials(pests: Iterable[str]) -> Dict[str, List[str]]:
     """Return beneficial insect suggestions for observed ``pests``."""
     return {p: get_beneficial_insects(p) for p in pests}
+
+
+def get_organic_control(pest: str) -> str:
+    """Return organic treatment recommendation for ``pest``."""
+    return _ORGANIC.get(normalize_key(pest), "")
+
+
+def recommend_organic_controls(pests: Iterable[str]) -> Dict[str, str]:
+    """Return organic control options for each pest in ``pests``."""
+    return {p: get_organic_control(p) for p in pests}
 
 
 def get_pest_prevention(plant_type: str) -> Dict[str, str]:
@@ -112,6 +124,7 @@ def build_pest_management_plan(
     treatments = recommend_treatments(plant_type, pest_list)
     prevention = recommend_prevention(plant_type, pest_list)
     beneficials = recommend_beneficials(pest_list)
+    organic = recommend_organic_controls(pest_list)
 
     for pest in pest_list:
         plan[pest] = {
@@ -119,6 +132,7 @@ def build_pest_management_plan(
             "prevention": prevention.get(pest, "No guideline available"),
             "beneficials": beneficials.get(pest, []),
             "ipm": ipm_actions.get(pest),
+            "organic": organic.get(pest, ""),
         }
 
     return plan
@@ -131,6 +145,8 @@ __all__ = [
     "recommend_treatments",
     "get_beneficial_insects",
     "recommend_beneficials",
+    "get_organic_control",
+    "recommend_organic_controls",
     "get_pest_prevention",
     "recommend_prevention",
     "get_ipm_guidelines",

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -9,6 +9,8 @@ from plant_engine.pest_manager import (
     recommend_ipm_actions,
     list_known_pests,
     build_pest_management_plan,
+    get_organic_control,
+    recommend_organic_controls,
 )
 
 
@@ -39,6 +41,17 @@ def test_recommend_beneficials():
     rec = recommend_beneficials(["aphids", "scale"])
     assert "ladybugs" in rec["aphids"]
     assert "parasitic wasps" in rec["scale"]
+
+
+def test_get_organic_control():
+    assert "neem" in get_organic_control("aphids").lower()
+    assert get_organic_control("unknown") == ""
+
+
+def test_recommend_organic_controls():
+    rec = recommend_organic_controls(["aphids", "scale"])
+    assert "neem" in rec["aphids"].lower()
+    assert "oil" in rec["scale"].lower()
 
 
 def test_list_known_pests():
@@ -75,4 +88,5 @@ def test_build_pest_management_plan():
     assert "general" in plan
     assert plan["aphids"]["treatment"].startswith("Apply insecticidal")
     assert "ladybugs" in plan["aphids"]["beneficials"]
+    assert "neem" in plan["aphids"]["organic"].lower()
     assert plan["unknown"]["treatment"] == "No guideline available"


### PR DESCRIPTION
## Summary
- integrate new organic pest control recommendations
- expose helpers in pest_manager
- surface organic advice in pest management plans
- test organic guidance
- document `organic_pest_controls.json` dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688216516be88330b7397d3245163656