### PR TITLE
Reduce JSON handling duplication

### DIFF
--- a/custom_components/horticulture_assistant/automation/actuator_utils.py
+++ b/custom_components/horticulture_assistant/automation/actuator_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
+
+from ..utils.json_io import load_json
 
 try:
     from homeassistant.core import HomeAssistant
@@ -27,8 +28,7 @@ def trigger_actuator(
         return
 
     try:
-        with open(profile_file, "r", encoding="utf-8") as f:
-            profile_data = json.load(f)
+        profile_data = load_json(str(profile_file))
     except Exception as e:  # pragma: no cover - unlikely to happen in tests
         _LOGGER.error("Error reading plant profile file %s: %s", profile_file, e)
         return

--- a/custom_components/horticulture_assistant/automation/helpers.py
+++ b/custom_components/horticulture_assistant/automation/helpers.py
@@ -1,9 +1,10 @@
 """Utility helpers for automation scripts."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Dict, Iterable, Tuple
+
+from ..utils.json_io import load_json, save_json
 
 
 def iter_profiles(base_path: str) -> Iterable[Tuple[str, Dict]]:
@@ -13,8 +14,7 @@ def iter_profiles(base_path: str) -> Iterable[Tuple[str, Dict]]:
         return
     for file in path.glob("*.json"):
         try:
-            with open(file, "r", encoding="utf-8") as f:
-                data = json.load(f)
+            data = load_json(str(file))
             plant_id = data.get("plant_id") or file.stem
             yield plant_id, data
         except Exception:
@@ -27,13 +27,11 @@ def append_json_log(log_path: Path, entry: Dict) -> None:
     log_entries = []
     if log_path.is_file():
         try:
-            with open(log_path, "r", encoding="utf-8") as f:
-                val = json.load(f)
+            val = load_json(str(log_path))
             if isinstance(val, list):
                 log_entries = val
-        except json.JSONDecodeError:
+        except Exception:
             pass
     log_entries.append(entry)
-    with open(log_path, "w", encoding="utf-8") as f:
-        json.dump(log_entries, f, indent=2)
+    save_json(str(log_path), log_entries)
 

--- a/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
+++ b/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
@@ -1,7 +1,8 @@
-import json
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from ..utils.json_io import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,8 +28,7 @@ def export_grafana_data(plant_id: str, base_path: str = "plants", output_path: s
     # Load plant profile JSON
     profile = {}
     try:
-        with open(profile_path, 'r', encoding='utf-8') as f:
-            profile = json.load(f) or {}
+        profile = load_json(str(profile_path)) or {}
     except FileNotFoundError:
         _LOGGER.error("Plant profile not found: %s", profile_path)
     except Exception as e:
@@ -54,8 +54,7 @@ def export_grafana_data(plant_id: str, base_path: str = "plants", output_path: s
     # Helper to load JSON log files safely
     def _load_log(path: Path):
         try:
-            with open(path, 'r', encoding='utf-8') as f:
-                return json.load(f) or []
+            return load_json(str(path)) or []
         except FileNotFoundError:
             _LOGGER.info("Log file not found: %s", path)
             return []
@@ -147,8 +146,7 @@ def export_grafana_data(plant_id: str, base_path: str = "plants", output_path: s
     # Write the resulting data to a JSON file
     output_file = output_dir / f"{plant_id}_grafana.json"
     try:
-        with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(data, f, indent=2)
+        save_json(str(output_file), data)
         _LOGGER.info("Grafana export saved for plant %s at %s", plant_id, output_file)
     except Exception as e:
         _LOGGER.error("Failed to write Grafana export for plant %s: %s", plant_id, e)

--- a/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
+++ b/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
@@ -4,6 +4,8 @@ import json
 import logging
 from datetime import datetime
 
+from ..utils.json_io import load_json, save_json
+
 _LOGGER = logging.getLogger(__name__)
 
 def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
@@ -13,12 +15,11 @@ def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
     """
     # Read the daily report JSON
     try:
-        with open(report_path, 'r', encoding='utf-8') as f:
-            report = json.load(f)
+        report = load_json(report_path)
     except FileNotFoundError:
         _LOGGER.error("Report file not found: %s", report_path)
         return
-    except json.JSONDecodeError as e:
+    except Exception as e:
         _LOGGER.error("Failed to parse JSON report for plant %s: %s", plant_id, e)
         return
     
@@ -170,8 +171,7 @@ def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
     filename = f"{plant_id}_{date_str}.json"
     file_path = os.path.join(base_dir, filename)
     try:
-        with open(file_path, "w", encoding="utf-8") as f:
-            json.dump(record, f, indent=2)
+        save_json(file_path, record)
     except Exception as e:
         _LOGGER.error("Failed to save pending thresholds for plant %s: %s", plant_id, e)
         return

--- a/custom_components/horticulture_assistant/engine/report_packager.py
+++ b/custom_components/horticulture_assistant/engine/report_packager.py
@@ -4,16 +4,17 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from statistics import mean
 
-from custom_components.horticulture_assistant.utils.plant_profile_loader import \
-    load_plant_profile
+from custom_components.horticulture_assistant.utils.plant_profile_loader import (
+    load_plant_profile,
+)
+from ..utils.json_io import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def _load_log(log_path):
     try:
-        with open(log_path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        return load_json(str(log_path))
     except Exception as e:
         _LOGGER.warning("Failed to read %s: %s", log_path, e)
         return []
@@ -106,8 +107,7 @@ def build_daily_report(
         Path(output_path) / f"{plant_id}_{datetime.now(timezone.utc).date()}.json"
     )
     try:
-        with open(out_file, "w", encoding="utf-8") as f:
-            json.dump(report, f, indent=2)
+        save_json(str(out_file), report)
         _LOGGER.info("Saved daily report for %s to %s", plant_id, out_file)
     except Exception as e:
         _LOGGER.error("Failed to write report for %s: %s", plant_id, e)


### PR DESCRIPTION
## Summary
- centralize JSON I/O through `json_io` helpers
- refactor helper, actuator, grafana exporter, AI context, threshold queue and report packager to use shared functions
- maintain behaviour while improving reliability and consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a9bebd4c83308bba7d070cb2e118