### PR TITLE
Improve plant runner with concurrency

### DIFF
--- a/scripts/run_all_plants.py
+++ b/scripts/run_all_plants.py
@@ -1,4 +1,6 @@
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 from plant_engine import run_daily_cycle
 from plant_engine.utils import save_json
 
@@ -12,22 +14,43 @@ def get_plant_ids():
         if f.endswith(".json")
     ]
 
-def run_all_plants():
-    summary = {}
 
-    for plant_id in get_plant_ids():
-        print(f"🔄 Running daily engine for: {plant_id}")
-        try:
-            report = run_daily_cycle(plant_id)
-            summary[plant_id] = report
-        except Exception as e:
-            summary[plant_id] = {"error": str(e)}
-            print(f"❌ Error processing {plant_id}: {e}")
+MAX_WORKERS = min(32, (os.cpu_count() or 1) * 2)
+
+
+def _run_for_plant(plant_id: str) -> tuple[str, dict]:
+    """Helper to execute :func:`run_daily_cycle` for a single plant."""
+
+    print(f"🔄 Running daily engine for: {plant_id}")
+    try:
+        return plant_id, run_daily_cycle(plant_id)
+    except Exception as exc:  # pragma: no cover - runtime safeguard
+        print(f"❌ Error processing {plant_id}: {exc}")
+        return plant_id, {"error": str(exc)}
+
+
+def run_all_plants(parallel: bool = True) -> dict:
+    """Run the daily engine for all plants and return summary."""
+
+    summary: dict[str, dict] = {}
+    plant_ids = get_plant_ids()
+
+    if parallel and len(plant_ids) > 1:
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            tasks = {executor.submit(_run_for_plant, pid): pid for pid in plant_ids}
+            for future in as_completed(tasks):
+                pid, result = future.result()
+                summary[pid] = result
+    else:
+        for pid in plant_ids:
+            pid, result = _run_for_plant(pid)
+            summary[pid] = result
 
     # Save master report
     os.makedirs(os.path.dirname(SUMMARY_PATH), exist_ok=True)
     save_json(SUMMARY_PATH, summary)
     print(f"\n✅ Summary report written to {SUMMARY_PATH}")
+    return summary
 
 if __name__ == "__main__":
     run_all_plants()


### PR DESCRIPTION
## Summary
- use a thread pool to run plant daily cycles concurrently
- return a summary from `run_all_plants`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a72752bc8330b04f41ac87263947