### PR TITLE
Add pest scientific names dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Key reference datasets reside in the `data/` directory:
 - `pest_prevention.json` – cultural practices to deter common pests
 - `organic_pest_controls.json` – organic treatment options for common pests
 - `pest_resistance_ratings.json` – relative resistance scores (1‑5) by crop and pest
+- `pest_scientific_names.json` – common pests mapped to scientific names
 - `disease_resistance_ratings.json` – relative resistance scores (1‑5) by crop and disease
 - `bioinoculant_guidelines.json` – microbial inoculant suggestions by crop
 - `pest_monitoring_intervals.json` – recommended scouting frequency by stage

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -102,6 +102,7 @@
   "disease_severity_actions.json": "Actions to take based on disease severity level.",
   "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
   "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
+  "pest_scientific_names.json": "Common pests mapped to their scientific names.",
   "disease_resistance_ratings.json": "Relative disease resistance ratings by crop.",
   "reference_et0.json": "Monthly reference ET0 values in mm/day",
   "electricity_rates.json": "Electricity cost per kWh by region."

--- a/data/pest_scientific_names.json
+++ b/data/pest_scientific_names.json
@@ -1,0 +1,9 @@
+{
+  "aphids": "Aphidoidea",
+  "whiteflies": "Aleyrodidae",
+  "spider mites": "Tetranychidae",
+  "scale": "Coccoidea",
+  "leafminers": "Agromyzidae",
+  "slugs": "Gastropoda",
+  "fruitworms": "Grapholita molesta"
+}

--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -11,6 +11,7 @@ PREVENTION_FILE = "pest_prevention.json"
 IPM_FILE = "ipm_guidelines.json"
 RESISTANCE_FILE = "pest_resistance_ratings.json"
 ORGANIC_FILE = "organic_pest_controls.json"
+TAXONOMY_FILE = "pest_scientific_names.json"
 
 
 
@@ -21,6 +22,7 @@ _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 _IPM: Dict[str, Dict[str, str]] = load_dataset(IPM_FILE)
 _RESISTANCE: Dict[str, Dict[str, float]] = load_dataset(RESISTANCE_FILE)
 _ORGANIC: Dict[str, List[str]] = load_dataset(ORGANIC_FILE)
+_TAXONOMY: Dict[str, str] = load_dataset(TAXONOMY_FILE)
 
 
 def list_supported_plants() -> list[str]:
@@ -36,6 +38,11 @@ def get_pest_guidelines(plant_type: str) -> Dict[str, str]:
 def list_known_pests(plant_type: str) -> list[str]:
     """Return all pests with guidelines for ``plant_type``."""
     return sorted(get_pest_guidelines(plant_type).keys())
+
+
+def get_scientific_name(pest: str) -> str | None:
+    """Return the scientific (Latin) name for ``pest`` if known."""
+    return _TAXONOMY.get(normalize_key(pest))
 
 
 def get_pest_resistance(plant_type: str, pest: str) -> float | None:
@@ -159,6 +166,7 @@ __all__ = [
     "list_supported_plants",
     "get_pest_guidelines",
     "list_known_pests",
+    "get_scientific_name",
     "recommend_treatments",
     "get_beneficial_insects",
     "recommend_beneficials",

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -46,6 +46,13 @@ def test_list_known_pests():
     assert "aphids" in pests
 
 
+def test_get_scientific_name():
+    from plant_engine.pest_manager import get_scientific_name
+
+    assert get_scientific_name("aphids") == "Aphidoidea"
+    assert get_scientific_name("unknown") is None
+
+
 def test_get_pest_prevention():
     guide = get_pest_prevention("citrus")
     assert "aphids" in guide


### PR DESCRIPTION
## Summary
- expand README and dataset catalog with new pest_scientific_names dataset
- implement get_scientific_name helper in pest_manager
- add pest_scientific_names.json data file
- test new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882665092f8833090e5731af60f4000