### PR TITLE
Integrate stage tasks into daily reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Key reference datasets reside in the `data/` directory:
 - `ph_adjustment_factors.json` – acid/base effect per mL for pH correction
 - `growth_stages.json` – lifecycle stage durations and notes by crop
 - `stage_multipliers.json` – default nutrient scaling factors by stage
+- `stage_tasks.json` – daily task recommendations for each growth stage
 - `pruning_guidelines.json` – stage-specific pruning recommendations
 - `pruning_intervals.json` – days between recommended pruning events
 - `soil_texture_parameters.json` – default field capacity and MAD values by soil texture
@@ -312,6 +313,8 @@ or incomplete and should only be used as a starting point for your own research.
   and end date of each growth stage when given a planting date.
 - **Stage Progress Remaining**: `days_until_next_stage` reports how many days
   remain in the current stage based on `growth_stages.json`.
+- **Stage Task Recommendations**: daily reports now include `stage_tasks` listing
+  suggested actions pulled from `stage_tasks.json`.
 - **Yield Estimation**: `estimate_remaining_yield` compares logged harvests to
   expected totals from `yield_estimates.json`.
   Daily reports now expose this value under `remaining_yield_g` for quick

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -34,6 +34,7 @@ from plant_engine.nutrient_analysis import analyze_nutrient_profile
 from plant_engine.compute_transpiration import compute_transpiration
 from plant_engine.rootzone_model import estimate_water_capacity
 from plant_engine.yield_prediction import estimate_remaining_yield
+from plant_engine.stage_tasks import get_stage_tasks
 
 
 @dataclass
@@ -57,6 +58,7 @@ class DailyReport:
     root_zone: dict[str, object] = field(default_factory=dict)
     transpiration: dict[str, float] = field(default_factory=dict)
     stage_info: dict[str, object] = field(default_factory=dict)
+    stage_tasks: list[str] = field(default_factory=list)
     stage_progress_pct: float | None = None
     fertigation_schedule: dict[str, float] = field(default_factory=dict)
     fertigation_cost: float | None = None
@@ -277,6 +279,9 @@ def run_daily_cycle(
         stage_key = stage_name if stage_name in stages else stage_name.lower()
         if stage_key in stages and isinstance(stages[stage_key], dict):
             report.stage_info = stages[stage_key]
+        tasks = get_stage_tasks(plant_type, stage_name)
+        if tasks:
+            report.stage_tasks = tasks
         if start_date_str:
             try:
                 start_date = datetime.fromisoformat(start_date_str).date()

--- a/tests/test_run_daily_cycle_stage_tasks.py
+++ b/tests/test_run_daily_cycle_stage_tasks.py
@@ -1,0 +1,18 @@
+import json
+from custom_components.horticulture_assistant.engine.run_daily_cycle import run_daily_cycle
+
+
+def test_run_daily_cycle_stage_tasks(tmp_path):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    out_dir = tmp_path / "reports"
+
+    (plants_dir / "plant1.json").write_text(
+        json.dumps({"general": {"plant_type": "tomato", "lifecycle_stage": "vegetative"}})
+    )
+    plant_dir = plants_dir / "plant1"
+    plant_dir.mkdir()
+
+    report = run_daily_cycle("plant1", base_path=str(plants_dir), output_path=str(out_dir))
+
+    assert report["stage_tasks"] == ["Prune side shoots", "Apply balanced fertilizer"]


### PR DESCRIPTION
## Summary
- expose `stage_tasks` in daily cycle reports
- document `stage_tasks.json` dataset and new report output
- test that daily reports include task suggestions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688216437b4c8330903a52f9e0669086