### PR TITLE
Add stage completion date helper

### DIFF
--- a/plant_engine/thermal_time.py
+++ b/plant_engine/thermal_time.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Dict, Iterable
+from datetime import date, timedelta
 
 from .utils import load_dataset, normalize_key, list_dataset_entries
 
@@ -17,6 +18,7 @@ __all__ = [
     "predict_stage_completion",
     "accumulate_gdd_series",
     "estimate_days_to_stage",
+    "estimate_stage_completion_date",
 ]
 
 
@@ -83,3 +85,18 @@ def estimate_days_to_stage(
             return day
 
     return None
+
+
+def estimate_stage_completion_date(
+    plant_type: str,
+    stage: str,
+    start_date: date,
+    temps: Iterable[tuple[float, float]],
+    base_temp_c: float = 10.0,
+) -> date | None:
+    """Return predicted date when ``stage`` will be reached."""
+
+    days = estimate_days_to_stage(plant_type, stage, temps, base_temp_c)
+    if days is None:
+        return None
+    return start_date + timedelta(days=days)

--- a/tests/test_thermal_time.py
+++ b/tests/test_thermal_time.py
@@ -1,3 +1,4 @@
+import datetime
 from plant_engine import thermal_time
 
 
@@ -29,3 +30,12 @@ def test_estimate_days_to_stage():
     temps = [(20, 30)] * 60
     days = thermal_time.estimate_days_to_stage("tomato", "fruiting", temps)
     assert isinstance(days, int) and 0 < days <= 60
+
+
+def test_estimate_stage_completion_date():
+    temps = [(20, 30)] * 10
+    start = datetime.date(2025, 1, 1)
+    date = thermal_time.estimate_stage_completion_date(
+        "lettuce", "vegetative", start, temps
+    )
+    assert date is None or date >= start


### PR DESCRIPTION
## Summary
- extend `thermal_time` with new `estimate_stage_completion_date` helper
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219b73a848330a80bc6238020f75d