### PR TITLE
Add fertilizer cost helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Key reference datasets reside in the `data/` directory:
   `plant_engine.wsda_lookup` for product N‑P‑K values
 - The `recommend_wsda_products` helper in `fertilizer_formulator` returns the
   highest concentration products for a nutrient using this dataset.
+- The `estimate_recommended_application_cost` helper computes the product cost
+  for recommended grams per liter based on the application rate data.
 - `products_index.jsonl` – compact summary of WSDA products for fast searches (use `wsda_product_index`)
 - `dataset_catalog.json` – short descriptions of the bundled datasets for quick reference
   Use `plant_engine.datasets.list_datasets()` to list available files and

--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -594,6 +594,13 @@ def calculate_recommended_application(fertilizer_id: str, volume_l: float) -> fl
     return round(grams, 3)
 
 
+def estimate_recommended_application_cost(fertilizer_id: str, volume_l: float) -> float:
+    """Return cost of fertilizer for ``volume_l`` solution using rate data."""
+
+    grams = calculate_recommended_application(fertilizer_id, volume_l)
+    return calculate_fertilizer_cost_from_mass(fertilizer_id, grams)
+
+
 def recommend_wsda_products(nutrient: str, limit: int = 5) -> List[str]:
     """Return WSDA product names with high concentrations of ``nutrient``."""
 
@@ -625,6 +632,7 @@ __all__ = [
     "get_application_method",
     "get_application_rate",
     "calculate_recommended_application",
+    "estimate_recommended_application_cost",
     "recommend_wsda_products",
     "CATALOG",
 ]

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -35,6 +35,7 @@ calculate_mass_for_target_ppm = fert_mod.calculate_mass_for_target_ppm
 get_application_method = fert_mod.get_application_method
 get_application_rate = fert_mod.get_application_rate
 calculate_recommended_application = fert_mod.calculate_recommended_application
+estimate_recommended_application_cost = fert_mod.estimate_recommended_application_cost
 recommend_wsda_products = fert_mod.recommend_wsda_products
 CATALOG = fert_mod.CATALOG
 
@@ -274,4 +275,10 @@ def test_recommend_wsda_products():
     products = recommend_wsda_products("N", limit=3)
     assert len(products) == 3
     assert all(isinstance(p, str) for p in products)
+
+
+def test_estimate_recommended_application_cost():
+    cost = estimate_recommended_application_cost("foxfarm_grow_big", 2)
+    expected = calculate_fertilizer_cost_from_mass("foxfarm_grow_big", 10.0)
+    assert cost == expected
 


### PR DESCRIPTION
## Summary
- compute fertilizer application cost from application rates
- document new helper in README
- cover new helper with tests

## Testing
- `pytest tests/test_fertilizer_formulator.py::test_estimate_recommended_application_cost -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838bf88df08330bb541a6c7ed2acec