### PR TITLE
Add configurable profile directories

### DIFF
--- a/custom_components/horticulture_assistant/utils/load_all_profiles.py
+++ b/custom_components/horticulture_assistant/utils/load_all_profiles.py
@@ -5,6 +5,7 @@ import logging
 import os
 from dataclasses import dataclass, asdict
 from pathlib import Path
+from plant_engine.utils import get_plants_dir
 
 from custom_components.horticulture_assistant.utils.validate_profile_structure import (
     validate_profile_structure,
@@ -46,7 +47,7 @@ def load_all_profiles(
     :param pattern: Glob pattern of files to load from each plant directory.
     :return: Mapping of plant_id to :class:`ProfileLoadResult` objects.
     """
-    base_dir = Path(base_path) if base_path else Path(os.getcwd()) / "plants"
+    base_dir = Path(base_path) if base_path else get_plants_dir()
     profiles: dict[str, ProfileLoadResult] = {}
     if not base_dir.is_dir():
         _LOGGER.error("Base directory for plant profiles not found: %s", base_dir)

--- a/custom_components/horticulture_assistant/utils/load_plant_profile.py
+++ b/custom_components/horticulture_assistant/utils/load_plant_profile.py
@@ -10,6 +10,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from plant_engine.utils import get_plants_dir
 from typing import Any, Dict
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,7 +66,7 @@ def load_plant_profile(
     :return: A dictionary containing the plant_id and loaded profile_data sections, or an empty dict on error.
     """
     # Determine the base directory and plant profile directory
-    base_dir = Path(base_path) if base_path else Path("plants")
+    base_dir = Path(base_path) if base_path else get_plants_dir()
     plant_dir = base_dir / str(plant_id)
 
     # Ensure the plant directory exists

--- a/custom_components/horticulture_assistant/utils/plant_profile_loader.py
+++ b/custom_components/horticulture_assistant/utils/plant_profile_loader.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 from functools import lru_cache
+from plant_engine.utils import get_plants_dir
 
 # Attempt to import PyYAML for optional YAML support. Tests fall back to a very
 # small parser that understands the limited subset of YAML used in fixtures.
@@ -17,7 +18,7 @@ except ImportError:
 _LOGGER = logging.getLogger(__name__)
 
 # Default directory containing individual plant profiles
-DEFAULT_BASE_DIR = Path("plants")
+DEFAULT_BASE_DIR = get_plants_dir()
 
 REQUIRED_THRESHOLD_KEYS = {"light", "temperature", "EC"}
 REQUIRED_STAGE_KEY = "stage_duration"

--- a/custom_components/horticulture_assistant/utils/profile_generator.py
+++ b/custom_components/horticulture_assistant/utils/profile_generator.py
@@ -3,6 +3,7 @@ import re
 import json
 import logging
 from pathlib import Path
+from plant_engine.utils import get_plants_dir
 
 try:
     from homeassistant.core import HomeAssistant
@@ -65,9 +66,9 @@ def generate_profile(metadata: dict, hass: 'HomeAssistant' = None, overwrite: bo
             base_path = Path(hass.config.path("plants"))
         except Exception as e:
             _LOGGER.error("Error resolving Home Assistant plants directory: %s", e)
-            base_path = Path("plants")
+            base_path = get_plants_dir()
     else:
-        base_path = Path("plants")
+        base_path = get_plants_dir()
 
     plant_dir = base_path / plant_id
     try:

--- a/custom_components/horticulture_assistant/utils/profile_helpers.py
+++ b/custom_components/horticulture_assistant/utils/profile_helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Mapping, Any
 
 from .json_io import save_json
+from plant_engine.utils import get_plants_dir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ def write_profile_sections(
         The ``plant_id`` on success or an empty string if a failure
         prevented writing any files.
     """
-    base_dir = Path(base_path) if base_path else Path("plants")
+    base_dir = Path(base_path) if base_path else get_plants_dir()
     plant_dir = base_dir / plant_id
     try:
         plant_dir.mkdir(parents=True, exist_ok=True)

--- a/custom_components/horticulture_assistant/utils/profile_index_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_index_writer.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 from pathlib import Path
+from plant_engine.utils import get_plants_dir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ def generate_profile_index(plant_id: str, base_path: str = None, overwrite: bool
     if base_path:
         base_dir = Path(base_path)
     else:
-        base_dir = Path("plants")
+        base_dir = get_plants_dir()
     plant_dir = base_dir / str(plant_id)
 
     # Ensure the plant directory exists

--- a/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
@@ -6,6 +6,7 @@ except ImportError:  # pragma: no cover - outside Home Assistant
     HomeAssistant = None
 
 from .profile_helpers import write_profile_sections
+from plant_engine.utils import get_plants_dir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,9 +25,9 @@ def initialize_nutrient_logs(
             base_path = Path(hass.config.path("plants"))
         except Exception as err:  # pragma: no cover - path resolution failure
             _LOGGER.error("Error resolving Home Assistant plants directory: %s", err)
-            base_path = Path("plants")
+            base_path = get_plants_dir()
     else:
-        base_path = Path("plants")
+        base_path = get_plants_dir()
     sections = {
         "nutrient_application_log.json": [],
         "fertilizer_cost_tracking.json": [],

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -4,7 +4,7 @@ from typing import Dict, Mapping, Any
 
 from functools import lru_cache
 
-from plant_engine.utils import save_json
+from plant_engine.utils import save_json, get_plants_dir, get_reports_dir
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_profile_by_id,
 )
@@ -34,8 +34,8 @@ from plant_engine.growth_stage import get_stage_info
 from plant_engine.report import DailyReport
 from plant_engine.constants import get_stage_multiplier, DEFAULT_ENV
 
-PLANTS_DIR = "plants"
-OUTPUT_DIR = "data/reports"
+PLANTS_DIR = str(get_plants_dir())
+OUTPUT_DIR = str(get_reports_dir())
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -22,6 +22,8 @@ __all__ = [
     "parse_range",
     "deep_update",
     "stage_value",
+    "get_plants_dir",
+    "get_reports_dir",
 ]
 
 
@@ -77,6 +79,14 @@ def deep_update(base: Dict[str, Any], other: Mapping[str, Any]) -> Dict[str, Any
 DEFAULT_DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 OVERLAY_ENV = "HORTICULTURE_OVERLAY_DIR"
 EXTRA_ENV = "HORTICULTURE_EXTRA_DATA_DIRS"
+
+# Paths for plant profiles and generated reports. These can be overridden with
+# the environment variables ``HORTICULTURE_PLANTS_DIR`` and
+# ``HORTICULTURE_REPORTS_DIR`` respectively.
+DEFAULT_PLANTS_DIR = Path(__file__).resolve().parents[1] / "plants"
+DEFAULT_REPORTS_DIR = Path(__file__).resolve().parents[1] / "data" / "reports"
+PLANTS_ENV = "HORTICULTURE_PLANTS_DIR"
+REPORTS_ENV = "HORTICULTURE_REPORTS_DIR"
 
 
 def get_data_dir() -> Path:
@@ -188,3 +198,15 @@ def stage_value(
         if value is not None:
             return value
     return plant.get(default_key)
+
+
+def get_plants_dir() -> Path:
+    """Return base directory for plant profiles."""
+    env = os.getenv(PLANTS_ENV)
+    return Path(env).expanduser() if env else DEFAULT_PLANTS_DIR
+
+
+def get_reports_dir() -> Path:
+    """Return directory for generated reports."""
+    env = os.getenv(REPORTS_ENV)
+    return Path(env).expanduser() if env else DEFAULT_REPORTS_DIR

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,8 @@ from plant_engine.utils import (
     normalize_key,
     clear_dataset_cache,
     stage_value,
+    get_plants_dir,
+    get_reports_dir,
 )
 
 
@@ -75,3 +77,21 @@ def test_stage_value_fallback():
 def test_stage_value_custom_default():
     data = {"crop": {"phase": 1, "default": 2}}
     assert stage_value(data, "crop", "missing", default_key="default") == 2
+
+
+def test_get_plants_dir_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HORTICULTURE_PLANTS_DIR", str(tmp_path))
+    import importlib
+    import plant_engine.utils as reload_utils
+    importlib.reload(reload_utils)
+    assert reload_utils.get_plants_dir() == tmp_path
+    monkeypatch.delenv("HORTICULTURE_PLANTS_DIR", raising=False)
+
+
+def test_get_reports_dir_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HORTICULTURE_REPORTS_DIR", str(tmp_path))
+    import importlib
+    import plant_engine.utils as reload_utils
+    importlib.reload(reload_utils)
+    assert reload_utils.get_reports_dir() == tmp_path
+    monkeypatch.delenv("HORTICULTURE_REPORTS_DIR", raising=False)


### PR DESCRIPTION
## Summary
- centralize plant and report directories via new `get_plants_dir` and `get_reports_dir` helpers
- update profile utilities to use the helpers
- respect environment variables when loading profiles or writing reports
- test the new helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a716d5108330a57d0ab2bbaf5cd6