### PR TITLE
Improve environment temperature normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ or incomplete and should only be used as a starting point for your own research.
   readings or nutrient multipliers when profiles omit them.
 - **Dataset Cache**: Call `plant_engine.utils.clear_dataset_cache()` after
   adjusting dataset environment variables to refresh cached lookups.
+- **Flexible Temperature Inputs**: `normalize_environment_readings` accepts
+  Fahrenheit or Kelvin temperature keys and converts them to Celsius
+  automatically.
 - **Dynamic Tags**: Tag plants (e.g. `"blueberry"`, `"fruiting"`) to generate grouped dashboards.
 - **Nutrient Mix Helper**: The `recommend_nutrient_mix` function computes exact
   fertilizer grams needed to hit N/P/K targets and can optionally include

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -48,6 +48,8 @@ ENV_ALIASES = {
     "temp_c": ["temp_c", "temperature", "temp", "temperature_c"],
     # Fahrenheit readings are converted to Celsius during normalization
     "temp_f": ["temp_f", "temperature_f", "temp_fahrenheit"],
+    # Kelvin readings are converted to Celsius during normalization
+    "temp_k": ["temp_k", "temperature_k", "temp_kelvin"],
     "humidity_pct": ["humidity_pct", "humidity", "rh", "rh_pct"],
     "light_ppfd": ["light_ppfd", "light", "par", "par_w_m2"],
     "co2_ppm": ["co2_ppm", "co2"],
@@ -56,6 +58,8 @@ ENV_ALIASES = {
     "soil_moisture_pct": ["soil_moisture_pct", "soil_moisture", "moisture", "vwc"],
     "soil_temp_c": ["soil_temp_c", "soil_temperature", "soil_temp", "root_temp"],
     "soil_temp_f": ["soil_temp_f", "soil_temp_fahrenheit"],
+    # Kelvin readings are converted to Celsius during normalization
+    "soil_temp_k": ["soil_temp_k", "soil_temperature_k", "soil_temp_kelvin"],
 }
 
 # reverse mapping for constant time alias lookups
@@ -197,6 +201,9 @@ def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, f
         if canonical in {"temp_f", "soil_temp_f"}:
             val = (val - 32) * 5 / 9
             canonical = canonical.replace("_f", "_c")
+        elif canonical in {"temp_k", "soil_temp_k"}:
+            val = val - 273.15
+            canonical = canonical.replace("_k", "_c")
         normalized[canonical] = val
     return normalized
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -528,6 +528,18 @@ def test_normalize_environment_readings_soil_temp_fahrenheit():
     assert result == {"soil_temp_c": 25.0}
 
 
+def test_normalize_environment_readings_temp_kelvin():
+    data = {"temperature_k": 298.15}
+    result = normalize_environment_readings(data)
+    assert result == {"temp_c": 25.0}
+
+
+def test_normalize_environment_readings_soil_temp_kelvin():
+    data = {"soil_temp_k": 298.15}
+    result = normalize_environment_readings(data)
+    assert result == {"soil_temp_c": 25.0}
+
+
 def test_normalize_environment_readings_unknown_key():
     result = normalize_environment_readings({"foo": 1})
     assert result == {"foo": 1.0}


### PR DESCRIPTION
## Summary
- support Kelvin temperature readings during environment normalization
- document flexible temperature inputs
- test Kelvin support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825dfd70288330a072d4a4ccb9cf91