### PR TITLE
Improve utils and dataset for tests

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -141,14 +141,28 @@ def list_dataset_entries(dataset: Mapping[str, Any]) -> list[str]:
     return sorted(str(k) for k in dataset.keys())
 
 
-def parse_range(value: Iterable[float]) -> tuple[float, float] | None:
+def parse_range(value: Iterable[float] | str) -> tuple[float, float] | None:
     """Return a normalized ``(min, max)`` tuple or ``None`` if invalid.
 
-    ``value`` may be any iterable with at least two numeric entries. Values are
-    cast to ``float`` and returned as a two-item tuple. If the input cannot be
-    interpreted as a pair of numbers, ``None`` is returned instead of raising an
-    exception.
+    ``value`` may be a two item iterable of numbers or a simple string
+    representation such as ``"1-2"`` or ``"1..2"``. Values are cast to
+    ``float``. Invalid inputs return ``None`` instead of raising an exception.
     """
+
+    if isinstance(value, str):
+        cleaned = (
+            value.replace("..", "-")
+            .replace(" to ", "-")
+            .replace(" ", "")
+        )
+        if "-" in cleaned:
+            parts = cleaned.split("-", 1)
+            if len(parts) == 2:
+                try:
+                    return float(parts[0]), float(parts[1])
+                except (TypeError, ValueError):
+                    return None
+        return None
 
     try:
         low, high = value

--- a/tests/test_parse_range.py
+++ b/tests/test_parse_range.py
@@ -12,3 +12,8 @@ def test_parse_range_tuple():
 def test_parse_range_invalid():
     assert parse_range([1]) is None
     assert parse_range("bad") is None
+
+
+def test_parse_range_string_formats():
+    assert parse_range("5-10") == (5.0, 10.0)
+    assert parse_range("3..7") == (3.0, 7.0)

--- a/wsda_fertilizer_database.json
+++ b/wsda_fertilizer_database.json
@@ -1,1 +1,29 @@
+[
+  {
+    "product_name": "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6",
+    "wsda_product_number": "(#4083-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 5,
+      "Available Phosphoric Acid": 6,
+      "Soluble Potash": 6
+    }
+  },
+  {
+    "product_name": "BASIC PLANT FOOD 10-10-10",
+    "wsda_product_number": "(#0001-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 10,
+      "Available Phosphoric Acid": 10,
+      "Soluble Potash": 10
+    }
+  },
+  {
+    "product_name": "SUPER K BOOST 0-0-50",
+    "wsda_product_number": "(#9999-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 0,
+      "Available Phosphoric Acid": 0,
+      "Soluble Potash": 50
+    }
+  }
 ]


### PR DESCRIPTION
## Summary
- enhance parse_range to handle simple string forms like `5-10`
- add sample WSDA fertilizer database records for tests
- extend parse_range tests to cover string inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827b9822f883309981526f793434a7