### PR TITLE
Refactor dataset stage lookups

### DIFF
--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -15,7 +15,7 @@ from .nutrient_manager import (
     calculate_all_deficiencies,
     get_all_recommended_levels,
 )
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, stage_value
 
 FOLIAR_DATA = "foliar_feed_guidelines.json"
 INTERVAL_DATA = "foliar_feed_intervals.json"
@@ -138,12 +138,7 @@ def recommend_foliar_feed(
 def get_foliar_feed_interval(plant_type: str, stage: str | None = None) -> int | None:
     """Return recommended days between foliar feeds."""
 
-    data = _INTERVALS.get(normalize_key(plant_type), {})
-    if stage:
-        value = data.get(normalize_key(stage))
-        if isinstance(value, (int, float)):
-            return int(value)
-    value = data.get("optimal")
+    value = stage_value(_INTERVALS, plant_type, stage)
     if isinstance(value, (int, float)):
         return int(value)
     return None
@@ -164,12 +159,7 @@ def next_foliar_feed_date(
 def get_foliar_spray_volume(plant_type: str, stage: str | None = None) -> float | None:
     """Return recommended foliar spray volume per plant in milliliters."""
 
-    data = _FOLIAR_VOLUME.get(normalize_key(plant_type), {})
-    if stage:
-        value = data.get(normalize_key(stage))
-        if isinstance(value, (int, float)):
-            return float(value)
-    value = data.get("optimal")
+    value = stage_value(_FOLIAR_VOLUME, plant_type, stage)
     if isinstance(value, (int, float)):
         return float(value)
     return None
@@ -193,12 +183,7 @@ def estimate_spray_solution_volume(
 def get_fertigation_interval(plant_type: str, stage: str | None = None) -> int | None:
     """Return recommended days between fertigation events."""
 
-    data = _FERTIGATION_INTERVALS.get(normalize_key(plant_type), {})
-    if stage:
-        value = data.get(normalize_key(stage))
-        if isinstance(value, (int, float)):
-            return int(value)
-    value = data.get("optimal")
+    value = stage_value(_FERTIGATION_INTERVALS, plant_type, stage)
     if isinstance(value, (int, float)):
         return int(value)
     return None

--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict
 from typing import Mapping, Dict, Any
 
-from .utils import load_dataset, normalize_key
+from .utils import load_dataset, normalize_key, stage_value
 from .et_model import calculate_eta
 
 from .rootzone_model import RootZone, calculate_remaining_water
@@ -305,12 +305,10 @@ def get_daily_irrigation_target(plant_type: str, stage: str) -> float:
 def get_recommended_interval(plant_type: str, stage: str) -> float | None:
     """Return days between irrigation events for a plant stage if known."""
 
-    plant = _INTERVAL_DATA.get(normalize_key(plant_type), {})
-    value = plant.get(normalize_key(stage))
+    value = stage_value(_INTERVAL_DATA, plant_type, stage)
     if isinstance(value, (int, float)):
         return float(value)
-    value = plant.get("optimal")
-    return float(value) if isinstance(value, (int, float)) else None
+    return None
 
 
 def generate_irrigation_schedule(

--- a/plant_engine/ph_manager.py
+++ b/plant_engine/ph_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-from .utils import load_dataset, list_dataset_entries
+from .utils import load_dataset, list_dataset_entries, stage_value
 
 DATA_FILE = "ph_guidelines.json"
 ADJUST_FILE = "ph_adjustment_factors.json"
@@ -34,13 +34,8 @@ def list_supported_plants() -> list[str]:
 
 def get_ph_range(plant_type: str, stage: str | None = None) -> list[float]:
     """Return pH range for ``plant_type`` and ``stage``."""
-    data = _DATA.get(plant_type.lower())
-    if not data:
-        return []
-    if stage and stage in data:
-        rng = data[stage]
-    else:
-        rng = data.get("optimal")
+
+    rng = stage_value(_DATA, plant_type, stage)
     if isinstance(rng, Iterable):
         values = list(rng)
         if len(values) == 2:

--- a/plant_engine/pruning_manager.py
+++ b/plant_engine/pruning_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Dict
 
-from .utils import load_dataset, normalize_key, list_dataset_entries
+from .utils import load_dataset, normalize_key, list_dataset_entries, stage_value
 
 DATA_FILE = "pruning_guidelines.json"
 INTERVAL_FILE = "pruning_intervals.json"
@@ -43,14 +43,7 @@ def get_pruning_instructions(plant_type: str, stage: str) -> str:
 def get_pruning_interval(plant_type: str, stage: str | None = None) -> int | None:
     """Return recommended days between pruning events."""
 
-    data = _INTERVALS.get(normalize_key(plant_type))
-    if not isinstance(data, dict):
-        return None
-    if stage and normalize_key(stage) in data:
-        value = data[normalize_key(stage)]
-        if isinstance(value, (int, float)):
-            return int(value)
-    value = data.get("optimal")
+    value = stage_value(_INTERVALS, plant_type, stage)
     if isinstance(value, (int, float)):
         return int(value)
     return None

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "list_dataset_entries",
     "parse_range",
     "deep_update",
+    "stage_value",
 ]
 
 
@@ -148,3 +149,19 @@ def parse_range(value: Iterable[float]) -> tuple[float, float] | None:
         return float(low), float(high)
     except (TypeError, ValueError, Exception):
         return None
+
+
+def stage_value(
+    dataset: Mapping[str, Any],
+    plant_type: str,
+    stage: str | None,
+    default_key: str = "optimal",
+) -> Any:
+    """Return a stage specific value from ``dataset`` with fallback."""
+
+    plant = dataset.get(normalize_key(plant_type), {})
+    if stage:
+        value = plant.get(normalize_key(stage))
+        if value is not None:
+            return value
+    return plant.get(default_key)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,12 @@ import pytest
 import importlib
 
 import plant_engine.utils as utils
-from plant_engine.utils import load_json, normalize_key, clear_dataset_cache
+from plant_engine.utils import (
+    load_json,
+    normalize_key,
+    clear_dataset_cache,
+    stage_value,
+)
 
 
 def test_normalize_key_lowercase():
@@ -58,3 +63,15 @@ def test_clear_dataset_cache(monkeypatch, tmp_path):
     importlib.reload(utils)
     second = utils.load_dataset("sample.json")
     assert second == {"a": 2}
+
+
+def test_stage_value_fallback():
+    data = {"lettuce": {"seedling": "A", "optimal": "B"}}
+    assert stage_value(data, "lettuce", "seedling") == "A"
+    assert stage_value(data, "lettuce", None) == "B"
+    assert stage_value(data, "lettuce", "unknown") == "B"
+
+
+def test_stage_value_custom_default():
+    data = {"crop": {"phase": 1, "default": 2}}
+    assert stage_value(data, "crop", "missing", default_key="default") == 2


### PR DESCRIPTION
## Summary
- add `stage_value` utility to streamline stage-specific dataset access
- refactor fertigation, irrigation, pH and pruning helpers to use the new helper
- test new helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219d7e4148330b2d56bfeab4a69b8