### PR TITLE
Improve environment planning with climate zones

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -292,6 +292,8 @@ __all__ = [
     "EnvironmentSummary",
     "calculate_environment_metrics_series",
     "generate_stage_environment_plan",
+    "suggest_environment_setpoints_zone",
+    "generate_zone_environment_plan",
 ]
 
 
@@ -794,6 +796,14 @@ def suggest_environment_setpoints(
     """Return midpoint setpoints for key environment parameters."""
 
     targets = get_environmental_targets(plant_type, stage)
+    return _midpoint_setpoints(targets, plant_type, stage)
+
+
+def _midpoint_setpoints(
+    targets: Mapping[str, Any], plant_type: str, stage: str | None
+) -> Dict[str, float]:
+    """Return midpoint values for ``targets`` with soil parameters."""
+
     setpoints: Dict[str, float] = {}
     for key, bounds in targets.items():
         if isinstance(bounds, (list, tuple)) and len(bounds) == 2:
@@ -878,6 +888,24 @@ def generate_stage_environment_plan(plant_type: str) -> Dict[str, Dict[str, floa
     plan: Dict[str, Dict[str, float]] = {}
     for stage in list_growth_stages(plant_type):
         plan[stage] = suggest_environment_setpoints(plant_type, stage)
+    return plan
+
+
+def suggest_environment_setpoints_zone(
+    plant_type: str, stage: str | None, zone: str
+) -> Dict[str, float]:
+    """Return midpoint setpoints for a plant stage adjusted for ``zone``."""
+
+    targets = get_combined_environmental_targets(plant_type, stage, zone)
+    return _midpoint_setpoints(targets, plant_type, stage)
+
+
+def generate_zone_environment_plan(plant_type: str, zone: str) -> Dict[str, Dict[str, float]]:
+    """Return environment setpoints for each stage adjusted for ``zone``."""
+
+    plan: Dict[str, Dict[str, float]] = {}
+    for stage in list_growth_stages(plant_type):
+        plan[stage] = suggest_environment_setpoints_zone(plant_type, stage, zone)
     return plan
 
 

--- a/tests/test_zone_environment_plan.py
+++ b/tests/test_zone_environment_plan.py
@@ -1,0 +1,17 @@
+from plant_engine.environment_manager import (
+    suggest_environment_setpoints_zone,
+    generate_zone_environment_plan,
+)
+
+
+def test_suggest_environment_setpoints_zone():
+    result = suggest_environment_setpoints_zone("citrus", "seedling", "temperate")
+    assert result["temp_c"] == 24
+    assert result["humidity_pct"] == 70
+    assert result["light_ppfd"] == 275
+    assert result["co2_ppm"] == 600
+
+
+def test_generate_zone_environment_plan():
+    plan = generate_zone_environment_plan("citrus", "temperate")
+    assert plan["seedling"]["light_ppfd"] == 275


### PR DESCRIPTION
## Summary
- factor out midpoint setpoint calculation
- add `suggest_environment_setpoints_zone` and `generate_zone_environment_plan`
- export new helpers via `__all__`
- test zone‐aware environment planning

## Testing
- `pytest -q tests/test_zone_environment_plan.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838c029d9c83309843ce5256dccee8