### PR TITLE
Improve numeric state parsing

### DIFF
--- a/custom_components/horticulture_assistant/utils/state_helpers.py
+++ b/custom_components/horticulture_assistant/utils/state_helpers.py
@@ -10,6 +10,11 @@ _LOGGER = logging.getLogger(__name__)
 
 __all__ = ["get_numeric_state"]
 
+# Pre-compiled pattern used to extract a numeric portion from a string. This
+# avoids recompiling the regex for every state lookup and handles optional
+# sign and decimal point.
+_NUM_RE = re.compile(r"[-+]?[0-9]*\.?[0-9]+")
+
 def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
     """Return the numeric state of ``entity_id`` or ``None`` if unavailable.
 
@@ -24,11 +29,11 @@ def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
         _LOGGER.debug("State unavailable: %s", entity_id)
         return None
 
-    value = state.state
+    value = str(state.state).replace(",", "").strip()
     try:
         return float(value)
     except (ValueError, TypeError):
-        match = re.search(r"[-+]?[0-9]*\.?[0-9]+", str(value))
+        match = _NUM_RE.search(value)
         if match:
             try:
                 return float(match.group(0))

--- a/tests/test_state_helpers.py
+++ b/tests/test_state_helpers.py
@@ -1,4 +1,12 @@
 import types
+import sys
+
+# Provide minimal 'homeassistant.core' stub so the helper module imports cleanly
+ha = types.ModuleType("homeassistant")
+ha.core = types.ModuleType("homeassistant.core")
+ha.core.HomeAssistant = object
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.core", ha.core)
 
 from custom_components.horticulture_assistant.utils.state_helpers import get_numeric_state
 
@@ -24,6 +32,12 @@ def test_get_numeric_state_with_units():
     hass = DummyHass()
     hass.states._data["sensor.temp"] = "21.5 °C"
     assert get_numeric_state(hass, "sensor.temp") == 21.5
+
+
+def test_get_numeric_state_commas_and_spaces():
+    hass = DummyHass()
+    hass.states._data["sensor.comma"] = "1,234.5 ppm"
+    assert get_numeric_state(hass, "sensor.comma") == 1234.5
 
 
 def test_get_numeric_state_invalid():


### PR DESCRIPTION
## Summary
- more robust numeric parsing in `get_numeric_state`
- add regression test for commas in state strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b0740bd883308baa4e1763bf001d