### PR TITLE
Expand nutrient datasets

### DIFF
--- a/data/nutrient_deficiency_symptoms.json
+++ b/data/nutrient_deficiency_symptoms.json
@@ -4,5 +4,11 @@
   "K": "Leaf edges may scorch or curl.",
   "Ca": "New leaves appear distorted or die back.",
   "Mg": "Yellowing between veins on older leaves.",
-  "Fe": "Young leaves become yellow while veins remain green."
+  "Fe": "Young leaves become yellow while veins remain green.",
+  "S": "Young foliage appears pale and overall growth slows.",
+  "Zn": "Short internodes with mottled young leaves.",
+  "Mn": "Interveinal chlorosis with brown spotting on leaves.",
+  "B": "Growing tips die back and leaves become brittle.",
+  "Cu": "New leaves are dark and may wilt or curl.",
+  "Mo": "Older leaves show mottling or marginal necrosis."
 }

--- a/data/nutrient_deficiency_treatments.json
+++ b/data/nutrient_deficiency_treatments.json
@@ -4,5 +4,11 @@
   "K": "Add potassium sulfate or a balanced fertilizer.",
   "Ca": "Use calcium nitrate or agricultural lime.",
   "Mg": "Apply magnesium sulfate (Epsom salt).",
-  "Fe": "Spray with chelated iron or adjust pH to improve availability."
+  "Fe": "Spray with chelated iron or adjust pH to improve availability.",
+  "S": "Apply gypsum or elemental sulfur depending on soil pH.",
+  "Zn": "Foliar spray with zinc sulfate or chelated zinc.",
+  "Mn": "Apply manganese sulfate as a soil drench or foliar spray.",
+  "B": "Use borax or a boron-containing fertilizer sparingly.",
+  "Cu": "Apply copper sulfate or a copper chelate at low rates.",
+  "Mo": "Provide sodium molybdate or ammonium molybdate."
 }

--- a/data/nutrient_mobility.json
+++ b/data/nutrient_mobility.json
@@ -4,5 +4,11 @@
   "K": "mobile",
   "Ca": "immobile",
   "Mg": "mobile",
-  "Fe": "immobile"
+  "Fe": "immobile",
+  "S": "mobile",
+  "Zn": "immobile",
+  "Mn": "immobile",
+  "B": "immobile",
+  "Cu": "immobile",
+  "Mo": "mobile"
 }

--- a/tests/test_deficiency_manager.py
+++ b/tests/test_deficiency_manager.py
@@ -51,6 +51,13 @@ def test_get_nutrient_mobility():
     assert get_nutrient_mobility("N") == "mobile"
 
 
+def test_new_nutrient_entries():
+    """Ensure newly added nutrients are recognized."""
+    assert "Zn" in list_known_nutrients()
+    assert get_nutrient_mobility("Zn") == "immobile"
+    assert "boron" in get_deficiency_treatment("B").lower()
+
+
 def test_diagnose_deficiencies_detailed():
     guidelines = get_recommended_levels("spinach", "harvest")
     current = {key: 0 for key in guidelines}


### PR DESCRIPTION
## Summary
- extend deficiency symptom dataset with more nutrients
- extend deficiency treatment dataset with matching recommendations
- mark additional nutrient mobility classifications
- test new entries in deficiency manager

## Testing
- `pytest -q`
- `pytest tests/test_deficiency_manager.py::test_new_nutrient_entries -q`


------
https://chatgpt.com/codex/tasks/task_e_688219d416a08330a9f3cf2db37eaeb6