### PR TITLE
Add dataset path override utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ provided before any overlay files.
 Call `plant_engine.utils.clear_dataset_cache()` if you modify these
 environment variables while the application is running so changes are
 immediately reflected.
+Alternatively, call `plant_engine.utils.set_dataset_paths()` to programmatically
+override the search locations and refresh cached lookups at runtime.
 
 The datasets are snapshots compiled from public resources. They may be outdated
 or incomplete and should only be used as a starting point for your own research.

--- a/tests/test_dataset_paths.py
+++ b/tests/test_dataset_paths.py
@@ -1,0 +1,28 @@
+import json
+
+import plant_engine.utils as utils
+
+
+def test_set_dataset_paths(tmp_path):
+    base1 = tmp_path / "base1"
+    base2 = tmp_path / "base2"
+    overlay = tmp_path / "overlay"
+    base1.mkdir()
+    base2.mkdir()
+    overlay.mkdir()
+
+    (base1 / "sample.json").write_text(json.dumps({"a": 1}))
+    (base2 / "sample.json").write_text(json.dumps({"a": 2, "b": 3}))
+    (overlay / "sample.json").write_text(json.dumps({"c": 4}))
+
+    utils.set_dataset_paths(data_dir=base1)
+    assert utils.load_dataset("sample.json") == {"a": 1}
+
+    utils.set_dataset_paths(data_dir=base2, overlay_dir=overlay, extra_dirs=[base1])
+    result = utils.load_dataset("sample.json")
+    # extra directories override the base data directory
+    assert result == {"a": 1, "b": 3, "c": 4}
+
+    # reset to defaults using None
+    utils.set_dataset_paths(None)
+


### PR DESCRIPTION
## Summary
- add a `set_dataset_paths` helper for programmatically overriding dataset directories
- document the helper in README
- test new dataset path override functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68838c00bdb88330bd597f2c6590c987