### PR TITLE
Consolidate growth model implementation

### DIFF
--- a/custom_components/horticulture_assistant/utils/growth_model.py
+++ b/custom_components/horticulture_assistant/utils/growth_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import logging
@@ -58,7 +60,12 @@ def calculate_eta(et0: float, kc: float = 1.0) -> float:
     """
     return max(et0 * kc, 0.0)
 
-def update_growth_index(hass: HomeAssistant, plant_id: str, env_data: dict, transpiration_ml: float = None) -> dict:
+def update_growth_index(
+    hass: HomeAssistant | None,
+    plant_id: str,
+    env_data: dict,
+    transpiration_ml: float | None = None,
+) -> dict:
     """
     Update the daily vegetative growth index (VGI) for a given plant.
 
@@ -72,7 +79,8 @@ def update_growth_index(hass: HomeAssistant, plant_id: str, env_data: dict, tran
     profile = {}
     try:
         from custom_components.horticulture_assistant.utils.plant_profile_loader import load_profile
-        profile = load_profile(plant_id=plant_id, base_dir=hass.config.path("plants"))
+        base_dir = hass.config.path("plants") if hass else "plants"
+        profile = load_profile(plant_id=plant_id, base_dir=base_dir)
     except Exception as e:
         _LOGGER.error("Could not load profile for plant %s: %s", plant_id, e)
         profile = {}
@@ -230,7 +238,7 @@ def update_growth_index(hass: HomeAssistant, plant_id: str, env_data: dict, tran
     vgi_today = round(base_vgi_today * growth_factor, 2)
 
     # Prepare to save growth trend data
-    data_dir = hass.config.path("data")
+    data_dir = hass.config.path("data") if hass else "data"
     os.makedirs(data_dir, exist_ok=True)
     trends_path = os.path.join(data_dir, "growth_trends.json")
 

--- a/plant_engine/growth_model.py
+++ b/plant_engine/growth_model.py
@@ -1,52 +1,21 @@
-"""Simple vegetation growth index calculator."""
+"""Wrapper for advanced growth index logic."""
 from __future__ import annotations
 
-import json
-import os
-from datetime import datetime
-from typing import Dict, Mapping
+from typing import Mapping, Dict
 
+from custom_components.horticulture_assistant.utils.growth_model import (
+    update_growth_index as _advanced_update,
+)
+
+# Compatibility constants preserved for tests
 GROWTH_DIR = "data/growth"
 YIELD_DIR = "data/yield"
 
-def update_growth_index(plant_id: str, env_data: Mapping, transpiration_ml: float) -> Dict:
-    """
-    Update the daily vegetative growth index (VGI) using ETa, PAR, and temp.
-    Returns updated VGI stats for the plant.
-    """
 
-    date_str = datetime.now().strftime("%Y-%m-%d")
-    gdd = max(0, ((env_data["temp_c_max"] + env_data["temp_c_min"]) / 2) - 10)
-    par_w = env_data.get("par_w_m2", env_data.get("par", 0))
-    par_mj = par_w * 0.0864  # Convert to MJ/m²/day
-    eta_factor = transpiration_ml / 1000  # Normalize to liters
-
-    vgi_today = round(gdd * par_mj * eta_factor, 2)
-
-    os.makedirs(GROWTH_DIR, exist_ok=True)
-    path = os.path.join(GROWTH_DIR, f"{plant_id}.json")
-
-    if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as f:
-            growth_data = json.load(f)
-    else:
-        growth_data = {}
-
-    growth_data[date_str] = {
-        "vgi": vgi_today,
-        "gdd": gdd,
-        "par": par_mj,
-        "et_liters": eta_factor
-    }
-
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(growth_data, f, indent=2)
-
-    cumulative_vgi = round(sum(day["vgi"] for day in growth_data.values()), 2)
-
-    return {
-        "plant_id": plant_id,
-        "vgi_today": vgi_today,
-        "vgi_total": cumulative_vgi,
-        "days_tracked": len(growth_data)
-    }
+def update_growth_index(
+    plant_id: str,
+    env_data: Mapping,
+    transpiration_ml: float,
+) -> Dict:
+    """Return vegetative growth index using the shared util implementation."""
+    return _advanced_update(None, plant_id, dict(env_data), transpiration_ml)


### PR DESCRIPTION
## Summary
- allow `hass` parameter to be optional in advanced `growth_model.update_growth_index`
- reuse the advanced growth logic from `plant_engine`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a9bb453c8330aa91552d4fca06df