### PR TITLE
Add lighting energy cost estimation utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -101,5 +101,6 @@
   "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
   "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
   "disease_resistance_ratings.json": "Relative disease resistance ratings by crop.",
-  "reference_et0.json": "Monthly reference ET0 values in mm/day"
+  "reference_et0.json": "Monthly reference ET0 values in mm/day",
+  "electricity_rates.json": "Electricity cost per kWh by region."
 }

--- a/data/electricity_rates.json
+++ b/data/electricity_rates.json
@@ -1,0 +1,5 @@
+{
+  "default": 0.12,
+  "california": 0.18,
+  "texas": 0.10
+}

--- a/plant_engine/energy_manager.py
+++ b/plant_engine/energy_manager.py
@@ -1,4 +1,4 @@
-"""Energy usage estimation utilities for HVAC systems."""
+"""Energy usage estimation utilities for HVAC systems and lighting."""
 from __future__ import annotations
 
 from functools import lru_cache
@@ -6,21 +6,26 @@ from typing import Dict
 
 from .utils import load_dataset, normalize_key
 
-DATA_FILE = "hvac_energy_coefficients.json"
+HVAC_FILE = "hvac_energy_coefficients.json"
+RATE_FILE = "electricity_rates.json"
 
-# Cache dataset via load_dataset
-_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+# Cache datasets via load_dataset
+_HVAC_DATA: Dict[str, Dict[str, float]] = load_dataset(HVAC_FILE)
+_RATES: Dict[str, float] = load_dataset(RATE_FILE)
 
 __all__ = [
     "get_energy_coefficient",
     "estimate_hvac_energy",
+    "get_electricity_rate",
+    "estimate_lighting_energy",
+    "estimate_lighting_cost",
 ]
 
 
 @lru_cache(maxsize=None)
 def get_energy_coefficient(system: str) -> float:
     """Return kWh per degree-day coefficient for an HVAC ``system``."""
-    entry = _DATA.get(normalize_key(system), {})
+    entry = _HVAC_DATA.get(normalize_key(system), {})
     try:
         return float(entry.get("kwh_per_degree_day", 0))
     except (TypeError, ValueError):
@@ -42,3 +47,36 @@ def estimate_hvac_energy(
     degree_hours = abs(target_temp_c - current_temp_c) * hours
     kwh = degree_hours * (coeff / 24)
     return round(kwh, 2)
+
+
+@lru_cache(maxsize=None)
+def get_electricity_rate(region: str | None = None) -> float:
+    """Return cost per kWh for ``region`` or the default rate."""
+
+    key = normalize_key(region) if region else "default"
+    rate = _RATES.get(key)
+    if rate is None:
+        rate = _RATES.get("default", 0.0)
+    try:
+        return float(rate)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def estimate_lighting_energy(power_watts: float, hours: float) -> float:
+    """Return kWh for running ``power_watts`` lights for ``hours``."""
+
+    if power_watts <= 0 or hours <= 0:
+        raise ValueError("power_watts and hours must be positive")
+    kwh = power_watts * hours / 1000
+    return round(kwh, 2)
+
+
+def estimate_lighting_cost(
+    power_watts: float, hours: float, region: str | None = None
+) -> float:
+    """Return lighting energy cost for ``power_watts`` and ``hours``."""
+
+    kwh = estimate_lighting_energy(power_watts, hours)
+    rate = get_electricity_rate(region)
+    return round(kwh * rate, 2)

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -1,6 +1,12 @@
 import pytest
 
-from plant_engine.energy_manager import get_energy_coefficient, estimate_hvac_energy
+from plant_engine.energy_manager import (
+    get_energy_coefficient,
+    estimate_hvac_energy,
+    get_electricity_rate,
+    estimate_lighting_energy,
+    estimate_lighting_cost,
+)
 
 
 def test_get_energy_coefficient():
@@ -18,3 +24,20 @@ def test_estimate_hvac_energy():
 def test_estimate_hvac_energy_invalid_hours():
     with pytest.raises(ValueError):
         estimate_hvac_energy(18, 20, 0, "heating")
+
+
+def test_electricity_rate_lookup():
+    assert get_electricity_rate("california") == 0.18
+    assert get_electricity_rate("unknown") == 0.12
+
+
+def test_estimate_lighting_energy_and_cost():
+    energy = estimate_lighting_energy(200, 5)
+    assert energy == 1.0
+    cost = estimate_lighting_cost(200, 5, "california")
+    assert cost == pytest.approx(1.0 * 0.18, 0.01)
+
+
+def test_estimate_lighting_energy_invalid():
+    with pytest.raises(ValueError):
+        estimate_lighting_energy(0, 5)


### PR DESCRIPTION
## Summary
- manage electricity rates dataset
- add lighting energy and cost calculations
- document dataset in catalog
- test new energy manager utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e0149b48330a4526201b8af0de3