### PR TITLE
Improve recommendation engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ or incomplete and should only be used as a starting point for your own research.
 - **Nutrient Interaction Details**: `analyze_interactions` returns ratios,
   messages and corrective actions for any detected nutrient imbalances.
 - **Deficit-Based Fertilizer Suggestions**: `RecommendationEngine` now recommends products using nutrient guidelines when sensor readings fall short.
+- **Multi-Plant Recommendations**: `RecommendationEngine.recommend_all` returns a
+  bundle for every registered plant and `reset_state` clears cached data for new
+  planning cycles.
 - **Daily Nutrient Report**: `run_daily_cycle` now embeds this analysis under
   `nutrient_analysis` to highlight imbalances in recent applications.
 - **Pruning Recommendations**: Call `get_pruning_instructions` for stage-specific

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -44,3 +44,12 @@ def test_recommendation_engine_environment_notes():
     eng = _setup_engine(auto=False)
     rec = eng.recommend("p1")
     assert any("temperature" in n for n in rec.notes)
+
+
+def test_recommendation_engine_recommend_all_and_reset():
+    eng = _setup_engine(auto=False)
+    all_recs = eng.recommend_all()
+    assert "p1" in all_recs
+    eng.reset_state()
+    assert eng.plant_profiles == {}
+    assert eng._element_map == {}


### PR DESCRIPTION
## Summary
- optimize `RecommendationEngine` with element cache
- add multi-plant recommendation and reset helpers
- document new features in README
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219b13004833080b0d030d542474e