### PR TITLE
Improve state parsing utilities

### DIFF
--- a/custom_components/horticulture_assistant/utils/state_helpers.py
+++ b/custom_components/horticulture_assistant/utils/state_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
@@ -10,13 +11,28 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = ["get_numeric_state"]
 
 def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
-    """Return the state of ``entity_id`` cast to ``float`` if available."""
+    """Return the numeric state of ``entity_id`` or ``None`` if unavailable.
+
+    The helper accepts values with optional units appended, such as
+    ``"25 °C"`` or ``"5.5pH"``. Non-numeric states return ``None`` and a
+    debug message is logged. Values like ``"unknown"`` or ``"unavailable````
+    are also treated as missing.
+    """
+
     state = hass.states.get(entity_id)
-    if not state or state.state in ("unknown", "unavailable"):
+    if not state or state.state in {"unknown", "unavailable"}:
         _LOGGER.debug("State unavailable: %s", entity_id)
         return None
+
+    value = state.state
     try:
-        return float(state.state)
+        return float(value)
     except (ValueError, TypeError):
-        _LOGGER.warning("State of %s is not numeric: %s", entity_id, state.state)
+        match = re.search(r"[-+]?[0-9]*\.?[0-9]+", str(value))
+        if match:
+            try:
+                return float(match.group(0))
+            except (ValueError, TypeError):
+                pass
+        _LOGGER.warning("State of %s is not numeric: %s", entity_id, value)
         return None

--- a/tests/test_state_helpers.py
+++ b/tests/test_state_helpers.py
@@ -1,0 +1,34 @@
+import types
+
+from custom_components.horticulture_assistant.utils.state_helpers import get_numeric_state
+
+class DummyStates:
+    def __init__(self):
+        self._data = {}
+    def get(self, entity_id):
+        val = self._data.get(entity_id)
+        return types.SimpleNamespace(state=val) if val is not None else None
+
+class DummyHass:
+    def __init__(self):
+        self.states = DummyStates()
+
+
+def test_get_numeric_state_basic():
+    hass = DummyHass()
+    hass.states._data["sensor.number"] = "5"
+    assert get_numeric_state(hass, "sensor.number") == 5.0
+
+
+def test_get_numeric_state_with_units():
+    hass = DummyHass()
+    hass.states._data["sensor.temp"] = "21.5 °C"
+    assert get_numeric_state(hass, "sensor.temp") == 21.5
+
+
+def test_get_numeric_state_invalid():
+    hass = DummyHass()
+    hass.states._data["sensor.bad"] = "unknown"
+    assert get_numeric_state(hass, "sensor.bad") is None
+    hass.states._data["sensor.bad"] = "foo"
+    assert get_numeric_state(hass, "sensor.bad") is None


### PR DESCRIPTION
## Summary
- better parse numeric state values from Home Assistant
- test numeric state helper covers units and invalid data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838bfbcecc83308b6d3653adb10300