### PR TITLE
Add tag registry helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Multiple plant profiles can be indexed in `plant_registry.json` so automations c
 }
 ```
 Tags defined in `tags.json` allow you to group plants for dashboards and analytics.
+The `tag_registry` utility exposes simple functions to list available tags and
+retrieve plants associated with a tag. This can be useful when generating
+automations or dynamic dashboards.
 
 
 ---

--- a/custom_components/horticulture_assistant/utils/tag_registry.py
+++ b/custom_components/horticulture_assistant/utils/tag_registry.py
@@ -1,0 +1,47 @@
+"""Simple helpers for working with the tags registry."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+__all__ = ["list_tags", "get_plants_with_tag", "search_tags"]
+
+_TAGS_FILE = Path(__file__).resolve().parents[3] / "tags.json"
+
+
+@lru_cache(maxsize=None)
+def _load_tags() -> Dict[str, List[str]]:
+    """Return contents of ``tags.json`` as ``{tag: [plant_ids]}``."""
+    if not _TAGS_FILE.exists():
+        return {}
+    with open(_TAGS_FILE, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+            return {str(k): list(v) for k, v in data.items()}
+        except Exception:
+            return {}
+
+
+def list_tags() -> List[str]:
+    """Return all available tag names sorted alphabetically."""
+    return sorted(_load_tags().keys())
+
+
+def get_plants_with_tag(tag: str) -> List[str]:
+    """Return plant IDs associated with ``tag``."""
+    return _load_tags().get(str(tag), [])
+
+
+def search_tags(term: str) -> Dict[str, List[str]]:
+    """Return tags containing ``term`` (case-insensitive)."""
+    if not term:
+        return {}
+    term = term.lower()
+    matches: Dict[str, List[str]] = {}
+    for tag, plants in _load_tags().items():
+        if term in tag.lower():
+            matches[tag] = plants
+    return matches

--- a/tests/test_tag_registry.py
+++ b/tests/test_tag_registry.py
@@ -1,0 +1,28 @@
+from custom_components.horticulture_assistant.utils import tag_registry
+
+
+def test_list_tags(tmp_path, monkeypatch):
+    file = tmp_path / "tags.json"
+    file.write_text('{"a": ["p1"], "b": ["p2", "p3"]}')
+    monkeypatch.setattr(tag_registry, "_TAGS_FILE", file)
+    tag_registry._load_tags.cache_clear()
+    assert tag_registry.list_tags() == ["a", "b"]
+
+
+def test_get_plants_with_tag(tmp_path, monkeypatch):
+    file = tmp_path / "tags.json"
+    file.write_text('{"x": ["p1", "p2"]}')
+    monkeypatch.setattr(tag_registry, "_TAGS_FILE", file)
+    tag_registry._load_tags.cache_clear()
+    assert tag_registry.get_plants_with_tag("x") == ["p1", "p2"]
+    assert tag_registry.get_plants_with_tag("missing") == []
+
+
+def test_search_tags(tmp_path, monkeypatch):
+    file = tmp_path / "tags.json"
+    file.write_text('{"cool": ["p1"], "warm": ["p2"]}')
+    monkeypatch.setattr(tag_registry, "_TAGS_FILE", file)
+    tag_registry._load_tags.cache_clear()
+    result = tag_registry.search_tags("co")
+    assert result == {"cool": ["p1"]}
+    assert tag_registry.search_tags("") == {}


### PR DESCRIPTION
## Summary
- add utility functions for querying plant tags
- test tag registry helpers
- document tag utilities in the README

## Testing
- `pytest tests/test_tag_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68827b8f8658833096774b4eaa287623