### PR TITLE
Improve climate adjustment suggestions

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -165,11 +165,17 @@ def get_combined_environmental_targets(
 def recommend_climate_adjustments(
     current_env: Mapping[str, float], zone: str
 ) -> Dict[str, str]:
-    """Return simple adjustment suggestions for ``zone`` based on ``current_env``."""
+    """Return simple adjustment suggestions for ``zone`` based on ``current_env``.
+
+    The comparison uses climate zone guidelines only and currently checks
+    temperature, humidity, light intensity and CO₂ levels. Keys in
+    ``current_env`` are normalized using :func:`normalize_environment_readings`.
+    """
 
     guide = get_climate_guidelines(zone)
     env = normalize_environment_readings(current_env)
     suggestions: Dict[str, str] = {}
+
     if guide.temp_c is not None:
         low, high = guide.temp_c
         temp = env.get("temp_c")
@@ -178,6 +184,7 @@ def recommend_climate_adjustments(
                 suggestions["temperature"] = f"raise to {low}-{high}°C"
             elif temp > high:
                 suggestions["temperature"] = f"lower to {low}-{high}°C"
+
     if guide.humidity_pct is not None:
         low, high = guide.humidity_pct
         rh = env.get("humidity_pct")
@@ -186,6 +193,25 @@ def recommend_climate_adjustments(
                 suggestions["humidity"] = f"increase to {low}-{high}%"
             elif rh > high:
                 suggestions["humidity"] = f"decrease to {low}-{high}%"
+
+    if guide.light_ppfd is not None:
+        low, high = guide.light_ppfd
+        light = env.get("light_ppfd")
+        if light is not None:
+            if light < low:
+                suggestions["light"] = f"raise to {low}-{high} PPFD"
+            elif light > high:
+                suggestions["light"] = f"lower to {low}-{high} PPFD"
+
+    if guide.co2_ppm is not None:
+        low, high = guide.co2_ppm
+        co2 = env.get("co2_ppm")
+        if co2 is not None:
+            if co2 < low:
+                suggestions["co2"] = f"raise to {low}-{high} ppm"
+            elif co2 > high:
+                suggestions["co2"] = f"lower to {low}-{high} ppm"
+
     return suggestions
 
 

--- a/tests/test_climate_guidelines.py
+++ b/tests/test_climate_guidelines.py
@@ -14,10 +14,12 @@ def test_get_climate_guidelines():
 
 
 def test_recommend_climate_adjustments():
-    env = {"temp_c": 30, "humidity_pct": 50}
+    env = {"temp_c": 30, "humidity_pct": 50, "light_ppfd": 700, "co2_ppm": 500}
     rec = recommend_climate_adjustments(env, "temperate")
     assert "temperature" in rec and rec["temperature"].startswith("lower")
     assert "humidity" in rec and rec["humidity"].startswith("increase")
+    assert "light" in rec and rec["light"].startswith("lower")
+    assert "co2" in rec and rec["co2"].startswith("raise")
 
 
 def test_get_combined_environment_guidelines():

--- a/wsda_fertilizer_database.json
+++ b/wsda_fertilizer_database.json
@@ -1,1 +1,43 @@
-]
+{
+  "records": [
+    {
+      "product_name": "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6",
+      "wsda_product_number": "(#4083-0001)",
+      "guaranteed_analysis": {
+        "Total Nitrogen (N)": 5,
+        "Available Phosphoric Acid (P2O5)": 6,
+        "Soluble Potash (K2O)": 6
+      }
+    },
+    {
+      "product_name": "GRANULAR POTASH 0-0-60",
+      "wsda_product_number": "(#2285-0006)",
+      "guaranteed_analysis": {
+        "Soluble Potash (K2O)": 60
+      }
+    },
+    {
+      "product_name": "ACADIAN LIQUID SEAWEED CONCENTRATE 0-0-5",
+      "wsda_product_number": "(#0001-0025)",
+      "guaranteed_analysis": {
+        "Soluble Potash (K2O)": 5
+      }
+    },
+    {
+      "product_name": "ACADIAN LIQUID SEAWEED CONCENTRATE 0.1-0-5",
+      "wsda_product_number": "(#0001-0018)",
+      "guaranteed_analysis": {
+        "Total Nitrogen (N)": 0.1,
+        "Soluble Potash (K2O)": 5
+      }
+    },
+    {
+      "product_name": "ACADIAN MARINE PLANT EXTRACT POWDER 0.5-0-17",
+      "wsda_product_number": "(#0001-0016)",
+      "guaranteed_analysis": {
+        "Total Nitrogen (N)": 0.5,
+        "Soluble Potash (K2O)": 17
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- extend `recommend_climate_adjustments` to also check light and CO₂
- add small WSDA fertilizer dataset used by lookup utilities
- verify new suggestions in climate guideline tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827b999f3883309ca34b82cec4e1dd