### PR TITLE
Improve pesticide data & water use

### DIFF
--- a/custom_components/horticulture_assistant/utils/threshold_approval_manager.py
+++ b/custom_components/horticulture_assistant/utils/threshold_approval_manager.py
@@ -13,8 +13,6 @@ from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
-_LOGGER = logging.getLogger(__name__)
-
 
 def _load_json(path: str) -> Any:
     if not os.path.exists(path):
@@ -54,6 +52,8 @@ def _save_json(path: str, data: Any) -> None:
 
 
 def _save_pending(path: str, pending: Dict[str, Any], original: Any) -> None:
+    """Write updated ``pending`` mapping back to ``path`` preserving format."""
+
     if isinstance(original, list):
         data = list(pending.values())
     elif isinstance(original, dict) and any(k in original for k in ("plant_id", "changes", "timestamp")):

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -95,6 +95,7 @@
   "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
   "pesticide_reentry_intervals.json": "Hours to wait before reentering treated areas after application.",
+  "pesticide_modes.json": "Mode of action classification for common pesticides.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",

--- a/data/pesticide_modes.json
+++ b/data/pesticide_modes.json
@@ -1,0 +1,5 @@
+{
+  "imidacloprid": "neonicotinoid",
+  "spinosad": "spinosyn",
+  "pyrethrin": "pyrethroid"
+}

--- a/data/water_usage_guidelines.json
+++ b/data/water_usage_guidelines.json
@@ -1,4 +1,5 @@
 {
   "lettuce": {"seedling": 60, "vegetative": 180, "harvest": 140},
-  "tomato": {"seedling": 80, "vegetative": 220, "fruiting": 320}
+  "tomato": {"seedling": 80, "vegetative": 220, "fruiting": 320},
+  "basil": {"vegetative": 120, "harvest": 100}
 }

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -2,16 +2,18 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
 from .utils import load_dataset
 
 DATA_FILE = "pesticide_withdrawal_days.json"
 REENTRY_FILE = "pesticide_reentry_intervals.json"
+MOA_FILE = "pesticide_modes.json"
 
 # Cached withdrawal data mapping product names to waiting days
 _DATA: Dict[str, int] = load_dataset(DATA_FILE)
 _REENTRY: Dict[str, float] = load_dataset(REENTRY_FILE)
+_MOA: Dict[str, str] = load_dataset(MOA_FILE)
 
 __all__ = [
     "get_withdrawal_days",
@@ -21,6 +23,8 @@ __all__ = [
     "get_reentry_hours",
     "earliest_reentry_time",
     "calculate_reentry_window",
+    "get_mode_of_action",
+    "list_known_pesticides",
 ]
 
 
@@ -109,3 +113,15 @@ def calculate_harvest_window(applications: Iterable[tuple[str, date]]) -> date |
         if latest is None or harvest > latest:
             latest = harvest
     return latest
+
+
+def get_mode_of_action(product: str) -> str | None:
+    """Return the mode of action classification for ``product`` if known."""
+
+    return _MOA.get(product.lower())
+
+
+def list_known_pesticides() -> List[str]:
+    """Return alphabetically sorted list of pesticides with MOA data."""
+
+    return sorted(_MOA.keys())

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -14,6 +14,7 @@ def test_list_datasets_contains_known():
     assert "soil_moisture_guidelines.json" in datasets
     assert "disease_monitoring_intervals.json" in datasets
     assert "reference_et0.json" in datasets
+    assert "pesticide_modes.json" in datasets
     assert "dataset_catalog.json" not in datasets
 
 
@@ -46,6 +47,9 @@ def test_get_dataset_description():
 
     desc8 = get_dataset_description("reference_et0.json")
     assert "ET0" in desc8 or "et0" in desc8.lower()
+
+    desc9 = get_dataset_description("pesticide_modes.json")
+    assert "action" in desc9
 
 
 def test_search_datasets():

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -8,6 +8,8 @@ from plant_engine.pesticide_manager import (
     get_reentry_hours,
     earliest_reentry_time,
     calculate_reentry_window,
+    get_mode_of_action,
+    list_known_pesticides,
 )
 
 
@@ -66,4 +68,15 @@ def test_calculate_reentry_window():
     window = calculate_reentry_window(apps)
     expected = earliest_reentry_time("imidacloprid", apps[1][1])
     assert window == expected
+
+
+def test_get_mode_of_action():
+    assert get_mode_of_action("spinosad") == "spinosyn"
+    assert get_mode_of_action("unknown") is None
+
+
+def test_list_known_pesticides():
+    pesticides = list_known_pesticides()
+    assert "imidacloprid" in pesticides
+    assert "pyrethrin" in pesticides
 

--- a/tests/test_water_usage.py
+++ b/tests/test_water_usage.py
@@ -5,6 +5,7 @@ from plant_engine import water_usage
 def test_get_daily_use():
     assert water_usage.get_daily_use("lettuce", "vegetative") == 180
     assert water_usage.get_daily_use("tomato", "fruiting") == 320
+    assert water_usage.get_daily_use("basil", "vegetative") == 120
     # Unknown plant returns 0
     assert water_usage.get_daily_use("unknown", "stage") == 0.0
 
@@ -13,6 +14,7 @@ def test_list_supported_plants():
     plants = water_usage.list_supported_plants()
     assert "lettuce" in plants
     assert "tomato" in plants
+    assert "basil" in plants
 
 
 def test_estimate_area_use():


### PR DESCRIPTION
## Summary
- fix logger duplication in threshold approval helper
- document pending change writer
- include basil water usage data
- add pesticide mode-of-action dataset
- extend pesticide manager with MOA helpers
- test catalog lists new dataset
- test pesticide MOA helpers
- validate basil water usage helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882665da7fc83308e0038ec59ebd284