### PR TITLE
Improve pesticide management

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -93,6 +93,7 @@
   "companion_plants.json": "Companion planting recommendations.",
   "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
+  "pesticide_reentry_intervals.json": "Hours to wait before reentering treated areas after application.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",

--- a/data/pesticide_reentry_intervals.json
+++ b/data/pesticide_reentry_intervals.json
@@ -1,0 +1,6 @@
+{
+  "imidacloprid": 12,
+  "spinosad": 4,
+  "pyrethrin": 0,
+  "sulfur": 0
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -50,6 +50,9 @@ from .pesticide_manager import (
     get_withdrawal_days,
     earliest_harvest_date,
     adjust_harvest_date,
+    get_reentry_hours,
+    earliest_reentry_time,
+    calculate_reentry_window,
 )
 from .disease_monitor import (
     get_disease_thresholds,
@@ -451,6 +454,9 @@ __all__ = [
     "get_withdrawal_days",
     "earliest_harvest_date",
     "adjust_harvest_date",
+    "get_reentry_hours",
+    "earliest_reentry_time",
+    "calculate_reentry_window",
     "DailyReport",
     "load_profile",
     "TranspirationMetrics",

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -5,6 +5,9 @@ from plant_engine.pesticide_manager import (
     earliest_harvest_date,
     adjust_harvest_date,
     calculate_harvest_window,
+    get_reentry_hours,
+    earliest_reentry_time,
+    calculate_reentry_window,
 )
 
 
@@ -40,4 +43,27 @@ def test_calculate_harvest_window():
     harvest = calculate_harvest_window(applications)
     expected = earliest_harvest_date("imidacloprid", datetime.date(2024, 6, 10))
     assert harvest == expected
+
+
+def test_get_reentry_hours():
+    assert get_reentry_hours("spinosad") == 4
+    assert get_reentry_hours("imidacloprid") == 12
+    assert get_reentry_hours("foo") is None
+
+
+def test_earliest_reentry_time():
+    dt = datetime.datetime(2024, 6, 1, 8, 0)
+    result = earliest_reentry_time("spinosad", dt)
+    assert result == dt + datetime.timedelta(hours=4)
+    assert earliest_reentry_time("foo", dt) is None
+
+
+def test_calculate_reentry_window():
+    apps = [
+        ("spinosad", datetime.datetime(2024, 6, 1, 6)),
+        ("imidacloprid", datetime.datetime(2024, 6, 2, 9)),
+    ]
+    window = calculate_reentry_window(apps)
+    expected = earliest_reentry_time("imidacloprid", apps[1][1])
+    assert window == expected
 


### PR DESCRIPTION
## Summary
- add pesticide reentry interval dataset
- support new reentry functions in `pesticide_manager`
- expose new APIs in package init
- document dataset in catalog
- test new pesticide reentry helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e0eba308330b353c2a7518604ad