### PR TITLE
Refactor dataclasses for efficiency

### DIFF
--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -41,7 +41,7 @@ from plant_engine.stage_tasks import get_stage_tasks
 from plant_engine import water_quality
 
 
-@dataclass
+@dataclass(slots=True)
 class DailyReport:
     """Structured daily report data."""
 

--- a/custom_components/horticulture_assistant/utils/ai_inference_engine.py
+++ b/custom_components/horticulture_assistant/utils/ai_inference_engine.py
@@ -7,14 +7,14 @@ examines daily plant data and emits simple suggestions.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Any, Dict, List, Mapping, Optional
 
 import datetime as _dt
 import json
 
 
-@dataclass
+@dataclass(slots=True)
 class InferenceResult:
     """Result of :class:`AIInferenceEngine.analyze`."""
 
@@ -25,7 +25,7 @@ class InferenceResult:
     notes: Optional[str] = None
 
 
-@dataclass
+@dataclass(slots=True)
 class DailyPackage:
     """Container for daily inference inputs."""
 
@@ -140,7 +140,7 @@ class AIInferenceEngine:
     def export_results(self) -> str:
         """Return the stored inference results as a JSON string."""
 
-        return json.dumps([r.__dict__ for r in self.history], indent=2)
+        return json.dumps([asdict(r) for r in self.history], indent=2)
 
     def reset_history(self) -> None:
         """Clear stored inference results."""

--- a/custom_components/horticulture_assistant/utils/cost_analyzer.py
+++ b/custom_components/horticulture_assistant/utils/cost_analyzer.py
@@ -7,7 +7,7 @@ from datetime import datetime
 __all__ = ["ProductPriceEntry", "CostAnalyzer"]
 
 
-@dataclass
+@dataclass(slots=True)
 class ProductPriceEntry:
     product_id: str
     distributor: str
@@ -19,7 +19,7 @@ class ProductPriceEntry:
     expiration_date: Optional[datetime] = None
 
 
-@dataclass
+@dataclass(slots=True)
 class CostAnalyzer:
     prices: Dict[str, List[ProductPriceEntry]] = field(default_factory=dict)
 

--- a/custom_components/horticulture_assistant/utils/daily_report_builder.py
+++ b/custom_components/horticulture_assistant/utils/daily_report_builder.py
@@ -22,7 +22,7 @@ from plant_engine import environment_manager
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class DailyReport:
     """Lightweight representation of a daily plant report."""
 

--- a/custom_components/horticulture_assistant/utils/delivery_tracker.py
+++ b/custom_components/horticulture_assistant/utils/delivery_tracker.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 import datetime
 
-@dataclass
+@dataclass(slots=True)
 class BatchDelivery:
     batch_id: str
     delivery_id: str
@@ -13,6 +13,6 @@ class BatchDelivery:
     dilution_factor: Optional[float] = None
     notes: Optional[str] = None
 
-@dataclass
+@dataclass(slots=True)
 class DeliveryLog:
     deliveries: List[BatchDelivery] = field(default_factory=list)

--- a/custom_components/horticulture_assistant/utils/inventory_tracker.py
+++ b/custom_components/horticulture_assistant/utils/inventory_tracker.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 import uuid
 
-@dataclass
+@dataclass(slots=True)
 class InventoryLot:
     """A single lot (batch) of a fertilizer or nutrient product."""
     product_name: str

--- a/custom_components/horticulture_assistant/utils/nutrient_tracker.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_tracker.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, List, Iterable
 from datetime import datetime, timedelta
 from collections import defaultdict
 
-@dataclass
+@dataclass(slots=True)
 class NutrientEntry:
     """Mapping of an element to its concentration in a product."""
 
@@ -13,7 +13,7 @@ class NutrientEntry:
     value_mg_per_kg: float
     source_compound: Optional[str] = None
 
-@dataclass
+@dataclass(slots=True)
 class ProductNutrientProfile:
     """Profile describing nutrient concentrations for a product."""
 
@@ -35,7 +35,7 @@ class ProductNutrientProfile:
             ppm_map[nutrient.element] = round(ppm, 4)
         return ppm_map
 
-@dataclass
+@dataclass(slots=True)
 class NutrientDeliveryRecord:
     """Record describing a single nutrient application."""
 
@@ -45,7 +45,7 @@ class NutrientDeliveryRecord:
     ppm_delivered: Dict[str, float]
     volume_l: float
 
-@dataclass
+@dataclass(slots=True)
 class NutrientTracker:
     """Track nutrient deliveries and summarize totals."""
 

--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -52,7 +52,7 @@ _RAIN_EFFICIENCY_FILE = "rain_capture_efficiency.json"
 _RAIN_EFFICIENCY_DATA: Dict[str, float] = load_dataset(_RAIN_EFFICIENCY_FILE)
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True, frozen=True)
 class IrrigationRecommendation:
     """Recommended irrigation volume with ET metrics."""
 

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -236,7 +236,7 @@ def classify_pest_severity(
     return severity
 
 
-@dataclass
+@dataclass(slots=True)
 class PestReport:
     """Consolidated pest monitoring report."""
 

--- a/plant_engine/report.py
+++ b/plant_engine/report.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 __all__ = ["DailyReport"]
 
-@dataclass
+@dataclass(slots=True)
 class DailyReport:
     """Container for daily plant processing results."""
 

--- a/plant_engine/yield_manager.py
+++ b/plant_engine/yield_manager.py
@@ -16,7 +16,7 @@ from .utils import load_json, save_json
 YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 
 
-@dataclass
+@dataclass(slots=True)
 class HarvestRecord:
     """Single harvest entry."""
 


### PR DESCRIPTION
## Summary
- use `slots=True` for many dataclasses to reduce memory
- update ai inference engine export to use `asdict`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a704a9f8833097d10ef31f3389ad