### PR TITLE
Enhance fertilizer formulator with conversion dataset

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -39,6 +39,7 @@
   "ec_guidelines.json": "Electrical conductivity ranges for nutrient solutions.",
   "fertilizer_purity.json": "Nutrient purity factors for fertilizer products.",
   "fertilizer_solubility.json": "Solubility limits for common fertilizers.",
+  "nutrient_conversion_factors.json": "Molar mass factors for converting oxide forms to elemental nutrients.",
   "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",
   "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
   "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",

--- a/data/nutrient_conversion_factors.json
+++ b/data/nutrient_conversion_factors.json
@@ -1,0 +1,6 @@
+{
+  "P2O5": {"element": "P", "factor": 0.436},
+  "K2O": {"element": "K", "factor": 0.830},
+  "CaO": {"element": "Ca", "factor": 0.715},
+  "MgO": {"element": "Mg", "factor": 0.603}
+}

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -16,6 +16,7 @@ def test_list_datasets_contains_known():
     assert "disease_monitoring_intervals.json" in datasets
     assert "reference_et0.json" in datasets
     assert "pesticide_modes.json" in datasets
+    assert "nutrient_conversion_factors.json" in datasets
     assert "dataset_catalog.json" not in datasets
 
 
@@ -33,6 +34,9 @@ def test_get_dataset_description():
 
     desc3 = get_dataset_description("fertilizer_purity.json")
     assert "purity" in desc3
+
+    desc_new = get_dataset_description("nutrient_conversion_factors.json")
+    assert "molar" in desc_new.lower()
 
     desc4 = get_dataset_description("irrigation_intervals.json")
     assert "irrigation" in desc4

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -14,6 +14,7 @@ spec.loader.exec_module(fert_mod)
 
 calculate_fertilizer_nutrients = fert_mod.calculate_fertilizer_nutrients
 convert_guaranteed_analysis = fert_mod.convert_guaranteed_analysis
+get_conversion_factors = fert_mod.get_conversion_factors
 list_products = fert_mod.list_products
 get_product_info = fert_mod.get_product_info
 calculate_fertilizer_cost = fert_mod.calculate_fertilizer_cost
@@ -45,6 +46,12 @@ def test_convert_guaranteed_analysis():
     assert result["N"] == 0.05
     assert round(result["P"], 4) == 0.0436
     assert round(result["K"], 3) == 0.166
+
+
+def test_get_conversion_factors():
+    factors = get_conversion_factors()
+    assert factors["P2O5"][0] == "P"
+    assert round(factors["P2O5"][1], 3) == 0.436
 
 
 def test_convert_guaranteed_analysis_skips_none():

--- a/wsda_fertilizer_database.json
+++ b/wsda_fertilizer_database.json
@@ -1,1 +1,29 @@
+[
+  {
+    "product_name": "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6",
+    "wsda_product_number": "(#4083-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen (N)": 5.0,
+      "Available Phosphoric Acid (P2O5)": 6.0,
+      "Soluble Potash (K2O)": 6.0
+    }
+  },
+  {
+    "product_name": "INTREPID POTASH-NEW MEXICO LLC Granular Potash 0-0-60 0-0-60",
+    "wsda_product_number": "(#2285-0006)",
+    "guaranteed_analysis": {
+      "Total Nitrogen (N)": 0.0,
+      "Available Phosphoric Acid (P2O5)": 0.0,
+      "Soluble Potash (K2O)": 60.0
+    }
+  },
+  {
+    "product_name": "ACADIAN LIQUID SEAWEED CONCENTRATE 0-0-5",
+    "wsda_product_number": "(#0001-0025)",
+    "guaranteed_analysis": {
+      "Total Nitrogen (N)": 0.0,
+      "Available Phosphoric Acid (P2O5)": 0.0,
+      "Soluble Potash (K2O)": 5.0
+    }
+  }
 ]


### PR DESCRIPTION
## Summary
- add nutrient_conversion_factors dataset and register in catalog
- factor out oxide conversion logic in fertilizer_formulator
- load conversion factors from dataset
- update WSDA fertilizer database with small sample for tests
- test coverage for new helpers and dataset access

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827b6c7f94833098891f94171aca80