### PR TITLE
Improve cost utilities and tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/cost_analyzer.py
+++ b/custom_components/horticulture_assistant/utils/cost_analyzer.py
@@ -1,6 +1,10 @@
+"""Data structures for tracking product pricing over time."""
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 from datetime import datetime
+
+__all__ = ["ProductPriceEntry", "CostAnalyzer"]
 
 
 @dataclass
@@ -37,3 +41,4 @@ class CostAnalyzer:
                 unit_prices = [e.price / e.package_size for e in entries]
                 summary[product_id] = sum(unit_prices) / len(unit_prices)
         return summary
+

--- a/custom_components/horticulture_assistant/utils/product_cost_analyzer.py
+++ b/custom_components/horticulture_assistant/utils/product_cost_analyzer.py
@@ -1,34 +1,39 @@
-from typing import Literal, List, Dict
+"""Utility helpers for comparing product prices across units."""
+
+from typing import Dict, List, Literal
+
+__all__ = [
+    "ProductCostAnalyzer",
+]
+
+
+# Conversion factors to liters or kilograms
+UNIT_CONVERSIONS = {
+    "L": 1.0,
+    "mL": 1.0 / 1000,
+    "gal": 3.78541,
+    "kg": 1.0,
+    "g": 1.0 / 1000,
+    "oz": 0.0283495,
+}
 
 
 class ProductCostAnalyzer:
+    """Convenience methods for normalizing product pricing."""
+
     @staticmethod
     def cost_per_unit(
         price: float,
         size: float,
         unit: Literal["L", "mL", "gal", "kg", "g", "oz"]
     ) -> float:
-        """
-        Calculates the cost per standard unit (1 L or 1 kg).
-        :param price: Total price of the product package
-        :param size: Size of the package in its specified unit
-        :param unit: Unit of the package (volume or mass)
-        :return: Cost per unit (USD)
-        """
-        conversions = {
-            "L": 1,
-            "mL": 1 / 1000,
-            "gal": 3.78541,
-            "kg": 1,
-            "g": 1 / 1000,
-            "oz": 0.0283495,
-        }
+        """Return cost per liter or kilogram for a packaged product."""
 
-        if unit not in conversions:
+        if unit not in UNIT_CONVERSIONS:
             raise ValueError(f"Unsupported unit: {unit}")
 
-        size_in_standard = size * conversions[unit]
-        if size_in_standard == 0:
+        size_in_standard = size * UNIT_CONVERSIONS[unit]
+        if size_in_standard <= 0:
             raise ValueError("Size must be greater than zero")
 
         return round(price / size_in_standard, 4)
@@ -47,9 +52,9 @@ class ProductCostAnalyzer:
                 cost = ProductCostAnalyzer.cost_per_unit(
                     entry["price"], entry["size"], entry["unit"]
                 )
-                per_unit_prices.append(cost)
-            except ValueError:
+            except (KeyError, ValueError):
                 continue
+            per_unit_prices.append(cost)
 
         if not per_unit_prices:
             raise ValueError("No valid pricing data")
@@ -66,19 +71,10 @@ class ProductCostAnalyzer:
         dose_amount: float,
         dose_unit: Literal["L", "kg", "mL", "g", "oz"]
     ) -> float:
-        """
-        Estimates the cost of a single dose based on unit cost.
-        """
-        conversions = {
-            "L": 1,
-            "mL": 1 / 1000,
-            "kg": 1,
-            "g": 1 / 1000,
-            "oz": 0.0283495,
-        }
+        """Return cost for a single application amount."""
 
-        if dose_unit not in conversions:
+        if dose_unit not in UNIT_CONVERSIONS:
             raise ValueError(f"Unsupported dose unit: {dose_unit}")
 
-        dose_in_standard = dose_amount * conversions[dose_unit]
+        dose_in_standard = dose_amount * UNIT_CONVERSIONS[dose_unit]
         return round(cost_per_unit * dose_in_standard, 4)

--- a/tests/test_cost_analyzer.py
+++ b/tests/test_cost_analyzer.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from custom_components.horticulture_assistant.utils.cost_analyzer import (
+    ProductPriceEntry,
+    CostAnalyzer,
+)
+
+
+def test_cost_analyzer_basic():
+    entry = ProductPriceEntry(
+        product_id="foo",
+        distributor="A",
+        package_size_unit="L",
+        package_size=1.0,
+        price=10.0,
+        date_purchased=datetime(2024, 1, 1),
+    )
+    analyzer = CostAnalyzer()
+    analyzer.add_price_entry(entry)
+    assert analyzer.get_latest_price_per_unit("foo") == 10.0
+    summary = analyzer.summarize_costs()
+    assert summary["foo"] == 10.0
+    assert analyzer.get_latest_price_per_unit("missing") is None

--- a/tests/test_product_cost_analyzer.py
+++ b/tests/test_product_cost_analyzer.py
@@ -1,0 +1,30 @@
+import pytest
+from custom_components.horticulture_assistant.utils.product_cost_analyzer import ProductCostAnalyzer
+
+
+def test_cost_per_unit_basic():
+    assert ProductCostAnalyzer.cost_per_unit(10.0, 1.0, "L") == 10.0
+    assert ProductCostAnalyzer.cost_per_unit(10.0, 1000.0, "mL") == 10.0
+    assert ProductCostAnalyzer.cost_per_unit(5.0, 1.0, "kg") == 5.0
+    with pytest.raises(ValueError):
+        ProductCostAnalyzer.cost_per_unit(1.0, 0.0, "L")
+    with pytest.raises(ValueError):
+        ProductCostAnalyzer.cost_per_unit(1.0, 1.0, "unknown")
+
+
+def test_compare_sources():
+    data = [
+        {"price": 10.0, "size": 1.0, "unit": "L"},
+        {"price": 5.0, "size": 500.0, "unit": "mL"},
+    ]
+    result = ProductCostAnalyzer.compare_sources(data)
+    assert result == {"min_cost_per_unit": 10.0, "max_cost_per_unit": 10.0, "avg_cost_per_unit": 10.0}
+    with pytest.raises(ValueError):
+        ProductCostAnalyzer.compare_sources([])
+
+
+def test_cost_of_dose():
+    per_unit = ProductCostAnalyzer.cost_per_unit(10.0, 1.0, "L")
+    assert ProductCostAnalyzer.cost_of_dose(per_unit, 100.0, "mL") == 1.0
+    with pytest.raises(ValueError):
+        ProductCostAnalyzer.cost_of_dose(per_unit, 1.0, "bad")


### PR DESCRIPTION
## Summary
- refine `product_cost_analyzer` with clearer structure and unit conversions
- document `cost_analyzer` module
- add new tests for cost utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882164e50448330a2cfc375108fc4e6