### PR TITLE
Add soil organic matter dataset and integrate into environment manager

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -97,5 +97,6 @@
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",
   "disease_monitoring_intervals.json": "Recommended days between disease scouting events.",
   "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
+  "soil_organic_matter_guidelines.json": "Recommended soil organic matter percentage for crops.",
   "reference_et0.json": "Monthly reference ET0 values in mm/day"
 }

--- a/data/soil_organic_matter_guidelines.json
+++ b/data/soil_organic_matter_guidelines.json
@@ -1,0 +1,5 @@
+{
+  "citrus": {"optimal": [2.5, 3.5]},
+  "tomato": {"optimal": [3.0, 4.0]},
+  "lettuce": {"optimal": [3.0, 4.5]}
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -39,6 +39,7 @@ from plant_engine.environment_manager import (
     evaluate_stress_conditions,
     evaluate_soil_temperature_stress,
     evaluate_soil_ec_stress,
+    evaluate_soil_organic_matter,
     score_environment,
     score_environment_series,
     score_environment_components,
@@ -57,6 +58,7 @@ from plant_engine.environment_manager import (
     clear_environment_cache,
     get_target_soil_temperature,
     get_target_soil_ec,
+    get_target_soil_organic_matter,
 )
 
 
@@ -624,8 +626,19 @@ def test_evaluate_soil_ec_stress():
     assert evaluate_soil_ec_stress(0.8, "lettuce", "seedling") is None
 
 
+def test_get_target_soil_organic_matter():
+    assert get_target_soil_organic_matter("citrus") == (2.5, 3.5)
+    assert get_target_soil_organic_matter("unknown") is None
+
+
+def test_evaluate_soil_organic_matter():
+    assert evaluate_soil_organic_matter(2.0, "lettuce") == "low"
+    assert evaluate_soil_organic_matter(5.0, "lettuce") == "high"
+    assert evaluate_soil_organic_matter(3.5, "lettuce") is None
+
+
 def test_evaluate_stress_conditions():
-    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling", 12)
+    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling", 12, 1.2, 2.0)
     assert stress.heat is True
     assert stress.cold is False
     assert stress.light == "low"
@@ -633,7 +646,7 @@ def test_evaluate_stress_conditions():
     assert stress.humidity is None
     assert stress.soil_temp == "cold"
 
-    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, "citrus")
+    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, "citrus", None, None, None)
     assert stress_none.heat is None
     assert stress_none.humidity is None
     assert stress_none.soil_temp is None


### PR DESCRIPTION
## Summary
- add new `soil_organic_matter_guidelines.json` dataset
- document dataset in `dataset_catalog.json`
- support soil organic matter targets in `environment_manager`
- expose `get_target_soil_organic_matter` and `evaluate_soil_organic_matter`
- include SOM analysis in environment optimization and stress evaluation
- extend tests for new functions and updated signature

## Testing
- `pytest -q`
- `pytest -q --cov=custom_components.horticulture_assistant --cov=plant_engine`

------
https://chatgpt.com/codex/tasks/task_e_6882165ffadc8330a2ef9c631c2c4e5f