### PR TITLE
Enhance profile loading and pH utilities

### DIFF
--- a/tests/test_load_plant_profile.py
+++ b/tests/test_load_plant_profile.py
@@ -1,5 +1,7 @@
 import json
-from custom_components.horticulture_assistant.utils.load_plant_profile import load_plant_profile
+
+from custom_components.horticulture_assistant.utils.load_plant_profile import \
+    load_plant_profile
 
 
 def test_load_profile_basic(tmp_path):
@@ -8,10 +10,10 @@ def test_load_profile_basic(tmp_path):
     (plant_dir / "general.json").write_text(json.dumps({"name": "demo"}))
     (plant_dir / "thresholds.json").write_text("{}")
     (plant_dir / "profile_index.json").write_text("{}")
-    data = load_plant_profile("demo", base_path=tmp_path / "plants")
-    assert data["plant_id"] == "demo"
-    assert "general" in data["profile_data"]
-    assert "profile_index" not in data["profile_data"]
+    profile = load_plant_profile("demo", base_path=tmp_path / "plants")
+    assert profile.plant_id == "demo"
+    assert "general" in profile.profile_data
+    assert "profile_index" not in profile.profile_data
 
 
 def test_load_profile_with_validation_files(tmp_path):
@@ -21,14 +23,14 @@ def test_load_profile_with_validation_files(tmp_path):
     (plant_dir / "validate_extra.json").write_text("{}")
 
     result = load_plant_profile("demo", base_path=tmp_path / "plants")
-    assert "validate_extra" not in result["profile_data"]
+    assert "validate_extra" not in result.profile_data
 
     result = load_plant_profile(
         "demo",
         base_path=tmp_path / "plants",
         include_validation_files=True,
     )
-    assert "validate_extra" in result["profile_data"]
+    assert "validate_extra" in result.profile_data
 
 
 def test_load_profile_missing_dir(tmp_path):

--- a/tests/test_ph_manager.py
+++ b/tests/test_ph_manager.py
@@ -48,6 +48,14 @@ def test_recommend_solution_ph_adjustment():
     assert ml == 100.0
 
 
+def test_recommend_ph_correction():
+    result = ph_manager.recommend_ph_correction(7.0, "citrus", None, 10)
+    assert result == ("ph_down", 100.0)
+
+    # No correction when within range
+    assert ph_manager.recommend_ph_correction(6.0, "citrus", None, 10) is None
+
+
 def test_medium_ph_functions():
     soil = ph_manager.get_medium_ph_range("soil")
     assert soil == [6.2, 7.0]
@@ -56,4 +64,3 @@ def test_medium_ph_functions():
     assert ph_manager.recommend_medium_ph_adjustment(6.5, "soil") is None
     assert ph_manager.recommended_ph_for_medium("coco") == 6.0
     assert ph_manager.get_medium_ph_range("unknown") == []
-


### PR DESCRIPTION
## Summary
- add `PlantProfile` dataclass for clearer plant profile handling
- refactor `load_plant_profile` to return `PlantProfile`
- update report packager and tests for new profile API
- implement `recommend_ph_correction` helper
- cover new behaviour in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e1baf9083309b5ac030e30495a8