### PR TITLE
Enhance dataset key normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ Key reference datasets reside in the `data/` directory:
   Use `plant_engine.datasets.list_datasets()` to list available files and
   `get_dataset_description()` to read these summaries programmatically.
 
-All dataset lookups are case-insensitive and ignore spaces thanks to the
-`normalize_key` helper, so references such as `"Citrus"` and `"citrus"` map to
-the same entries.
+All dataset lookups are case-insensitive and ignore spaces or hyphens thanks to
+the `normalize_key` helper, so references such as `"Citrus"`, `"citrus"` and
+`"citrus-tree"` map to the same entries.
 
 You can override the default `data/` directory by setting the environment
 variable `HORTICULTURE_DATA_DIR` when running scripts or tests. An additional

--- a/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from custom_components.horticulture_assistant.utils.plant_profile_loader import load_profile
 from plant_engine.nutrient_manager import get_recommended_levels
-from plant_engine.utils import load_json, save_json, load_dataset
+from plant_engine.utils import load_json, save_json, load_dataset, normalize_key
 from plant_engine.constants import get_stage_multiplier
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,11 +33,6 @@ STAGE_SYNONYMS = {
     "fruiting": "fruiting",
 }
 
-# Normalize tags to lowercase with underscores for dataset lookups.
-def _normalize_tag(tag: str) -> str:
-    return str(tag).lower().replace(" ", "_").replace("-", "_")
-
-
 # Tag-specific nutrient modifiers loaded from a dataset.  Users can extend
 # or override this mapping by providing ``nutrient_tag_modifiers.json`` in
 # the dataset overlay directory.
@@ -49,7 +44,7 @@ def _tag_modifiers() -> dict[str, dict[str, float]]:
     raw = load_dataset(TAG_MODIFIER_FILE)
     modifiers: dict[str, dict[str, float]] = {}
     for tag, data in raw.items():
-        norm_tag = _normalize_tag(tag)
+        norm_tag = normalize_key(tag)
         if not isinstance(data, dict):
             continue
         mods: dict[str, float] = {}
@@ -132,7 +127,7 @@ def _apply_tag_modifiers(targets: dict[str, float], tags: list[str]) -> None:
 
     modifiers = _tag_modifiers()
     for tag in tags:
-        mods = modifiers.get(_normalize_tag(tag))
+        mods = modifiers.get(normalize_key(tag))
         if not mods:
             continue
         for nut, factor in mods.items():

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -23,7 +23,20 @@ clear_dataset_cache()
 _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 _RATIO_DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(RATIO_DATA_FILE)
 _WEIGHTS: Dict[str, float] = load_dataset(WEIGHT_DATA_FILE)
-_TAG_MODIFIERS: Dict[str, Dict[str, float]] = load_dataset(TAG_MODIFIER_FILE)
+_RAW_TAG_MODIFIERS = load_dataset(TAG_MODIFIER_FILE)
+_TAG_MODIFIERS: Dict[str, Dict[str, float]] = {}
+for _tag, _mods in _RAW_TAG_MODIFIERS.items():
+    if not isinstance(_mods, dict):
+        continue
+    norm = normalize_key(_tag)
+    parsed: Dict[str, float] = {}
+    for _nut, _factor in _mods.items():
+        try:
+            parsed[_nut] = float(_factor)
+        except (TypeError, ValueError):
+            continue
+    if parsed:
+        _TAG_MODIFIERS[norm] = parsed
 
 __all__ = [
     "list_supported_plants",

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -169,7 +169,8 @@ def clear_dataset_cache() -> None:
 
 def normalize_key(key: str) -> str:
     """Return ``key`` normalized for case-insensitive dataset lookups."""
-    return str(key).lower().replace(" ", "_")
+
+    return str(key).lower().replace(" ", "_").replace("-", "_")
 
 
 def list_dataset_entries(dataset: Mapping[str, Any]) -> list[str]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,10 @@ def test_normalize_key_spaces_replaced():
     assert normalize_key("My Plant") == "my_plant"
 
 
+def test_normalize_key_hyphen_replaced():
+    assert normalize_key("high-nitrogen") == "high_nitrogen"
+
+
 def test_normalize_key_non_string():
     assert normalize_key(123) == "123"
 


### PR DESCRIPTION
## Summary
- support hyphen normalization in `normalize_key`
- simplify `nutrient_scheduler` tag helpers to use `normalize_key`
- normalize tag modifier dataset keys in `nutrient_manager`
- document hyphen handling and test it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a9bcf93c8330beb8f0b0faa41383