### PR TITLE
Enhance micronutrient utilities

### DIFF
--- a/tests/test_micro_manager.py
+++ b/tests/test_micro_manager.py
@@ -19,3 +19,10 @@ def test_micro_surplus():
     surplus = micro.calculate_surplus(current, "lettuce", "seedling")
     assert surplus["Fe"] == 3.0
     assert surplus["Mn"] == 0.5
+
+
+def test_micro_balance():
+    current = {"Fe": 1.0, "Mn": 0.25}
+    ratios = micro.calculate_balance(current, "lettuce", "seedling")
+    assert ratios["Fe"] == 0.5
+    assert ratios["Mn"] == 0.5


### PR DESCRIPTION
## Summary
- refactor micro_manager to share diff logic
- add `calculate_balance` to compute micronutrient ratios
- expand micro nutrient tests

## Testing
- `pytest tests/test_micro_manager.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838c068f888330b9c5f69f3be1c14b