### PR TITLE
Enhance irrigation utilities

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -395,6 +395,8 @@ __all__ = [
     "list_irrigation_plants",
     "get_daily_irrigation_target",
     "generate_irrigation_schedule",
+    "generate_irrigation_schedule_with_runtime",
+    "summarize_irrigation_schedule",
     "generate_cycle_irrigation_plan",
     "HarvestRecord",
     "load_yield_history",

--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -21,6 +21,7 @@ __all__ = [
     "get_daily_irrigation_target",
     "generate_irrigation_schedule",
     "generate_irrigation_schedule_with_runtime",
+    "summarize_irrigation_schedule",
     "adjust_irrigation_for_efficiency",
     "generate_env_irrigation_schedule",
     "generate_precipitation_schedule",
@@ -449,6 +450,29 @@ def generate_irrigation_schedule_with_runtime(
         result[day] = {"volume_ml": volume, "runtime_h": runtime}
 
     return result
+
+
+def summarize_irrigation_schedule(
+    schedule: Mapping[int, Mapping[str, float | None]]
+) -> Dict[str, float]:
+    """Return total events, volume and runtime for an irrigation schedule."""
+
+    total_volume = 0.0
+    total_runtime = 0.0
+    events = 0
+    for entry in schedule.values():
+        volume = float(entry.get("volume_ml", 0.0) or 0.0)
+        runtime = float(entry.get("runtime_h") or 0.0)
+        total_volume += volume
+        total_runtime += runtime
+        if volume > 0 or runtime > 0:
+            events += 1
+
+    return {
+        "events": events,
+        "total_volume_ml": round(total_volume, 1),
+        "total_runtime_h": round(total_runtime, 2),
+    }
 
 
 def generate_cycle_irrigation_plan(plant_type: str) -> Dict[str, Dict[int, float]]:

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -11,6 +11,7 @@ from plant_engine.irrigation_manager import (
     list_supported_plants,
     generate_irrigation_schedule,
     generate_irrigation_schedule_with_runtime,
+    summarize_irrigation_schedule,
     generate_cycle_irrigation_plan,
     adjust_irrigation_for_efficiency,
     estimate_irrigation_time,
@@ -274,6 +275,26 @@ def test_generate_irrigation_schedule_with_runtime():
     assert schedule[1]["volume_ml"] == 0.0
     runtime = estimate_irrigation_time(80.0, "drip", emitters=2)
     assert schedule[2]["runtime_h"] == pytest.approx(runtime, rel=1e-2)
+
+
+def test_summarize_irrigation_schedule():
+    zone = RootZone(
+        root_depth_cm=10,
+        root_volume_cm3=1000,
+        total_available_water_ml=200.0,
+        readily_available_water_ml=100.0,
+    )
+    schedule = generate_irrigation_schedule_with_runtime(
+        zone,
+        150.0,
+        [30.0, 30.0],
+        emitter_type="drip",
+        emitters=2,
+    )
+    summary = summarize_irrigation_schedule(schedule)
+    assert summary["events"] == 1
+    assert summary["total_volume_ml"] > 0
+    assert summary["total_runtime_h"] > 0
 
 
 def test_generate_cycle_irrigation_plan():


### PR DESCRIPTION
## Summary
- expose schedule runtime utilities via plant_engine API
- add `summarize_irrigation_schedule` helper
- test schedule summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688266640a5083308e1df8ea5b451bd8