### PR TITLE
Enhance fertilizer utilities and growth stage API

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -81,6 +81,7 @@
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
   "fertilizers/fertilizer_application_methods.json": "Recommended application methods for each fertilizer product.",
+  "fertilizers/fertilizer_application_rates.json": "Recommended grams per liter of fertilizer product.",
   "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
   "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
   "wsda_fertilizer_database.json": "Full WSDA fertilizer product database for nutrient lookups.",

--- a/data/fertilizers/fertilizer_application_rates.json
+++ b/data/fertilizers/fertilizer_application_rates.json
@@ -1,0 +1,5 @@
+{
+  "foxfarm_grow_big": 5.0,
+  "magriculture": 2.5,
+  "intrepid_granular_potash_0_0_60": 1.0
+}

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -25,6 +25,7 @@ __all__ = [
     "estimate_stage_from_age",
     "estimate_stage_from_date",
     "predict_harvest_date",
+    "get_total_cycle_duration",
     "stage_progress",
     "days_until_harvest",
     "predict_next_stage_date",
@@ -50,6 +51,20 @@ def get_stage_duration(plant_type: str, stage: str) -> int | None:
     if isinstance(duration, (int, float)):
         return int(duration)
     return None
+
+
+def get_total_cycle_duration(plant_type: str) -> int | None:
+    """Return total days for all stages of ``plant_type`` if available."""
+
+    stages = _DATA.get(normalize_key(plant_type))
+    if not isinstance(stages, dict):
+        return None
+    total = 0
+    for info in stages.values():
+        days = info.get("duration_days")
+        if isinstance(days, (int, float)):
+            total += int(days)
+    return total if total > 0 else None
 
 
 def estimate_stage_from_age(plant_type: str, days_since_start: int) -> str | None:

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -33,6 +33,8 @@ estimate_cost_per_nutrient = fert_mod.estimate_cost_per_nutrient
 calculate_fertilizer_ppm = fert_mod.calculate_fertilizer_ppm
 calculate_mass_for_target_ppm = fert_mod.calculate_mass_for_target_ppm
 get_application_method = fert_mod.get_application_method
+get_application_rate = fert_mod.get_application_rate
+calculate_recommended_application = fert_mod.calculate_recommended_application
 recommend_wsda_products = fert_mod.recommend_wsda_products
 CATALOG = fert_mod.CATALOG
 
@@ -245,6 +247,20 @@ def test_get_application_method():
     assert get_application_method("foxfarm_grow_big") == "soil drench"
     assert get_application_method("magriculture") == "foliar"
     assert get_application_method("unknown") is None
+
+
+def test_get_application_rate():
+    assert get_application_rate("foxfarm_grow_big") == 5.0
+    assert get_application_rate("unknown") is None
+
+
+def test_calculate_recommended_application():
+    grams = calculate_recommended_application("foxfarm_grow_big", 2)
+    assert grams == 10.0
+    with pytest.raises(ValueError):
+        calculate_recommended_application("foxfarm_grow_big", 0)
+    with pytest.raises(KeyError):
+        calculate_recommended_application("unknown", 1)
 
 
 def test_catalog_lists_products():

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -7,6 +7,7 @@ from plant_engine.growth_stage import (
     estimate_stage_from_age,
     estimate_stage_from_date,
     predict_harvest_date,
+    get_total_cycle_duration,
     stage_progress,
     days_until_harvest,
     predict_next_stage_date,
@@ -105,5 +106,10 @@ def test_days_until_next_stage():
     assert days_until_next_stage("unknown", "seedling", 5) is None
     with pytest.raises(ValueError):
         days_until_next_stage("tomato", "seedling", -1)
+
+
+def test_get_total_cycle_duration():
+    assert get_total_cycle_duration("tomato") == 120
+    assert get_total_cycle_duration("unknown") is None
 
 


### PR DESCRIPTION
## Summary
- add dataset describing recommended fertilizer application rates
- extend `fertilizer_formulator` with rate helpers
- expose new `get_total_cycle_duration` in growth stage utilities
- document new dataset in catalog
- test new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825e17afec8330a23bf49c21e58161