### PR TITLE
Improve fertilizer recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Key reference datasets reside in the `data/` directory:
   `plant_engine.wsda_lookup` for product N‑P‑K values
 - The `recommend_wsda_products` helper in `fertilizer_formulator` returns the
   highest concentration products for a nutrient using this dataset.
+- The `recommend_cost_effective_products` helper ranks local inventory by
+  cost per nutrient to simplify budget-conscious fertilizer selection.
 - `products_index.jsonl` – compact summary of WSDA products for fast searches (use `wsda_product_index`)
 - `dataset_catalog.json` – short descriptions of the bundled datasets for quick reference
   Use `plant_engine.datasets.list_datasets()` to list available files and

--- a/data/fertilizers/fertilizer_prices.json
+++ b/data/fertilizers/fertilizer_prices.json
@@ -1,5 +1,6 @@
 {
   "foxfarm_grow_big": 20.0,
   "magriculture": 10.0,
-  "intrepid_granular_potash_0_0_60": 5.0
+  "intrepid_granular_potash_0_0_60": 5.0,
+  "earth_care_plus_5_6_6": 15.0
 }

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -36,6 +36,7 @@ get_application_method = fert_mod.get_application_method
 get_application_rate = fert_mod.get_application_rate
 calculate_recommended_application = fert_mod.calculate_recommended_application
 recommend_wsda_products = fert_mod.recommend_wsda_products
+recommend_cost_effective_products = fert_mod.recommend_cost_effective_products
 CATALOG = fert_mod.CATALOG
 
 
@@ -274,4 +275,14 @@ def test_recommend_wsda_products():
     products = recommend_wsda_products("N", limit=3)
     assert len(products) == 3
     assert all(isinstance(p, str) for p in products)
+
+
+def test_recommend_cost_effective_products():
+    ranked = fert_mod.recommend_cost_effective_products("K", limit=2)
+    # cheapest source of potassium should be the granular potash product
+    assert ranked[0][0] == "intrepid_granular_potash_0_0_60"
+    assert len(ranked) == 2
+
+    with pytest.raises(ValueError):
+        fert_mod.recommend_cost_effective_products("")
 


### PR DESCRIPTION
## Summary
- add new dataset entry for `earth_care_plus_5_6_6` pricing
- convert fertilizer guaranteed analysis keys more robustly
- expose `recommend_cost_effective_products` helper
- document new helper in README
- test ranking of cost-efficient fertilizer products

## Testing
- `python3 -m pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838bf717788330b1a56baac10ea4c7