### PR TITLE
Add fertigation summary helper function

### DIFF
--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -379,3 +379,20 @@ def test_recommend_rootzone_fertigation():
 
     assert volume > 0
     assert schedule["N"] > 0
+
+
+def test_summarize_fertigation_schedule():
+    from plant_engine.fertigation import summarize_fertigation_schedule
+
+    fert_map = {
+        "N": "foxfarm_grow_big",
+        "P": "foxfarm_grow_big",
+        "K": "intrepid_granular_potash_0_0_60",
+    }
+    summary = summarize_fertigation_schedule(
+        "citrus", "vegetative", 1.0, fertilizers=fert_map
+    )
+    assert "schedule" in summary
+    assert "cost_total" in summary
+    assert isinstance(summary["schedule"], dict)
+    assert summary["cost_total"] >= 0


### PR DESCRIPTION
## Summary
- add `summarize_fertigation_schedule` utility to generate fertigation schedule summaries with cost and solubility warnings
- expose new helper via `__all__`
- test coverage for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825df6be4c8330b26c124d424d951e