### PR TITLE
Add pending directory helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ or incomplete and should only be used as a starting point for your own research.
   adjusting dataset environment variables to refresh cached lookups.
   Use `plant_engine.datasets.refresh_datasets()` to clear both the dataset
   catalog and dataset caches when files change.
+- **Pending Approvals Directory**: Set `HORTICULTURE_PENDING_DIR` to store
+  threshold changes in a custom location.
 - **Flexible Temperature Inputs**: `normalize_environment_readings` accepts
   Fahrenheit or Kelvin temperature keys and converts them to Celsius
   automatically.

--- a/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
+++ b/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
@@ -3,6 +3,9 @@ import os
 import json
 import logging
 from datetime import datetime
+from pathlib import Path
+
+from plant_engine import approval_queue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,8 +160,8 @@ def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
         "changes": changes
     }
     
-    # Write record to data/pending_thresholds/{plant_id}_{YYYY-MM-DD}.json
-    base_dir = os.path.join("data", "pending_thresholds")
+    # Write record to the pending thresholds directory
+    base_dir = approval_queue.get_pending_dir()
     os.makedirs(base_dir, exist_ok=True)
     date_str = datetime.now().date().isoformat()
     ts = report.get("timestamp")
@@ -168,7 +171,7 @@ def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
         except Exception:
             pass
     filename = f"{plant_id}_{date_str}.json"
-    file_path = os.path.join(base_dir, filename)
+    file_path = Path(base_dir) / filename
     try:
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(record, f, indent=2)

--- a/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
+++ b/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
@@ -2,6 +2,9 @@ import os
 import json
 import logging
 import re
+from pathlib import Path
+
+from plant_engine import approval_queue
 try:
     from homeassistant.core import HomeAssistant
 except ImportError:
@@ -17,7 +20,7 @@ def approve_threshold_queue(hass: "HomeAssistant" = None) -> None:
     """
     base_data_dir = hass.config.path("data") if hass else "data"
     base_plants_dir = hass.config.path("plants") if hass else "plants"
-    pending_dir = os.path.join(base_data_dir, "pending_thresholds")
+    pending_dir = approval_queue.get_pending_dir(base_data_dir)
     # Pattern for pending threshold files: {plant_id}_YYYY-MM-DD.json
     file_pattern = re.compile(r"^.+_\d{4}-\d{2}-\d{2}\.json$")
     if not os.path.isdir(pending_dir):
@@ -34,7 +37,7 @@ def approve_threshold_queue(hass: "HomeAssistant" = None) -> None:
     total_rejected = 0
     total_skipped = 0
     for filename in files:
-        file_path = os.path.join(pending_dir, filename)
+        file_path = Path(pending_dir) / filename
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)

--- a/custom_components/horticulture_assistant/engine/push_to_approval_queue.py
+++ b/custom_components/horticulture_assistant/engine/push_to_approval_queue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from plant_engine.approval_queue import queue_threshold_updates
+from plant_engine.approval_queue import queue_threshold_updates, get_pending_dir
 from plant_engine.utils import load_json
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def push_to_approval_queue(
         return {}
 
     old = profile.get("thresholds", {})
-    pending_dir = base / "data" / "pending_thresholds"
+    pending_dir = get_pending_dir(base)
     pending_file = queue_threshold_updates(
         plant_id, old, proposed_thresholds, pending_dir
     )

--- a/scripts/review_thresholds.py
+++ b/scripts/review_thresholds.py
@@ -1,18 +1,18 @@
 import os
-from approval_queue import apply_approved_thresholds
+from plant_engine.approval_queue import apply_approved_thresholds, get_pending_dir
 from plant_engine.utils import load_json, save_json
 
-PENDING_DIR = "data/pending_thresholds"
 PLANT_DIR = "plants"
 
 def review_pending_thresholds():
     print("🔍 Scanning for pending threshold files...\n")
 
-    for fname in os.listdir(PENDING_DIR):
+    pending_dir = get_pending_dir()
+    for fname in os.listdir(pending_dir):
         if not fname.endswith(".json"):
             continue
 
-        full_path = os.path.join(PENDING_DIR, fname)
+        full_path = os.path.join(pending_dir, fname)
         pending = load_json(full_path)
         plant_id = pending["plant_id"]
         changes = pending["changes"]


### PR DESCRIPTION
## Summary
- centralize pending threshold path handling with `get_pending_dir`
- use new helper in engine modules and scripts
- document `HORTICULTURE_PENDING_DIR` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a93a1c148330b2b37ee7bbc465c4