### PR TITLE
Refine dataset utils and add coverage

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -6,7 +6,7 @@ import json
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Iterable
 
 __all__ = [
     "load_json",
@@ -75,12 +75,12 @@ EXTRA_ENV = "HORTICULTURE_EXTRA_DATA_DIRS"
 
 def _data_dir() -> Path:
     env = os.getenv("HORTICULTURE_DATA_DIR")
-    return Path(env) if env else DEFAULT_DATA_DIR
+    return Path(env).expanduser() if env else DEFAULT_DATA_DIR
 
 
 def _overlay_dir() -> Path | None:
     env = os.getenv(OVERLAY_ENV)
-    return Path(env) if env else None
+    return Path(env).expanduser() if env else None
 
 
 def _extra_dirs() -> list[Path]:
@@ -89,7 +89,7 @@ def _extra_dirs() -> list[Path]:
         return []
     dirs: list[Path] = []
     for part in env.split(os.pathsep):
-        path = Path(part)
+        path = Path(part).expanduser()
         if path.is_dir():
             dirs.append(path)
     return dirs
@@ -141,7 +141,13 @@ def list_dataset_entries(dataset: Mapping[str, Any]) -> list[str]:
 
 
 def parse_range(value: Iterable[float]) -> tuple[float, float] | None:
-    """Return a normalized ``(min, max)`` tuple or ``None`` if invalid."""
+    """Return a normalized ``(min, max)`` tuple or ``None`` if invalid.
+
+    ``value`` may be any iterable with at least two numeric entries. Values are
+    cast to ``float`` and returned as a two-item tuple. If the input cannot be
+    interpreted as a pair of numbers, ``None`` is returned instead of raising an
+    exception.
+    """
 
     try:
         low, high = value

--- a/tests/test_parse_range.py
+++ b/tests/test_parse_range.py
@@ -1,0 +1,14 @@
+import pytest
+from plant_engine.utils import parse_range
+
+def test_parse_range_valid_list():
+    assert parse_range([1, 2]) == (1.0, 2.0)
+
+
+def test_parse_range_tuple():
+    assert parse_range(("3", 4)) == (3.0, 4.0)
+
+
+def test_parse_range_invalid():
+    assert parse_range([1]) is None
+    assert parse_range("bad") is None


### PR DESCRIPTION
## Summary
- expand dataset path handling to support user paths
- import Iterable and clarify `parse_range` docs
- add missing tests for `parse_range`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219c15118833088c066f32c3be1ac