### PR TITLE
Extend daily report with water quality data

### DIFF
--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from custom_components.horticulture_assistant.engine.run_daily_cycle import run_daily_cycle
 
 
@@ -17,10 +18,20 @@ def test_run_daily_cycle_extended(tmp_path):
                     "start_date": "2025-01-01",
                     "observed_pests": ["aphids"],
                     "observed_diseases": [],
-                    "observed_pest_counts": {"aphids": 12}
+                "observed_pest_counts": {"aphids": 12}
                 }
             }
         )
+    )
+
+    (plants_dir / "sample" ).mkdir()
+    (plants_dir / "sample" / "water_quality_log.json").write_text(
+        json.dumps([
+            {
+                "results": {"Na": 60, "Cl": 50},
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat()
+            }
+        ])
     )
 
     report = run_daily_cycle("sample", base_path=str(plants_dir), output_path=str(out_dir))
@@ -33,3 +44,4 @@ def test_run_daily_cycle_extended(tmp_path):
     assert "fertigation_schedule" in report
     assert "fertigation_cost" in report
     assert (out_dir / f"sample_{report['timestamp'][:10]}.json").exists()
+    assert report["water_quality_summary"]["rating"] == "fair"


### PR DESCRIPTION
## Summary
- include water quality analysis in `run_daily_cycle`
- test that daily reports now show water quality rating

## Testing
- `pytest -q`
- `pytest tests/test_run_daily_cycle_extended.py::test_run_daily_cycle_extended -q`

------
https://chatgpt.com/codex/tasks/task_e_68838bfef05c8330994aca1241a6573e