### PR TITLE
Enhance environment manager with leaf temp data

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -28,6 +28,7 @@
   "water_quality_actions.json": "Recommended remediation steps for poor water quality.",
   "leaf_tissue_targets.json": "Optimal nutrient ranges for leaf tissue analysis.",
   "leaf_tissue_score_weights.json": "Scoring weights for leaf tissue nutrients.",
+  "leaf_temperature_guidelines.json": "Recommended leaf temperature ranges for optimal photosynthesis.",
   "root_depth_guidelines.json": "Typical maximum root depth per crop.",
   "plant_density_guidelines.json": "Recommended plant spacing for common crops.",
   "beneficial_insects.json": "Natural predators for common greenhouse pests.",

--- a/data/leaf_temperature_guidelines.json
+++ b/data/leaf_temperature_guidelines.json
@@ -1,0 +1,10 @@
+{
+  "citrus": {
+    "optimal": [24, 30],
+    "germination": [26, 32]
+  },
+  "lettuce": {
+    "optimal": [18, 24],
+    "germination": [20, 24]
+  }
+}

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -12,6 +12,7 @@ def test_list_datasets_contains_known():
     assert "nutrient_guidelines.json" in datasets
     assert "irrigation_intervals.json" in datasets
     assert "soil_moisture_guidelines.json" in datasets
+    assert "leaf_temperature_guidelines.json" in datasets
     assert "disease_monitoring_intervals.json" in datasets
     assert "reference_et0.json" in datasets
     assert "dataset_catalog.json" not in datasets
@@ -46,6 +47,8 @@ def test_get_dataset_description():
 
     desc8 = get_dataset_description("reference_et0.json")
     assert "ET0" in desc8 or "et0" in desc8.lower()
+    desc9 = get_dataset_description("leaf_temperature_guidelines.json")
+    assert "temperature" in desc9
 
 
 def test_search_datasets():

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -40,6 +40,7 @@ from plant_engine.environment_manager import (
     evaluate_stress_conditions,
     evaluate_soil_temperature_stress,
     evaluate_soil_ec_stress,
+    evaluate_leaf_temperature_stress,
     score_environment,
     score_environment_series,
     score_environment_components,
@@ -59,6 +60,7 @@ from plant_engine.environment_manager import (
     clear_environment_cache,
     get_target_soil_temperature,
     get_target_soil_ec,
+    get_target_leaf_temperature,
     energy_optimized_setpoints,
 )
 
@@ -647,10 +649,20 @@ def test_get_target_soil_temperature():
     assert get_target_soil_temperature("citrus", "germination") == (25, 32)
 
 
+def test_get_target_leaf_temperature():
+    assert get_target_leaf_temperature("citrus", "germination") == (26, 32)
+
+
 def test_evaluate_soil_temperature_stress():
     assert evaluate_soil_temperature_stress(18, "citrus") == "cold"
     assert evaluate_soil_temperature_stress(30, "citrus") == "hot"
     assert evaluate_soil_temperature_stress(35, "citrus") == "hot"
+
+
+def test_evaluate_leaf_temperature_stress():
+    assert evaluate_leaf_temperature_stress(22, "citrus") == "cold"
+    assert evaluate_leaf_temperature_stress(31, "citrus") == "hot"
+    assert evaluate_leaf_temperature_stress(27, "citrus") is None
 
 
 def test_get_target_soil_ec():
@@ -664,18 +676,20 @@ def test_evaluate_soil_ec_stress():
 
 
 def test_evaluate_stress_conditions():
-    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, "lettuce", "seedling", 12)
+    stress = evaluate_stress_conditions(32, 70, 8, 7.5, 16, 45, 30, "lettuce", "seedling", 12)
     assert stress.heat is True
     assert stress.cold is False
     assert stress.light == "low"
     assert stress.wind is True
     assert stress.humidity is None
     assert stress.soil_temp == "cold"
+    assert stress.leaf_temp == "hot"
 
-    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, "citrus")
+    stress_none = evaluate_stress_conditions(None, None, None, None, None, None, None, "citrus")
     assert stress_none.heat is None
     assert stress_none.humidity is None
     assert stress_none.soil_temp is None
+    assert stress_none.leaf_temp is None
 
 
 def test_score_environment_components():


### PR DESCRIPTION
## Summary
- add leaf temperature dataset and description
- support leaf temperature guidelines in environment manager
- expose API for leaf temperature stress evaluation
- include leaf temp support in stress calculations
- test coverage for new dataset and functions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826669d5cc8330b7cea2648b89c545