### PR TITLE
Add cycle irrigation plan feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ or incomplete and should only be used as a starting point for your own research.
 - **Irrigation Duration Estimate**: `estimate_irrigation_time` uses `emitter_flow_rates.json` to predict how long a watering event will take.
 - **Irrigation Schedule Efficiency**: `generate_irrigation_schedule` accepts a
   `method` parameter to automatically apply those efficiency factors.
+- **Cycle Irrigation Plan**: `generate_cycle_irrigation_plan` returns stage
+  irrigation volumes using guideline intervals and durations.
 - **Fertigation Planning**: `generate_fertigation_plan` produces a day-by-day
   fertilizer schedule using those irrigation targets.
 - **Comprehensive Fertigation**: `recommend_precise_fertigation` adjusts for

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -102,6 +102,7 @@ from .irrigation_manager import (
     list_supported_plants as list_irrigation_plants,
     get_daily_irrigation_target,
     generate_irrigation_schedule,
+    generate_cycle_irrigation_plan,
 )
 from .nutrient_manager import (
     calculate_deficiencies,
@@ -379,6 +380,7 @@ __all__ = [
     "list_irrigation_plants",
     "get_daily_irrigation_target",
     "generate_irrigation_schedule",
+    "generate_cycle_irrigation_plan",
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -11,6 +11,7 @@ from plant_engine.irrigation_manager import (
     list_supported_plants,
     generate_irrigation_schedule,
     generate_irrigation_schedule_with_runtime,
+    generate_cycle_irrigation_plan,
     adjust_irrigation_for_efficiency,
     estimate_irrigation_time,
     generate_env_irrigation_schedule,
@@ -273,4 +274,13 @@ def test_generate_irrigation_schedule_with_runtime():
     assert schedule[1]["volume_ml"] == 0.0
     runtime = estimate_irrigation_time(80.0, "drip", emitters=2)
     assert schedule[2]["runtime_h"] == pytest.approx(runtime, rel=1e-2)
+
+
+def test_generate_cycle_irrigation_plan():
+    plan = generate_cycle_irrigation_plan("lettuce")
+    assert "vegetative" in plan
+    veg = plan["vegetative"]
+    # verify at least one scheduled volume and it is positive
+    assert veg
+    assert veg[1] > 0
 


### PR DESCRIPTION
## Summary
- expose `generate_cycle_irrigation_plan` via `irrigation_manager`
- re-export in `plant_engine.__init__`
- document the new helper in README
- test new irrigation planning helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882163c89ac8330924fe5df5e939a1a