### PR TITLE
Improve pesticide management

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Key reference datasets reside in the `data/` directory:
 - `yield/` – per‑plant yield logs created during operation
 - `plant_density_guidelines.json` – recommended plant spacing (cm) for density calculations
 - `pesticide_withdrawal_days.json` – required wait time before harvest after pesticide use
+- `pesticide_info.json` – withdrawal periods and toxicity classes for common products
 - `wsda_fertilizer_database.json` – full fertilizer analysis database used by
   `plant_engine.wsda_lookup` for product N‑P‑K values
 - `products_index.jsonl` – compact summary of WSDA products for fast searches (use `wsda_product_index`)

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -92,6 +92,7 @@
   "companion_plants.json": "Companion planting recommendations.",
   "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
+  "pesticide_info.json": "Pesticide withdrawal periods and toxicity classifications.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",

--- a/data/pesticide_info.json
+++ b/data/pesticide_info.json
@@ -1,0 +1,7 @@
+{
+  "imidacloprid": {"withdrawal_days": 7, "toxicity": "moderate"},
+  "spinosad": {"withdrawal_days": 1, "toxicity": "low"},
+  "pyrethrin": {"withdrawal_days": 0, "toxicity": "low"},
+  "sulfur": {"withdrawal_days": 0, "toxicity": "low"},
+  "copper_sulfate": {"withdrawal_days": 2, "toxicity": "high"}
+}

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -2,20 +2,34 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Dict
+from typing import Any, Dict
 
 from .utils import load_dataset
 
 DATA_FILE = "pesticide_withdrawal_days.json"
+INFO_FILE = "pesticide_info.json"
 
 # Cached withdrawal data mapping product names to waiting days
 _DATA: Dict[str, int] = load_dataset(DATA_FILE)
+# Extended info including toxicity class
+_INFO: Dict[str, Dict[str, Any]] = load_dataset(INFO_FILE)
 
 __all__ = [
+    "get_pesticide_info",
     "get_withdrawal_days",
     "earliest_harvest_date",
     "adjust_harvest_date",
 ]
+
+
+def get_pesticide_info(product: str) -> Dict[str, Any] | None:
+    """Return pesticide information dictionary if available."""
+
+    info = _INFO.get(product.lower())
+    if info is not None:
+        return dict(info)
+    days = _DATA.get(product.lower())
+    return {"withdrawal_days": days} if days is not None else None
 
 
 def get_withdrawal_days(product: str) -> int | None:
@@ -31,7 +45,13 @@ def get_withdrawal_days(product: str) -> int | None:
     int | None
         Days to wait before harvesting or ``None`` if unknown.
     """
-    return _DATA.get(product.lower())
+    info = get_pesticide_info(product)
+    if info is None:
+        return None
+    try:
+        return int(info.get("withdrawal_days"))
+    except (TypeError, ValueError):
+        return None
 
 
 def earliest_harvest_date(product: str, application_date: date) -> date | None:

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -1,6 +1,7 @@
 import datetime
 
 from plant_engine.pesticide_manager import (
+    get_pesticide_info,
     get_withdrawal_days,
     earliest_harvest_date,
     adjust_harvest_date,
@@ -14,6 +15,12 @@ def test_get_withdrawal_days_known():
 
 def test_get_withdrawal_days_unknown():
     assert get_withdrawal_days("foo") is None
+
+
+def test_get_pesticide_info():
+    info = get_pesticide_info("spinosad")
+    assert info == {"withdrawal_days": 1, "toxicity": "low"}
+    assert get_pesticide_info("foo") is None
 
 
 def test_earliest_harvest_date():


### PR DESCRIPTION
## Summary
- add dataset for pesticide information
- document new dataset
- extend dataset catalog
- add helper function `get_pesticide_info`
- test pesticide info helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219b3ff348330b5f5deea4716a1df