### PR TITLE
Improve pending threshold path handling

### DIFF
--- a/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
+++ b/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 
 from ..utils.json_io import load_json, save_json
+from plant_engine.utils import get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,7 +160,7 @@ def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
     }
     
     # Write record to data/pending_thresholds/{plant_id}_{YYYY-MM-DD}.json
-    base_dir = os.path.join("data", "pending_thresholds")
+    base_dir = get_pending_dir()
     os.makedirs(base_dir, exist_ok=True)
     date_str = datetime.now().date().isoformat()
     ts = report.get("timestamp")
@@ -169,7 +170,7 @@ def analyze_ai_recommendations(plant_id: str, report_path: str) -> None:
         except Exception:
             pass
     filename = f"{plant_id}_{date_str}.json"
-    file_path = os.path.join(base_dir, filename)
+    file_path = os.path.join(str(base_dir), filename)
     try:
         save_json(file_path, record)
     except Exception as e:

--- a/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
+++ b/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
@@ -8,6 +8,7 @@ except ImportError:
     HomeAssistant = None  # if Home Assistant not available, ignore for standalone use
 
 from ..utils.json_io import load_json, save_json
+from plant_engine.utils import get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def approve_threshold_queue(hass: "HomeAssistant" = None) -> None:
     """
     base_data_dir = hass.config.path("data") if hass else "data"
     base_plants_dir = hass.config.path("plants") if hass else "plants"
-    pending_dir = os.path.join(base_data_dir, "pending_thresholds")
+    pending_dir = str(get_pending_dir(base_data_dir))
     # Pattern for pending threshold files: {plant_id}_YYYY-MM-DD.json
     file_pattern = re.compile(r"^.+_\d{4}-\d{2}-\d{2}\.json$")
     if not os.path.isdir(pending_dir):

--- a/custom_components/horticulture_assistant/engine/push_to_approval_queue.py
+++ b/custom_components/horticulture_assistant/engine/push_to_approval_queue.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 
 from plant_engine.approval_queue import queue_threshold_updates
-from plant_engine.utils import load_json
+from plant_engine.utils import load_json, get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def push_to_approval_queue(
         return {}
 
     old = profile.get("thresholds", {})
-    pending_dir = base / "data" / "pending_thresholds"
+    pending_dir = get_pending_dir(base / "data")
     pending_file = queue_threshold_updates(
         plant_id, old, proposed_thresholds, pending_dir
     )

--- a/plant_engine/approval_queue.py
+++ b/plant_engine/approval_queue.py
@@ -8,11 +8,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Mapping
 
-from .utils import load_json, save_json
+from .utils import load_json, save_json, get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)
 
-PENDING_DIR = Path("data/pending_thresholds")
+PENDING_DIR = get_pending_dir()
 
 __all__ = [
     "queue_threshold_updates",

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "clear_dataset_cache",
     "dataset_paths",
     "get_data_dir",
+    "get_pending_dir",
     "get_extra_dirs",
     "get_overlay_dir",
     "normalize_key",
@@ -82,12 +83,22 @@ EXTRA_ENV = "HORTICULTURE_EXTRA_DATA_DIRS"
 _PATH_CACHE: tuple[Path, ...] | None = None
 _ENV_STATE: tuple[str | None, str | None] | None = None
 
+# Directory name for pending threshold changes relative to the data dir
+PENDING_THRESHOLD_DIRNAME = "pending_thresholds"
+
 
 def get_data_dir() -> Path:
     """Return base dataset directory honoring the ``HORTICULTURE_DATA_DIR`` env."""
 
     env = os.getenv("HORTICULTURE_DATA_DIR")
     return Path(env).expanduser() if env else DEFAULT_DATA_DIR
+
+
+def get_pending_dir(base: str | Path | None = None) -> Path:
+    """Return directory used for pending threshold changes."""
+
+    base_dir = Path(base).expanduser() if base else get_data_dir()
+    return base_dir / PENDING_THRESHOLD_DIRNAME
 
 
 def get_overlay_dir() -> Path | None:
@@ -190,7 +201,7 @@ def parse_range(value: Iterable[float]) -> tuple[float, float] | None:
     try:
         low, high = value
         return float(low), float(high)
-    except (TypeError, ValueError, Exception):
+    except (TypeError, ValueError):
         return None
 
 

--- a/scripts/review_thresholds.py
+++ b/scripts/review_thresholds.py
@@ -1,8 +1,8 @@
 import os
 from approval_queue import apply_approved_thresholds
-from plant_engine.utils import load_json, save_json
+from plant_engine.utils import load_json, save_json, get_pending_dir
 
-PENDING_DIR = "data/pending_thresholds"
+PENDING_DIR = str(get_pending_dir())
 PLANT_DIR = "plants"
 
 def review_pending_thresholds():


### PR DESCRIPTION
## Summary
- add `get_pending_dir` helper in `utils`
- simplify `parse_range` error handling
- use `get_pending_dir` throughout approval queue helpers and scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b0688f888330b2b2ae39e4c54a81