### PR TITLE
Add pH-adjusted nutrient targets

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -341,6 +341,8 @@ __all__ = [
     "list_nutrient_plants",
     "get_nutrient_weight",
     "score_nutrient_levels",
+    "get_ph_adjusted_levels",
+    "calculate_deficiencies_with_ph",
     "list_micro_plants",
     "get_micro_levels",
     "list_silicon_plants",

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -138,3 +138,18 @@ def test_apply_tag_modifiers():
 
     unchanged = nm.apply_tag_modifiers(base, ["unknown-tag"])
     assert unchanged == base
+
+
+def test_get_ph_adjusted_levels():
+    from plant_engine.nutrient_manager import get_ph_adjusted_levels
+
+    adjusted = get_ph_adjusted_levels("tomato", "fruiting", 5.0)
+    assert adjusted["P"] > 60  # higher target at low pH
+
+
+def test_calculate_deficiencies_with_ph():
+    from plant_engine.nutrient_manager import calculate_deficiencies_with_ph
+
+    current = {"N": 80, "P": 60, "K": 120}
+    deficits = calculate_deficiencies_with_ph(current, "tomato", "fruiting", 5.0)
+    assert deficits["P"] > 0


### PR DESCRIPTION
## Summary
- clear dataset cache when (re)loading nutrient manager to honor overlays
- support pH adjusted nutrient guidelines and deficiency checks
- expose new utilities via plant_engine package
- test pH-based nutrient calculations

## Testing
- `pytest -q tests/test_nutrient_manager.py`
- `pytest -q tests/test_nutrient_availability.py`

------
https://chatgpt.com/codex/tasks/task_e_6882164b0d8883308726ea210fe5a520