### PR TITLE
Add disease resistance dataset and shared risk evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Key reference datasets reside in the `data/` directory:
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `pest_prevention.json` – cultural practices to deter common pests
 - `pest_resistance_ratings.json` – relative resistance scores (1‑5) by crop and pest
+- `disease_resistance_ratings.json` – relative resistance scores (1‑5) by crop and disease
 - `bioinoculant_guidelines.json` – microbial inoculant suggestions by crop
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage
 - `ipm_guidelines.json` – integrated pest management practices by crop

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -99,5 +99,6 @@
   "disease_severity_actions.json": "Actions to take based on disease severity level.",
   "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
   "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
+  "disease_resistance_ratings.json": "Relative disease resistance ratings by crop.",
   "reference_et0.json": "Monthly reference ET0 values in mm/day"
 }

--- a/data/disease_resistance_ratings.json
+++ b/data/disease_resistance_ratings.json
@@ -1,0 +1,5 @@
+{
+  "citrus": {"greasy_spot": 4, "powdery_mildew": 3},
+  "tomato": {"blight": 2},
+  "lettuce": {"downy_mildew": 2}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -64,6 +64,7 @@ from .disease_manager import (
     list_supported_plants as list_disease_plants,
     get_disease_prevention,
     recommend_prevention as recommend_disease_prevention,
+    get_disease_resistance,
 )
 from .fertigation import (
     recommend_fertigation_schedule,
@@ -303,6 +304,7 @@ __all__ = [
     "recommend_disease_treatments",
     "get_disease_prevention",
     "recommend_disease_prevention",
+    "get_disease_resistance",
     "list_disease_plants",
     "get_disease_thresholds",
     "assess_disease_pressure",

--- a/plant_engine/disease_manager.py
+++ b/plant_engine/disease_manager.py
@@ -5,6 +5,8 @@ from typing import Dict, Iterable
 
 from .utils import load_dataset, normalize_key, list_dataset_entries
 
+RESISTANCE_FILE = "disease_resistance_ratings.json"
+
 DATA_FILE = "disease_guidelines.json"
 PREVENTION_FILE = "disease_prevention.json"
 
@@ -13,6 +15,7 @@ PREVENTION_FILE = "disease_prevention.json"
 # Dataset is cached by ``load_dataset`` so load once at import time
 _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
 _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
+_RESISTANCE: Dict[str, Dict[str, float]] = load_dataset(RESISTANCE_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -53,6 +56,18 @@ def recommend_prevention(plant_type: str, diseases: Iterable[str]) -> Dict[str, 
     return actions
 
 
+def get_disease_resistance(plant_type: str, disease: str) -> float | None:
+    """Return relative resistance rating of a plant to ``disease``.
+
+    Ratings are arbitrary scores (1-5). ``None`` is returned when no rating is
+    defined for the plant/disease combination.
+    """
+
+    data = _RESISTANCE.get(normalize_key(plant_type), {})
+    value = data.get(normalize_key(disease))
+    return float(value) if isinstance(value, (int, float)) else None
+
+
 __all__ = [
     "list_supported_plants",
     "get_disease_guidelines",
@@ -60,4 +75,5 @@ __all__ = [
     "recommend_treatments",
     "get_disease_prevention",
     "recommend_prevention",
+    "get_disease_resistance",
 ]

--- a/plant_engine/disease_monitor.py
+++ b/plant_engine/disease_monitor.py
@@ -99,28 +99,9 @@ def estimate_disease_risk(
     if not factors:
         return {}
 
-    readings = environment_manager.normalize_environment_readings(environment)
-    risks: Dict[str, str] = {}
-    for disease, reqs in factors.items():
-        matches = 0
-        total = 0
-        for key, (low, high) in reqs.items():
-            total += 1
-            value = readings.get(key)
-            if value is None:
-                continue
-            if low <= value <= high:
-                matches += 1
-        if total == 0:
-            continue
-        if matches == 0:
-            level = "low"
-        elif matches < total:
-            level = "moderate"
-        else:
-            level = "high"
-        risks[disease] = level
-    return risks
+    from .monitor_utils import estimate_condition_risk
+
+    return estimate_condition_risk(factors, environment)
 
 
 def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | None:

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -135,28 +135,9 @@ def estimate_pest_risk(
     if not factors:
         return {}
 
-    readings = environment_manager.normalize_environment_readings(environment)
-    risks: Dict[str, str] = {}
-    for pest, reqs in factors.items():
-        matches = 0
-        total = 0
-        for key, (low, high) in reqs.items():
-            total += 1
-            value = readings.get(key)
-            if value is None:
-                continue
-            if low <= value <= high:
-                matches += 1
-        if total == 0:
-            continue
-        if matches == 0:
-            level = "low"
-        elif matches < total:
-            level = "moderate"
-        else:
-            level = "high"
-        risks[pest] = level
-    return risks
+    from .monitor_utils import estimate_condition_risk
+
+    return estimate_condition_risk(factors, environment)
 
 
 def classify_pest_severity(

--- a/tests/test_disease_manager.py
+++ b/tests/test_disease_manager.py
@@ -2,6 +2,7 @@ from plant_engine.disease_manager import (
     get_disease_guidelines,
     recommend_treatments,
     list_known_diseases,
+    get_disease_resistance,
 )
 
 
@@ -25,3 +26,8 @@ def test_recommend_treatments():
 def test_list_known_diseases():
     diseases = list_known_diseases("citrus")
     assert "root rot" in diseases
+
+
+def test_get_disease_resistance():
+    assert get_disease_resistance("citrus", "greasy_spot") == 4.0
+    assert get_disease_resistance("citrus", "unknown") is None


### PR DESCRIPTION
## Summary
- add dataset for disease resistance ratings
- list new dataset in catalog and documentation
- implement `get_disease_resistance` helper
- factor pest/disease risk logic into `estimate_condition_risk`
- use new helper in pest and disease monitors
- test disease resistance helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219aa8ccc8330aaf8000ccb07ff76