### PR TITLE
Add unified CLI for helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,17 +406,25 @@ Select the corresponding sensors and plant profile when prompted. Ensure each se
 Development is private for now. Feedback is welcome, but pull requests will open once the repository becomes public. Please open discussions or issues for questions or suggestions.
 
 ## Command Line Utilities
-This repository ships with a few helper scripts in the `scripts/` directory. The
-`generate_plant_sensors.py` utility converts daily JSON reports into Home
-Assistant template sensor YAML. It can process a single plant or every report in
-the directory. Example usage:
+This repository ships with a collection of helper scripts located in the
+`scripts/` directory.  They can now be invoked through a single entry point,
+which keeps the command line interface organized:
+
+```bash
+python -m scripts <command> [args]
+```
+
+Here `<command>` corresponds to the script name without the `.py` extension.
+For example, the `generate_plant_sensors` utility converts daily JSON reports
+into Home Assistant template sensor YAML. It can process a single plant or every
+report in the directory. Example usage:
 
 ```bash
 # single plant
-python scripts/generate_plant_sensors.py <plant_id>
+python -m scripts generate_plant_sensors <plant_id>
 
 # generate for all reports
-python scripts/generate_plant_sensors.py --all
+python -m scripts generate_plant_sensors --all
 ```
 The generated YAML is written to `templates/generated/` for easy import.
 
@@ -424,8 +432,8 @@ The generated YAML is written to `templates/generated/` for easy import.
 database from the command line:
 
 ```bash
-python scripts/wsda_search.py "EARTH-CARE" --limit 5
-python scripts/wsda_search.py "(#4083-0001)" --number
+python -m scripts wsda_search "EARTH-CARE" --limit 5
+python -m scripts wsda_search "(#4083-0001)" --number
 ```
 Use `--number` to look up a product by its WSDA product number.
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,0 +1,46 @@
+"""Unified command line interface for scripts.
+
+Usage::
+
+    python -m scripts <command> [args]
+
+The available commands correspond to modules in the ``scripts`` package
+that contain a ``main`` entrypoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pkgutil
+import runpy
+import sys
+from pathlib import Path
+from typing import Dict
+
+
+def _discover_commands() -> Dict[str, str]:
+    """Return mapping of command names to module paths."""
+    package_dir = Path(__file__).resolve().parent
+    commands: Dict[str, str] = {}
+    for mod in pkgutil.iter_modules([str(package_dir)]):
+        if mod.ispkg or mod.name in {"cli", "__init__"}:
+            continue
+        commands[mod.name.replace("_", "-")] = f"scripts.{mod.name}"
+    return commands
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run a script subcommand."""
+    commands = _discover_commands()
+    parser = argparse.ArgumentParser(description="Horticulture Assistant utilities")
+    parser.add_argument("command", choices=sorted(commands))
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    ns = parser.parse_args(argv)
+
+    module_name = commands[ns.command]
+    sys.argv = [module_name] + ns.args
+    runpy.run_module(module_name, run_name="__main__", alter_sys=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/cli.py` for a consolidated command line interface
- document new usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a9c3cf688330aa78d085ecb6a1f5