### PR TITLE
Refactor unit conversions into shared helper

### DIFF
--- a/custom_components/horticulture_assistant/utils/product_cost_analyzer.py
+++ b/custom_components/horticulture_assistant/utils/product_cost_analyzer.py
@@ -2,20 +2,26 @@
 
 from typing import Dict, List, Literal
 
+try:
+    from .unit_utils import UNIT_CONVERSIONS, to_base
+except ImportError:  # pragma: no cover - fallback for direct execution
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "unit_utils",
+        Path(__file__).resolve().parent / "unit_utils.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    UNIT_CONVERSIONS = mod.UNIT_CONVERSIONS  # type: ignore
+    to_base = mod.to_base  # type: ignore
+
 __all__ = [
     "ProductCostAnalyzer",
 ]
 
 
-# Conversion factors to liters or kilograms
-UNIT_CONVERSIONS = {
-    "L": 1.0,
-    "mL": 1.0 / 1000,
-    "gal": 3.78541,
-    "kg": 1.0,
-    "g": 1.0 / 1000,
-    "oz": 0.0283495,
-}
 
 
 class ProductCostAnalyzer:
@@ -32,7 +38,7 @@ class ProductCostAnalyzer:
         if unit not in UNIT_CONVERSIONS:
             raise ValueError(f"Unsupported unit: {unit}")
 
-        size_in_standard = size * UNIT_CONVERSIONS[unit]
+        size_in_standard = to_base(size, unit)
         if size_in_standard <= 0:
             raise ValueError("Size must be greater than zero")
 
@@ -76,5 +82,5 @@ class ProductCostAnalyzer:
         if dose_unit not in UNIT_CONVERSIONS:
             raise ValueError(f"Unsupported dose unit: {dose_unit}")
 
-        dose_in_standard = dose_amount * UNIT_CONVERSIONS[dose_unit]
+        dose_in_standard = to_base(dose_amount, dose_unit)
         return round(cost_per_unit * dose_in_standard, 4)

--- a/custom_components/horticulture_assistant/utils/unit_utils.py
+++ b/custom_components/horticulture_assistant/utils/unit_utils.py
@@ -1,0 +1,42 @@
+"""Shared unit conversion helpers for Horticulture Assistant."""
+
+from __future__ import annotations
+
+UNIT_CONVERSIONS = {
+    "kg": 1.0,
+    "g": 0.001,
+    "lb": 0.453592,
+    "oz": 0.0283495,
+    "L": 1.0,
+    "mL": 0.001,
+    "gal": 3.78541,
+    "fl_oz": 0.0295735,
+}
+
+PAIR_CONVERSIONS = {
+    ("oz", "g"): 28.3495,
+    ("g", "oz"): 1 / 28.3495,
+    ("mL", "L"): 0.001,
+    ("L", "mL"): 1000,
+    ("gal", "L"): 3.78541,
+    ("L", "gal"): 1 / 3.78541,
+}
+
+
+def to_base(value: float, unit: str) -> float:
+    """Return ``value`` converted to kilograms or liters."""
+    if unit not in UNIT_CONVERSIONS:
+        raise ValueError(f"Unsupported unit: {unit}")
+    return value * UNIT_CONVERSIONS[unit]
+
+
+def convert(value: float, from_unit: str, to_unit: str) -> float:
+    """Convert ``value`` between supported units."""
+    if from_unit == to_unit:
+        return value
+    key = (from_unit, to_unit)
+    if key in PAIR_CONVERSIONS:
+        return value * PAIR_CONVERSIONS[key]
+    if from_unit in UNIT_CONVERSIONS and to_unit in UNIT_CONVERSIONS:
+        return value * UNIT_CONVERSIONS[from_unit] / UNIT_CONVERSIONS[to_unit]
+    raise ValueError(f"Unsupported conversion: {from_unit} -> {to_unit}")


### PR DESCRIPTION
## Summary
- centralize unit conversions in `unit_utils`
- refactor dose, fertilizer and product cost analyzers to use common helpers
- keep standalone module execution support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a71fc94c8330b9264d3526053e77