### PR TITLE
Improve dataset utilities and profile caching

### DIFF
--- a/custom_components/horticulture_assistant/utils/load_plant_profile.py
+++ b/custom_components/horticulture_assistant/utils/load_plant_profile.py
@@ -9,10 +9,17 @@ default to speed up loading in production.
 import json
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict
 
 _LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "PlantProfile",
+    "load_plant_profile",
+    "clear_profile_cache",
+]
 
 
 @dataclass(slots=True)
@@ -31,6 +38,7 @@ class PlantProfile:
         return self.as_dict()[item]
 
 
+@lru_cache(maxsize=None)
 def load_plant_profile(
     plant_id: str,
     base_path: str | None = None,
@@ -124,3 +132,9 @@ def load_plant_profile(
     _LOGGER.info("Loaded %d profile modules for plant '%s'.", count_loaded, plant_id)
 
     return PlantProfile(plant_id=str(plant_id), profile_data=profile_data)
+
+
+def clear_profile_cache() -> None:
+    """Clear cached profile results from :func:`load_plant_profile`."""
+
+    load_plant_profile.cache_clear()

--- a/scripts/dataset_info.py
+++ b/scripts/dataset_info.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""List or search bundled datasets."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+# Ensure project root is on the Python path when executed directly
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from plant_engine.datasets import (
+    list_datasets,
+    list_dataset_info,
+    search_datasets,
+)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Dataset discovery utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = sub.add_parser("list", help="list available dataset files")
+    list_parser.add_argument(
+        "--describe",
+        action="store_true",
+        help="include dataset descriptions in output",
+    )
+
+    search_parser = sub.add_parser("search", help="search dataset names")
+    search_parser.add_argument("term", help="search term")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "list":
+        if args.describe:
+            for name, desc in list_dataset_info().items():
+                line = f"{name}: {desc}" if desc else name
+                print(line)
+        else:
+            for name in list_datasets():
+                print(name)
+        return
+
+    if args.command == "search":
+        results = search_datasets(args.term)
+        for name, desc in results.items():
+            line = f"{name}: {desc}" if desc else name
+            print(line)
+        return
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_dataset_info_script.py
+++ b/tests/test_dataset_info_script.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import subprocess
+import sys
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/dataset_info.py"
+
+
+def test_list_cli():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert "nutrient_guidelines.json" in lines
+
+
+def test_search_cli():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "search", "nutrient"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = result.stdout
+    assert "nutrient_guidelines.json" in out

--- a/tests/test_load_plant_profile.py
+++ b/tests/test_load_plant_profile.py
@@ -1,7 +1,9 @@
 import json
 
-from custom_components.horticulture_assistant.utils.load_plant_profile import \
-    load_plant_profile
+from custom_components.horticulture_assistant.utils.load_plant_profile import (
+    load_plant_profile,
+    clear_profile_cache,
+)
 
 
 def test_load_profile_basic(tmp_path):
@@ -36,3 +38,19 @@ def test_load_profile_with_validation_files(tmp_path):
 def test_load_profile_missing_dir(tmp_path):
     result = load_plant_profile("missing", base_path=tmp_path / "plants")
     assert result == {}
+
+def test_profile_caching(tmp_path):
+    plant_dir = tmp_path / "plants" / "demo"
+    plant_dir.mkdir(parents=True)
+    data_file = plant_dir / "general.json"
+    data_file.write_text(json.dumps({"name": "first"}))
+
+    first = load_plant_profile("demo", base_path=tmp_path / "plants")
+    data_file.write_text(json.dumps({"name": "second"}))
+    second = load_plant_profile("demo", base_path=tmp_path / "plants")
+    assert first.profile_data["general"]["name"] == "first"
+    assert second.profile_data["general"]["name"] == "first"
+
+    clear_profile_cache()
+    third = load_plant_profile("demo", base_path=tmp_path / "plants")
+    assert third.profile_data["general"]["name"] == "second"


### PR DESCRIPTION
## Summary
- add `dataset_info.py` script for dataset discovery
- cache results from `load_plant_profile`
- expose `clear_profile_cache` helper
- test the new CLI and caching behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a72339948330801660a68b5f56ed