### PR TITLE
Add pH classification helper

### DIFF
--- a/plant_engine/ph_manager.py
+++ b/plant_engine/ph_manager.py
@@ -18,6 +18,7 @@ __all__ = [
     "list_supported_plants",
     "get_ph_range",
     "recommend_ph_adjustment",
+    "classify_ph",
     "recommended_ph_setpoint",
     "estimate_ph_adjustment_volume",
     "recommend_solution_ph_adjustment",
@@ -58,6 +59,28 @@ def recommend_ph_adjustment(
     if current_ph > high:
         return "decrease"
     return None
+
+
+def classify_ph(current_ph: float, plant_type: str, stage: str | None = None) -> str | None:
+    """Return 'low', 'optimal' or 'high' for ``current_ph``.
+
+    The classification is based on :func:`get_ph_range`. ``None`` is returned
+    when no guideline exists for the specified plant or stage.
+    """
+
+    if current_ph <= 0:
+        raise ValueError("current_ph must be positive")
+
+    target = get_ph_range(plant_type, stage)
+    if not target:
+        return None
+
+    low, high = target
+    if current_ph < low:
+        return "low"
+    if current_ph > high:
+        return "high"
+    return "optimal"
 
 
 def recommended_ph_setpoint(plant_type: str, stage: str | None = None) -> float | None:

--- a/tests/test_ph_manager.py
+++ b/tests/test_ph_manager.py
@@ -16,6 +16,13 @@ def test_recommend_ph_adjustment():
     assert ph_manager.recommend_ph_adjustment(6.0, "citrus") is None
 
 
+def test_classify_ph():
+    assert ph_manager.classify_ph(5.0, "citrus") == "low"
+    assert ph_manager.classify_ph(7.0, "citrus") == "high"
+    assert ph_manager.classify_ph(6.0, "citrus") == "optimal"
+    assert ph_manager.classify_ph(6.0, "unknown") is None
+
+
 def test_recommend_unknown_or_invalid():
     assert ph_manager.get_ph_range("unknown") == []
     assert ph_manager.recommend_ph_adjustment(6.0, "unknown") is None


### PR DESCRIPTION
## Summary
- add `classify_ph` helper to `ph_manager`
- test pH classification logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e2d9af883309837e30cfc1dd401