### PR TITLE
Enhance pest manager with organic control data

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Key reference datasets reside in the `data/` directory:
 - `pest_thresholds.json` – action thresholds for common pests
 - `beneficial_insects.json` – natural predator recommendations for pests
 - `pest_prevention.json` – cultural practices to deter common pests
+- `organic_pest_controls.json` – organic treatment options for common pests
 - `pest_resistance_ratings.json` – relative resistance scores (1‑5) by crop and pest
 - `bioinoculant_guidelines.json` – microbial inoculant suggestions by crop
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -58,6 +58,7 @@
   "nutrient_uptake.json": "Estimated daily uptake rates for nutrients.",
   "nutrient_removal_rates.json": "Nutrient removal from harvested biomass per kg yield.",
   "pest_prevention.json": "Cultural practices to reduce pest pressure.",
+  "organic_pest_controls.json": "Organic treatment options for common pests.",
   "pest_risk_factors.json": "Environmental factors increasing pest risk.",
   "disease_risk_factors.json": "Environmental factors increasing disease risk.",
   "pest_severity_actions.json": "Actions to take based on pest severity level.",

--- a/data/organic_pest_controls.json
+++ b/data/organic_pest_controls.json
@@ -1,0 +1,6 @@
+{
+  "aphids": ["neem oil", "insecticidal soap"],
+  "whiteflies": ["horticultural oil", "yellow sticky traps"],
+  "powdery mildew": ["sulfur-based fungicide", "potassium bicarbonate"],
+  "scale": ["horticultural oil", "prune infested branches"]
+}

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -10,6 +10,7 @@ BENEFICIAL_FILE = "beneficial_insects.json"
 PREVENTION_FILE = "pest_prevention.json"
 IPM_FILE = "ipm_guidelines.json"
 RESISTANCE_FILE = "pest_resistance_ratings.json"
+ORGANIC_FILE = "organic_pest_controls.json"
 
 
 
@@ -19,6 +20,7 @@ _BENEFICIALS: Dict[str, List[str]] = load_dataset(BENEFICIAL_FILE)
 _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 _IPM: Dict[str, Dict[str, str]] = load_dataset(IPM_FILE)
 _RESISTANCE: Dict[str, Dict[str, float]] = load_dataset(RESISTANCE_FILE)
+_ORGANIC: Dict[str, List[str]] = load_dataset(ORGANIC_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -66,6 +68,18 @@ def get_beneficial_insects(pest: str) -> List[str]:
 def recommend_beneficials(pests: Iterable[str]) -> Dict[str, List[str]]:
     """Return beneficial insect suggestions for observed ``pests``."""
     return {p: get_beneficial_insects(p) for p in pests}
+
+
+def get_organic_controls(pest: str) -> List[str]:
+    """Return organic control options for ``pest``."""
+
+    return _ORGANIC.get(normalize_key(pest), [])
+
+
+def recommend_organic_controls(pests: Iterable[str]) -> Dict[str, List[str]]:
+    """Return organic control recommendations for observed ``pests``."""
+
+    return {p: get_organic_controls(p) for p in pests}
 
 
 def get_pest_prevention(plant_type: str) -> Dict[str, str]:
@@ -127,6 +141,7 @@ def build_pest_management_plan(
     treatments = recommend_treatments(plant_type, pest_list)
     prevention = recommend_prevention(plant_type, pest_list)
     beneficials = recommend_beneficials(pest_list)
+    organic = recommend_organic_controls(pest_list)
 
     for pest in pest_list:
         plan[pest] = {
@@ -134,6 +149,7 @@ def build_pest_management_plan(
             "prevention": prevention.get(pest, "No guideline available"),
             "beneficials": beneficials.get(pest, []),
             "ipm": ipm_actions.get(pest),
+            "organic": organic.get(pest, []),
         }
 
     return plan
@@ -146,6 +162,8 @@ __all__ = [
     "recommend_treatments",
     "get_beneficial_insects",
     "recommend_beneficials",
+    "get_organic_controls",
+    "recommend_organic_controls",
     "get_pest_prevention",
     "recommend_prevention",
     "get_ipm_guidelines",

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -83,3 +83,24 @@ def test_get_pest_resistance():
 
     assert get_pest_resistance("citrus", "aphids") == 3.0
     assert get_pest_resistance("citrus", "unknown") is None
+
+
+def test_get_organic_controls():
+    from plant_engine.pest_manager import (
+        get_organic_controls,
+        recommend_organic_controls,
+    )
+
+    controls = get_organic_controls("aphids")
+    assert "neem oil" in controls
+    assert get_organic_controls("unknown") == []
+
+    rec = recommend_organic_controls(["aphids", "unknown"])
+    assert "neem oil" in rec["aphids"]
+    assert rec["unknown"] == []
+
+
+def test_build_pest_management_plan_includes_organic():
+    plan = build_pest_management_plan("citrus", ["aphids"])
+    assert "organic" in plan["aphids"]
+    assert "neem oil" in plan["aphids"]["organic"]


### PR DESCRIPTION
## Summary
- add organic pest control dataset
- load and expose organic control recommendations in `pest_manager`
- include organic options in pest management plan output
- document new dataset in README
- test organic control functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219c481bc8330976774afe02f3918