### PR TITLE
Add infiltration scheduling helper

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -109,7 +109,10 @@ from .irrigation_manager import (
     list_supported_plants as list_irrigation_plants,
     get_daily_irrigation_target,
     generate_irrigation_schedule,
+    generate_irrigation_schedule_with_runtime,
+    summarize_irrigation_schedule,
     generate_cycle_irrigation_plan,
+    estimate_infiltration_series,
 )
 from .nutrient_manager import (
     calculate_deficiencies,
@@ -399,6 +402,7 @@ __all__ = [
     "generate_irrigation_schedule_with_runtime",
     "summarize_irrigation_schedule",
     "generate_cycle_irrigation_plan",
+    "estimate_infiltration_series",
     "HarvestRecord",
     "load_yield_history",
     "record_harvest",

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -19,6 +19,7 @@ from plant_engine.irrigation_manager import (
     generate_precipitation_schedule,
     get_rain_capture_efficiency,
     get_recommended_interval,
+    estimate_infiltration_series,
     IrrigationRecommendation,
 )
 from plant_engine.rootzone_model import RootZone, calculate_remaining_water
@@ -304,4 +305,14 @@ def test_generate_cycle_irrigation_plan():
     # verify at least one scheduled volume and it is positive
     assert veg
     assert veg[1] > 0
+
+
+def test_estimate_infiltration_series():
+    schedule = {1: 100.0, 2: 0.0, 3: 50.0}
+    times = estimate_infiltration_series(schedule, 1.0, "loam")
+    assert times[1] == 0.01
+    assert times[2] == 0.0
+    assert times[3] == 0.01
+    with pytest.raises(ValueError):
+        estimate_infiltration_series(schedule, 0, "loam")
 

--- a/wsda_fertilizer_database.json
+++ b/wsda_fertilizer_database.json
@@ -1,1 +1,40 @@
+[
+  {
+    "product_name": "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6",
+    "wsda_product_number": "(#4083-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 5.0,
+      "Available Phosphoric Acid": 6.0,
+      "Soluble Potash": 6.0
+    }
+  },
+  {
+    "product_name": "GRANULAR POTASH 0-0-60",
+    "wsda_product_number": "(#2285-0006)",
+    "guaranteed_analysis": {
+      "Soluble Potash": 60.0
+    }
+  },
+  {
+    "product_name": "20 MULE TEAM BORAX FERTIBOR SODIUM BORATE 15% B 0-0-0",
+    "wsda_product_number": "(#3830-0001)",
+    "guaranteed_analysis": {
+      "Boron": 15.0
+    }
+  },
+  {
+    "product_name": "K BLEND 3-0-20",
+    "wsda_product_number": "(#9999-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 3.0,
+      "Soluble Potash": 20.0
+    }
+  },
+  {
+    "product_name": "NITROGEN BOOST 10-0-0",
+    "wsda_product_number": "(#7777-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 10.0
+    }
+  }
 ]


### PR DESCRIPTION
## Summary
- extend irrigation manager with `estimate_infiltration_series`
- expose helper through package `__init__`
- expand WSDA fertilizer sample dataset for tests
- cover new helper with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827b9314b88330966fedc326be57ee