### PR TITLE
Improve dataset catalog performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ or incomplete and should only be used as a starting point for your own research.
   readings or nutrient multipliers when profiles omit them.
 - **Dataset Cache**: Call `plant_engine.utils.clear_dataset_cache()` after
   adjusting dataset environment variables to refresh cached lookups.
+  Use `plant_engine.datasets.refresh_datasets()` to clear both the dataset
+  catalog and dataset caches when files change.
 - **Flexible Temperature Inputs**: `normalize_environment_readings` accepts
   Fahrenheit or Kelvin temperature keys and converts them to Celsius
   automatically.

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -128,8 +128,14 @@ class DatasetCatalog:
                 return candidate
         return None
 
+    @lru_cache(maxsize=None)
     def load(self, name: str) -> object | None:
-        """Return parsed JSON contents of ``name`` or ``None`` if missing."""
+        """Return parsed JSON contents of ``name`` or ``None`` if missing.
+
+        Results are cached to avoid repeated disk reads. Call
+        :meth:`refresh` to clear the cache when underlying files may have
+        changed.
+        """
 
         path = self.find_path(name)
         if not path:
@@ -144,6 +150,7 @@ class DatasetCatalog:
         self._load_catalog.cache_clear()
         self.list_info.cache_clear()
         self.list_by_category.cache_clear()
+        self.load.cache_clear()
 
 
 DEFAULT_CATALOG = DatasetCatalog()

--- a/tests/test_dataset_refresh.py
+++ b/tests/test_dataset_refresh.py
@@ -16,13 +16,16 @@ def test_refresh_datasets_reload(tmp_path, monkeypatch):
     importlib.reload(datasets)
 
     assert utils.load_dataset("sample.json") == {"a": 1}
+    assert datasets.load_dataset_file("sample.json") == {"a": 1}
 
     file.write_text(json.dumps({"a": 2}))
 
     # Cached result should still return original value
     assert utils.load_dataset("sample.json") == {"a": 1}
+    assert datasets.load_dataset_file("sample.json") == {"a": 1}
 
     datasets.refresh_datasets()
 
     # After refresh we should get the updated value
     assert utils.load_dataset("sample.json") == {"a": 2}
+    assert datasets.load_dataset_file("sample.json") == {"a": 2}


### PR DESCRIPTION
## Summary
- cache `DatasetCatalog.load` to avoid repeated disk IO
- clear new cache inside `DatasetCatalog.refresh`
- document refresh helper in README
- test dataset refresh clears catalog cache

## Testing
- `pytest tests/test_dataset_refresh.py::test_refresh_datasets_reload -q`
- `pytest tests/test_dataset_catalog.py -q`
- `pytest -k dataset -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a715946083308afa3eb8c53d02f6