### PR TITLE
Improve WSDA lookup dataset

### DIFF
--- a/plant_engine/wsda_lookup.py
+++ b/plant_engine/wsda_lookup.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Tuple, Mapping, Iterable
 
-from plant_engine.utils import load_json
+from plant_engine.utils import load_json, load_dataset
 
 # Path to the WSDA fertilizer database packaged with the repository. Using
 # :func:`load_dataset` allows overrides via ``HORTICULTURE_*`` environment
@@ -60,9 +60,12 @@ def _parse_analysis(raw: Mapping[str, object]) -> Dict[str, float]:
 def _records() -> Iterable[Mapping[str, object]]:
     """Return WSDA fertilizer records loaded from the bundled JSON file."""
 
-    if not _WSDA_PATH.exists():
-        return []
-    data = load_json(str(_WSDA_PATH))
+    if _WSDA_PATH.exists():
+        data = load_json(str(_WSDA_PATH))
+    else:
+        # Fallback to dataset loader so overrides work even if the path is missing
+        data = load_dataset(_WSDA_PATH.name)
+
     if isinstance(data, list):
         return data
     if isinstance(data, Mapping) and "records" in data:

--- a/wsda_fertilizer_database.json
+++ b/wsda_fertilizer_database.json
@@ -1,1 +1,43 @@
-]
+{"records": [
+  {
+    "product_name": "GRANULAR POTASH 0-0-60",
+    "wsda_product_number": "(#2285-0006)",
+    "guaranteed_analysis": {
+      "Soluble Potash (K2O)": "60"
+    }
+  },
+  {
+    "product_name": "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6",
+    "wsda_product_number": "(#4083-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": "5",
+      "Available Phosphoric Acid (P2O5)": "6",
+      "Soluble Potash (K2O)": "6"
+    }
+  },
+  {
+    "product_name": "ACADIAN LIQUID SEAWEED CONCENTRATE 0-0-5",
+    "wsda_product_number": "(#0001-0025)",
+    "guaranteed_analysis": {
+      "Soluble Potash (K2O)": "5"
+    }
+  },
+  {
+    "product_name": "ACADIAN LIQUID SEAWEED CONCENTRATE 0.1-0-5",
+    "wsda_product_number": "(#0001-0018)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": "0.1",
+      "Soluble Potash (K2O)": "5"
+    }
+  }
+  ,
+  {
+    "product_name": "KELP MEAL 1-0.15-2",
+    "wsda_product_number": "(#0001-0003)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": "1",
+      "Available Phosphoric Acid (P2O5)": "0.15",
+      "Soluble Potash (K2O)": "2"
+    }
+  }
+]}


### PR DESCRIPTION
## Summary
- fix malformed `wsda_fertilizer_database.json` and include sample records
- enhance `wsda_lookup` to use `load_dataset` when the file path is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827b70b97483309aafd4a7ead2864f