### PR TITLE
Add HVAC cost helper

### DIFF
--- a/plant_engine/energy_manager.py
+++ b/plant_engine/energy_manager.py
@@ -16,6 +16,7 @@ _RATES: Dict[str, float] = load_dataset(RATE_FILE)
 __all__ = [
     "get_energy_coefficient",
     "estimate_hvac_energy",
+    "estimate_hvac_cost",
     "get_electricity_rate",
     "estimate_lighting_energy",
     "estimate_lighting_cost",
@@ -80,3 +81,17 @@ def estimate_lighting_cost(
     kwh = estimate_lighting_energy(power_watts, hours)
     rate = get_electricity_rate(region)
     return round(kwh * rate, 2)
+
+
+def estimate_hvac_cost(
+    current_temp_c: float,
+    target_temp_c: float,
+    hours: float,
+    system: str,
+    region: str | None = None,
+) -> float:
+    """Return cost to maintain ``target_temp_c`` for ``hours`` using ``system``."""
+
+    energy = estimate_hvac_energy(current_temp_c, target_temp_c, hours, system)
+    rate = get_electricity_rate(region)
+    return round(energy * rate, 2)

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -3,6 +3,7 @@ import pytest
 from plant_engine.energy_manager import (
     get_energy_coefficient,
     estimate_hvac_energy,
+    estimate_hvac_cost,
     get_electricity_rate,
     estimate_lighting_energy,
     estimate_lighting_cost,
@@ -41,3 +42,10 @@ def test_estimate_lighting_energy_and_cost():
 def test_estimate_lighting_energy_invalid():
     with pytest.raises(ValueError):
         estimate_lighting_energy(0, 5)
+
+
+def test_estimate_hvac_cost():
+    # 2 degree difference for 12 hours using heating system with rate 0.18
+    cost = estimate_hvac_cost(18, 20, 12, "heating", region="california")
+    expected_kwh = 0.5 * (2 * 12 / 24)
+    assert cost == pytest.approx(expected_kwh * 0.18, 0.01)


### PR DESCRIPTION
## Summary
- add `estimate_hvac_cost` to calculate HVAC energy cost
- test HVAC cost estimation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882665479188330b9ab0eb57f1fe36f