### PR TITLE
Improve pH validation for nutrient adjustments

### DIFF
--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -267,10 +267,20 @@ def calculate_all_nutrient_balance(
 
 
 def get_ph_adjusted_levels(plant_type: str, stage: str, ph: float) -> Dict[str, float]:
-    """Return nutrient targets adjusted for solution pH availability."""
+    """Return nutrient targets adjusted for solution pH availability.
 
-    if ph <= 0:
-        raise ValueError("ph must be positive")
+    Parameters
+    ----------
+    plant_type : str
+        Crop identifier used to look up nutrient guidelines.
+    stage : str
+        Growth stage for guideline lookup.
+    ph : float
+        Solution pH value. Must be within the standard 0-14 range.
+    """
+
+    if not 0 < ph <= 14:
+        raise ValueError("ph must be between 0 and 14")
 
     targets = get_recommended_levels(plant_type, stage)
     if not targets:

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from plant_engine.nutrient_manager import (
     get_recommended_levels,
     get_all_recommended_levels,
@@ -145,6 +146,16 @@ def test_get_ph_adjusted_levels():
 
     adjusted = get_ph_adjusted_levels("tomato", "fruiting", 5.0)
     assert adjusted["P"] > 60  # higher target at low pH
+
+
+def test_get_ph_adjusted_levels_invalid():
+    from plant_engine.nutrient_manager import get_ph_adjusted_levels
+
+    with pytest.raises(ValueError):
+        get_ph_adjusted_levels("tomato", "fruiting", -1)
+
+    with pytest.raises(ValueError):
+        get_ph_adjusted_levels("tomato", "fruiting", 15)
 
 
 def test_calculate_deficiencies_with_ph():


### PR DESCRIPTION
## Summary
- validate pH values fall within the 0-14 range
- test invalid pH values for `get_ph_adjusted_levels`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68825e24a6f883309d132443ff03153f