### PR TITLE
Improve sensor template generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,15 @@ Development is private for now. Feedback is welcome, but pull requests will open
 ## Command Line Utilities
 This repository ships with a few helper scripts in the `scripts/` directory. The
 `generate_plant_sensors.py` utility converts daily JSON reports into Home
-Assistant template sensor YAML. Run it with:
+Assistant template sensor YAML. It can process a single plant or every report in
+the directory. Example usage:
 
 ```bash
+# single plant
 python scripts/generate_plant_sensors.py <plant_id>
+
+# generate for all reports
+python scripts/generate_plant_sensors.py --all
 ```
 The generated YAML is written to `templates/generated/` for easy import.
 

--- a/scripts/generate_plant_sensors.py
+++ b/scripts/generate_plant_sensors.py
@@ -4,12 +4,29 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - fallback when PyYAML is missing
+    yaml = None
 
 
 DEFAULT_OUTPUT_DIR = Path("templates/generated")
 DEFAULT_REPORT_DIR = Path("data/reports")
+
+
+@dataclass
+class SensorTemplate:
+    """Representation of a Home Assistant template sensor."""
+
+    name: str
+    unique_id: str
+    state: object
+    unit_of_measurement: str = ""
+    device_class: str = ""
 
 
 def _load_report(plant_id: str, report_dir: Path) -> Dict[str, object]:
@@ -20,18 +37,30 @@ def _load_report(plant_id: str, report_dir: Path) -> Dict[str, object]:
         return json.load(fh)
 
 
-def _write_yaml(sensors: Iterable[Dict[str, object]], out_path: Path) -> None:
-    """Write a list of ``sensors`` to ``out_path`` in YAML format."""
+def _write_yaml(sensors: Iterable[SensorTemplate], out_path: Path) -> None:
+    """Write ``sensors`` to ``out_path`` in YAML format."""
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    sensor_dicts = [asdict(s) for s in sensors]
+    if yaml is not None:
+        data = {"template": [{"sensor": sensor_dicts}]}
+        with out_path.open("w", encoding="utf-8") as fh:
+            yaml.safe_dump(data, fh, sort_keys=False)
+        return
+
+    # Basic string-based writer as fallback
     with out_path.open("w", encoding="utf-8") as fh:
         fh.write("template:\n  - sensor:\n")
-        for sensor in sensors:
+        for sensor in sensor_dicts:
             fh.write(f"      - name: \"{sensor['name']}\"\n")
             fh.write(f"        unique_id: {sensor['unique_id']}\n")
             fh.write(f"        state: \"{sensor['state']}\"\n")
-            fh.write("        unit_of_measurement: \"\"\n")
-            fh.write("        device_class: \"\"\n")
+            fh.write(
+                f"        unit_of_measurement: \"{sensor.get('unit_of_measurement','')}\"\n"
+            )
+            fh.write(
+                f"        device_class: \"{sensor.get('device_class','')}\"\n"
+            )
 
 
 def generate_template_yaml(
@@ -42,63 +71,80 @@ def generate_template_yaml(
     """Generate YAML template sensors for ``plant_id`` and return path."""
 
     data = _load_report(plant_id, report_dir)
-    
-    sensors = []
+
+    sensors: List[SensorTemplate] = []
 
     # Add VGI and Transpiration
     growth = data.get("growth", {})
-    sensors.append({
-        "name": f"{plant_id} VGI Today",
-        "unique_id": f"{plant_id}_vgi_today",
-        "state": growth.get("vgi_today", 0)
-    })
-    sensors.append({
-        "name": f"{plant_id} VGI Total",
-        "unique_id": f"{plant_id}_vgi_total",
-        "state": growth.get("vgi_total", 0)
-    })
+    sensors.append(
+        SensorTemplate(
+            name=f"{plant_id} VGI Today",
+            unique_id=f"{plant_id}_vgi_today",
+            state=growth.get("vgi_today", 0),
+        )
+    )
+    sensors.append(
+        SensorTemplate(
+            name=f"{plant_id} VGI Total",
+            unique_id=f"{plant_id}_vgi_total",
+            state=growth.get("vgi_total", 0),
+        )
+    )
 
-    sensors.append({
-        "name": f"{plant_id} Transpiration",
-        "unique_id": f"{plant_id}_transpiration",
-        "state": data.get("transpiration", {}).get("transpiration_ml_day", 0)
-    })
+    sensors.append(
+        SensorTemplate(
+            name=f"{plant_id} Transpiration",
+            unique_id=f"{plant_id}_transpiration",
+            state=data.get("transpiration", {}).get("transpiration_ml_day", 0),
+        )
+    )
 
     water = data.get("water_deficit", {})
-    sensors.append({
-        "name": f"{plant_id} Water Available",
-        "unique_id": f"{plant_id}_ml_available",
-        "state": water.get("ml_available", 0)
-    })
-    sensors.append({
-        "name": f"{plant_id} Depletion %",
-        "unique_id": f"{plant_id}_depletion_pct",
-        "state": round(water.get("depletion_pct", 0) * 100, 2)
-    })
+    sensors.append(
+        SensorTemplate(
+            name=f"{plant_id} Water Available",
+            unique_id=f"{plant_id}_ml_available",
+            state=water.get("ml_available", 0),
+        )
+    )
+    sensors.append(
+        SensorTemplate(
+            name=f"{plant_id} Depletion %",
+            unique_id=f"{plant_id}_depletion_pct",
+            state=round(water.get("depletion_pct", 0) * 100, 2),
+            unit_of_measurement="%",
+        )
+    )
 
-    sensors.append({
-        "name": f"{plant_id} MAD Crossed",
-        "unique_id": f"{plant_id}_mad_crossed",
-        "state": str(water.get("mad_crossed", False))
-    })
+    sensors.append(
+        SensorTemplate(
+            name=f"{plant_id} MAD Crossed",
+            unique_id=f"{plant_id}_mad_crossed",
+            state=str(water.get("mad_crossed", False)),
+        )
+    )
 
     # NUE sensors
     nue = data.get("nue", {}).get("nue", {})
     for element, value in nue.items():
-        sensors.append({
-            "name": f"{plant_id} NUE {element}",
-            "unique_id": f"{plant_id}_nue_{element}",
-            "state": value
-        })
+        sensors.append(
+            SensorTemplate(
+                name=f"{plant_id} NUE {element}",
+                unique_id=f"{plant_id}_nue_{element}",
+                state=value,
+            )
+        )
 
     # Threshold sensors
     thresholds = data.get("thresholds", {})
     for element, value in thresholds.items():
-        sensors.append({
-            "name": f"{plant_id} Target {element}",
-            "unique_id": f"{plant_id}_threshold_{element}",
-            "state": value
-        })
+        sensors.append(
+            SensorTemplate(
+                name=f"{plant_id} Target {element}",
+                unique_id=f"{plant_id}_threshold_{element}",
+                state=value,
+            )
+        )
 
     out_path = output_dir / f"{plant_id}_sensors.yaml"
     _write_yaml(sensors, out_path)
@@ -107,9 +153,24 @@ def generate_template_yaml(
     return out_path
 
 
+def generate_from_directory(
+    report_dir: Path = DEFAULT_REPORT_DIR,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> list[Path]:
+    """Generate YAML templates for all reports in ``report_dir``."""
+
+    paths: list[Path] = []
+    for report in sorted(report_dir.glob("*.json")):
+        plant_id = report.stem
+        paths.append(generate_template_yaml(plant_id, report_dir, output_dir))
+    return paths
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate template sensors from daily reports")
-    parser.add_argument("plant_id", help="ID used for the daily report file")
+    parser = argparse.ArgumentParser(
+        description="Generate template sensors from daily reports"
+    )
+    parser.add_argument("plant_id", nargs="?", help="ID used for the daily report file")
     parser.add_argument(
         "--reports",
         type=Path,
@@ -122,8 +183,19 @@ def main() -> None:
         default=DEFAULT_OUTPUT_DIR,
         help="directory to write generated YAML",
     )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="generate templates for all reports in the directory",
+    )
 
     args = parser.parse_args()
+
+    if args.all:
+        generate_from_directory(args.reports, args.output)
+        return
+    if not args.plant_id:
+        parser.error("plant_id is required unless --all is specified")
     generate_template_yaml(args.plant_id, args.reports, args.output)
 
 

--- a/tests/test_generate_plant_sensors_script.py
+++ b/tests/test_generate_plant_sensors_script.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.generate_plant_sensors import generate_template_yaml, generate_from_directory
+
+
+def _sample_report():
+    return {
+        "growth": {"vgi_today": 2, "vgi_total": 20},
+        "transpiration": {"transpiration_ml_day": 150},
+        "water_deficit": {"ml_available": 500, "depletion_pct": 0.25, "mad_crossed": False},
+        "nue": {"nue": {"N": 1.5}},
+        "thresholds": {"N": 100}
+    }
+
+
+def test_generate_template_yaml(tmp_path: Path):
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    report_file = report_dir / "plant1.json"
+    report_file.write_text(json.dumps(_sample_report()))
+    out_dir = tmp_path / "out"
+
+    out_path = generate_template_yaml("plant1", report_dir, out_dir)
+    assert out_path.exists()
+
+    data = yaml.safe_load(out_path.read_text())
+    sensors = data["template"][0]["sensor"]
+    names = {s["name"] for s in sensors}
+    assert "plant1 VGI Today" in names
+    assert "plant1 NUE N" in names
+
+
+def test_generate_from_directory(tmp_path: Path):
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    for pid in ["one", "two"]:
+        (report_dir / f"{pid}.json").write_text(json.dumps(_sample_report()))
+    out_dir = tmp_path / "out"
+
+    paths = generate_from_directory(report_dir, out_dir)
+    assert len(paths) == 2
+    assert sorted(p.stem for p in paths) == ["one_sensors", "two_sensors"]


### PR DESCRIPTION
## Summary
- refactor `generate_plant_sensors.py`
- support PyYAML output and fallback writer
- allow generating YAML for an entire directory
- document new options in README
- add regression tests for sensor YAML generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219bde46c8330a79ffd40e5b934b3