### PR TITLE
Improve dataset catalog utility

### DIFF
--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -89,3 +89,10 @@ def test_catalog_refresh(tmp_path):
     assert cat.list_datasets() == ["x.json"]
     cat.refresh()
     assert sorted(cat.list_datasets()) == ["x.json", "y.json"]
+
+
+def test_get_dataset_path_and_load():
+    path = datasets.get_dataset_path("nutrient_guidelines.json")
+    assert path and path.exists()
+    data = datasets.load_dataset_file("nutrient_guidelines.json")
+    assert isinstance(data, dict)


### PR DESCRIPTION
## Summary
- expose dataset path lookup utilities
- load dataset file directly from dataset catalog
- test dataset path helper

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688266835d5083309c61e21348a1a6fb