### PR TITLE
Enhance environment optimization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -225,6 +225,7 @@ __all__ = [
     "suggest_environment_setpoints",
     "suggest_environment_setpoints_advanced",
     "energy_optimized_setpoints",
+    "cost_optimized_setpoints",
     "saturation_vapor_pressure",
     "actual_vapor_pressure",
     "calculate_vpd",
@@ -869,6 +870,38 @@ def energy_optimized_setpoints(
     low_kwh = estimate_hvac_energy(current_temp_c, low, hours, system)
     high_kwh = estimate_hvac_energy(current_temp_c, high, hours, system)
     setpoints["temp_c"] = low if low_kwh <= high_kwh else high
+    return setpoints
+
+
+def cost_optimized_setpoints(
+    plant_type: str,
+    stage: str | None,
+    current_temp_c: float,
+    hours: float,
+    system: str = "heating",
+    region: str | None = None,
+) -> Dict[str, float]:
+    """Return environment setpoints minimizing HVAC cost.
+
+    The temperature setpoint that results in the lowest estimated energy
+    cost for ``hours`` is selected using :func:`energy_manager.estimate_hvac_cost`.
+    All other setpoints match :func:`suggest_environment_setpoints`.
+    """
+
+    if hours <= 0:
+        raise ValueError("hours must be positive")
+
+    setpoints = suggest_environment_setpoints(plant_type, stage)
+    temp_range = get_environmental_targets(plant_type, stage).get("temp_c")
+    if not isinstance(temp_range, (list, tuple)) or len(temp_range) != 2:
+        return setpoints
+
+    from .energy_manager import estimate_hvac_cost
+
+    low, high = float(temp_range[0]), float(temp_range[1])
+    low_cost = estimate_hvac_cost(current_temp_c, low, hours, system, region)
+    high_cost = estimate_hvac_cost(current_temp_c, high, hours, system, region)
+    setpoints["temp_c"] = low if low_cost <= high_cost else high
     return setpoints
 
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -63,6 +63,7 @@ from plant_engine.environment_manager import (
     get_target_soil_ec,
     get_target_leaf_temperature,
     energy_optimized_setpoints,
+    cost_optimized_setpoints,
 )
 
 
@@ -151,6 +152,22 @@ def test_energy_optimized_setpoints():
 def test_energy_optimized_setpoints_invalid():
     with pytest.raises(ValueError):
         energy_optimized_setpoints("citrus", "seedling", 20, 0)
+
+
+def test_cost_optimized_setpoints():
+    normal = suggest_environment_setpoints("citrus", "seedling")
+    result = cost_optimized_setpoints(
+        "citrus", "seedling", 20, 12, region="default"
+    )
+    assert result["temp_c"] == 22
+    for key, value in normal.items():
+        if key != "temp_c":
+            assert result[key] == value
+
+
+def test_cost_optimized_setpoints_invalid():
+    with pytest.raises(ValueError):
+        cost_optimized_setpoints("citrus", "seedling", 20, 0)
 
 
 def test_vapor_pressure_helpers():


### PR DESCRIPTION
## Summary
- add `cost_optimized_setpoints` helper to minimize HVAC cost
- expose it via `__all__`
- test cost optimized environment setpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68838c08798883309434b837495bdc6a