### PR TITLE
Enhance environment recommendations with detailed actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Key reference datasets reside in the `data/` directory:
 - `ipm_guidelines.json` – integrated pest management practices by crop
 - `water_quality_thresholds.json` – acceptable ion limits for irrigation water
 - `water_quality_actions.json` – recommended treatments when limits are exceeded
+- `environment_actions.json` – suggested actions for environmental adjustments
 - `fertilizer_purity.json` – default purity factors for common fertilizers
 - `fertilizer_solubility.json` – maximum solubility (g/L) for fertilizers
 - `fertigation_recipes.json` – grams per liter of each product for standard mixes

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -27,6 +27,7 @@
   "rain_capture_efficiency.json": "Fraction of rainfall captured by different ground covers.",
   "water_quality_thresholds.json": "Maximum safe levels of common water analytes.",
   "water_quality_actions.json": "Recommended remediation steps for poor water quality.",
+  "environment_actions.json": "Recommended actions to increase or decrease environment parameters.",
   "leaf_tissue_targets.json": "Optimal nutrient ranges for leaf tissue analysis.",
   "leaf_tissue_score_weights.json": "Scoring weights for leaf tissue nutrients.",
   "leaf_temperature_guidelines.json": "Recommended leaf temperature ranges for optimal photosynthesis.",

--- a/data/environment_actions.json
+++ b/data/environment_actions.json
@@ -1,0 +1,22 @@
+{
+  "temperature": {
+    "increase": "enable heating to raise temperature",
+    "decrease": "use cooling or shade to lower temperature"
+  },
+  "humidity": {
+    "increase": "use misting or humidifiers",
+    "decrease": "increase ventilation or dehumidify"
+  },
+  "light": {
+    "increase": "add supplemental lighting",
+    "decrease": "reduce light intensity"
+  },
+  "co2": {
+    "increase": "inject CO2",
+    "decrease": "improve air exchange"
+  },
+  "soil_moisture": {
+    "increase": "irrigate to raise soil moisture",
+    "decrease": "allow soil to dry"
+  }
+}

--- a/tests/test_environment_actions.py
+++ b/tests/test_environment_actions.py
@@ -1,0 +1,13 @@
+from plant_engine.environment_manager import recommend_environment_actions
+
+
+def test_recommend_environment_actions_increase():
+    readings = {"temperature": 10}
+    actions = recommend_environment_actions(readings, "citrus", "vegetative")
+    assert actions["temperature"].startswith("enable")
+
+
+def test_recommend_environment_actions_none_when_in_range():
+    readings = {"temp_c": 20, "humidity_pct": 60}
+    actions = recommend_environment_actions(readings, "citrus", "vegetative")
+    assert actions == {}

--- a/wsda_fertilizer_database.json
+++ b/wsda_fertilizer_database.json
@@ -1,1 +1,40 @@
+[
+  {
+    "product_name": "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6",
+    "wsda_product_number": "(#4083-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 5,
+      "Available Phosphoric Acid": 6,
+      "Soluble Potash": 6,
+      "Calcium (Ca)": 1,
+      "Magnesium (Mg)": 0.5
+    }
+  },
+  {
+    "product_name": "BEST K+ 0-0-50",
+    "wsda_product_number": "(#1234-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 0,
+      "Available Phosphoric Acid": 0,
+      "Soluble Potash": 50
+    }
+  },
+  {
+    "product_name": "SUPER NITRO 32-0-0",
+    "wsda_product_number": "(#2345-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 32,
+      "Available Phosphoric Acid": 0,
+      "Soluble Potash": 0
+    }
+  },
+  {
+    "product_name": "TRIPLE SUPERPHOSPHATE 0-45-0",
+    "wsda_product_number": "(#3456-0001)",
+    "guaranteed_analysis": {
+      "Total Nitrogen": 0,
+      "Available Phosphoric Acid": 45,
+      "Soluble Potash": 0
+    }
+  }
 ]


### PR DESCRIPTION
## Summary
- add new dataset `environment_actions.json` with suggestions for changing key parameters
- load dataset in `environment_manager` and expose `recommend_environment_actions`
- keep existing adjustment recommendations but allow optional detailed versions
- include dataset in catalog and README
- create minimal WSDA fertilizer database used in tests
- add tests for new environment actions helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68827b94a0cc83309b8635b254c230b5