### PR TITLE
Add environment variance helper

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -289,6 +289,7 @@ __all__ = [
     "summarize_environment",
     "summarize_environment_series",
     "average_environment_readings",
+    "calculate_environment_variance",
     "EnvironmentSummary",
     "calculate_environment_metrics_series",
     "generate_stage_environment_plan",
@@ -385,6 +386,25 @@ def average_environment_readings(series: Iterable[Mapping[str, float]]) -> Dict[
         return {}
 
     return {k: v / count for k, v in totals.items()}
+
+
+def calculate_environment_variance(series: Iterable[Mapping[str, float]]) -> Dict[str, float]:
+    """Return variance for normalized environment readings."""
+
+    values: Dict[str, list[float]] = {}
+    for reading in series:
+        for key, value in normalize_environment_readings(reading).items():
+            values.setdefault(key, []).append(float(value))
+
+    variance: Dict[str, float] = {}
+    for key, vals in values.items():
+        n = len(vals)
+        if n == 0:
+            continue
+        mean = sum(vals) / n
+        var = sum((v - mean) ** 2 for v in vals) / n
+        variance[key] = round(var, 3)
+    return variance
 
 
 def saturation_vapor_pressure(temp_c: float) -> float:

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -58,6 +58,7 @@ from plant_engine.environment_manager import (
     summarize_environment_series,
     calculate_environment_metrics_series,
     average_environment_readings,
+    calculate_environment_variance,
     clear_environment_cache,
     get_target_soil_temperature,
     get_target_soil_ec,
@@ -556,6 +557,21 @@ def test_average_environment_readings():
     avg = average_environment_readings(series)
     assert avg["temp_c"] == pytest.approx(21)
     assert avg["humidity_pct"] == pytest.approx(65)
+
+
+def test_calculate_environment_variance():
+    series = [
+        {"temp_c": 20, "humidity_pct": 70},
+        {"temperature": 22, "humidity": 72},
+        {"temp_c": 21, "humidity_pct": 74},
+    ]
+    var = calculate_environment_variance(series)
+    assert var["temp_c"] == pytest.approx(0.667, rel=1e-3)
+    assert var["humidity_pct"] == pytest.approx(2.667, rel=1e-3)
+
+
+def test_calculate_environment_variance_empty():
+    assert calculate_environment_variance([]) == {}
 
 
 def test_summarize_environment():


### PR DESCRIPTION
## Summary
- expose new `calculate_environment_variance` helper in environment_manager
- unit tests for the new variance calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838c0b125c8330bf44798f21fd19b5