### PR TITLE
Refactor script bootstrap helpers

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,14 @@
+from __future__ import annotations
 
+"""Helper utilities for command line scripts."""
+
+from pathlib import Path
+import sys
+
+
+def ensure_repo_root_on_path() -> Path:
+    """Add repository root to ``sys.path`` and return the path."""
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    return root

--- a/scripts/dataset_info.py
+++ b/scripts/dataset_info.py
@@ -9,8 +9,10 @@ import sys
 
 # Ensure project root is on the Python path when executed directly
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
 
 from plant_engine.datasets import (
     list_datasets,

--- a/scripts/wsda_search.py
+++ b/scripts/wsda_search.py
@@ -12,8 +12,10 @@ import sys
 
 # Ensure project root is on the Python path when executed directly
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
 
 from plant_engine.wsda_lookup import (
     search_products,


### PR DESCRIPTION
## Summary
- add `ensure_repo_root_on_path` helper for command line scripts
- use helper in dataset and WSDA search CLI tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a9c89990833086f2ec18803a4dc2