### PR TITLE
Enhance pest management utilities

### DIFF
--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -49,6 +49,19 @@ def get_pest_resistance(plant_type: str, pest: str) -> float | None:
     return float(value) if isinstance(value, (int, float)) else None
 
 
+def get_all_pest_resistance(plant_type: str) -> Dict[str, float]:
+    """Return mapping of pests to resistance ratings for ``plant_type``."""
+
+    ratings = _RESISTANCE.get(normalize_key(plant_type), {})
+    result: Dict[str, float] = {}
+    for pest, value in ratings.items():
+        try:
+            result[pest] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
 def recommend_treatments(plant_type: str, pests: Iterable[str]) -> Dict[str, str]:
     """Return recommended treatment strings for each observed pest."""
     guide = get_pest_guidelines(plant_type)
@@ -134,6 +147,7 @@ def build_pest_management_plan(
             "prevention": prevention.get(pest, "No guideline available"),
             "beneficials": beneficials.get(pest, []),
             "ipm": ipm_actions.get(pest),
+            "resistance": get_pest_resistance(plant_type, pest),
         }
 
     return plan
@@ -151,5 +165,6 @@ __all__ = [
     "get_ipm_guidelines",
     "recommend_ipm_actions",
     "get_pest_resistance",
+    "get_all_pest_resistance",
     "build_pest_management_plan",
 ]

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -9,6 +9,7 @@ from plant_engine.pest_manager import (
     recommend_ipm_actions,
     list_known_pests,
     build_pest_management_plan,
+    get_all_pest_resistance,
 )
 
 
@@ -83,3 +84,16 @@ def test_get_pest_resistance():
 
     assert get_pest_resistance("citrus", "aphids") == 3.0
     assert get_pest_resistance("citrus", "unknown") is None
+
+
+def test_get_all_pest_resistance():
+    from plant_engine.pest_manager import get_all_pest_resistance
+
+    ratings = get_all_pest_resistance("citrus")
+    assert ratings["aphids"] == 3.0
+    assert "scale" in ratings
+
+
+def test_plan_includes_resistance():
+    plan = build_pest_management_plan("citrus", ["aphids"])
+    assert plan["aphids"]["resistance"] == 3.0


### PR DESCRIPTION
## Summary
- expand pest manager with `get_all_pest_resistance`
- include resistance ratings in pest management plans
- test new pest resistance features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219ba922c83309f9b862887b715dc