### PR TITLE
Add multi-step config flow with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ The bundled datasets are not exhaustive and may contain inaccuracies. Always cro
 ## Quick Start
 1. Go to **Settings → Devices & Services** in Home Assistant.
 2. Choose **Add Integration** and search for **Horticulture Assistant**.
-3. Follow the prompts to link sensors and select or create plant profiles.
-4. Copy `blueprints/automation/plant_monitoring.yaml` into `<config>/blueprints/automation/>` and create an automation from it.
-5. Enable `input_boolean.auto_approve_all` if you want AI recommendations applied automatically.
-6. Ensure all numeric sensors use `state_class: measurement` so statistics are recorded.
+3. Enter a name and zone for your plant.
+4. Optionally fill in details like plant type and cultivar.
+5. Select any sensors you want linked to the profile.
+6. Copy `blueprints/automation/plant_monitoring.yaml` into `<config>/blueprints/automation/>` and create an automation from it.
+7. Enable `input_boolean.auto_approve_all` if you want AI recommendations applied automatically.
+8. Ensure all numeric sensors use `state_class: measurement` so statistics are recorded.
 
 Plant profiles are stored in the `plants/` directory and can be created through the config flow or edited manually.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,67 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/config_flow.py"
+PACKAGE = "custom_components.horticulture_assistant"
+if PACKAGE not in sys.modules:
+    pkg = types.ModuleType(PACKAGE)
+    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    sys.modules[PACKAGE] = pkg
+CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
+const_mod = importlib.util.module_from_spec(const_spec)
+sys.modules[const_spec.name] = const_mod
+const_spec.loader.exec_module(const_mod)
+
+spec = importlib.util.spec_from_file_location(f"{PACKAGE}.config_flow", MODULE_PATH)
+config_flow = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = config_flow
+
+# Minimal Home Assistant stubs
+ha = sys.modules.get("homeassistant", types.ModuleType("homeassistant"))
+ha.config_entries = sys.modules.get("homeassistant.config_entries", types.ModuleType("homeassistant.config_entries"))
+class ConfigFlowBase:
+    def __init_subclass__(cls, **kwargs):
+        pass
+    def async_show_form(self, **kwargs):
+        return {"type": "form", **kwargs}
+    def async_create_entry(self, **kwargs):
+        self.created_entry = kwargs
+        return {"type": "create_entry", **kwargs}
+ha.config_entries.ConfigFlow = getattr(ha.config_entries, "ConfigFlow", ConfigFlowBase)
+ha.data_entry_flow = sys.modules.get("homeassistant.data_entry_flow", types.ModuleType("homeassistant.data_entry_flow"))
+ha.data_entry_flow.FlowResult = getattr(ha.data_entry_flow, "FlowResult", dict)
+ha.helpers = sys.modules.get("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
+ha.helpers.selector = sys.modules.get("homeassistant.helpers.selector", types.ModuleType("homeassistant.helpers.selector"))
+ha.helpers.selector.BooleanSelector = object
+ha.helpers.selector.TextSelector = object
+sys.modules["homeassistant"] = ha
+sys.modules["homeassistant.config_entries"] = ha.config_entries
+sys.modules["homeassistant.data_entry_flow"] = ha.data_entry_flow
+sys.modules["homeassistant.helpers"] = ha.helpers
+sys.modules["homeassistant.helpers.selector"] = ha.helpers.selector
+
+spec.loader.exec_module(config_flow)
+
+Flow = config_flow.HorticultureAssistantConfigFlow
+
+
+def test_full_flow(monkeypatch):
+    recorded = {}
+    def fake_generate(data, hass=None):
+        recorded.update(data)
+        return data.get("plant_name")
+    monkeypatch.setattr(config_flow, "generate_profile", fake_generate)
+
+    flow = Flow()
+    result = asyncio.run(flow.async_step_user({"plant_name": "Tomato", "zone_id": "9"}))
+    assert result["step_id"] == "details"
+    result = asyncio.run(flow.async_step_details({"plant_type": "tomato"}))
+    assert result["step_id"] == "sensors"
+    result = asyncio.run(flow.async_step_sensors({"moisture_sensor": "sensor.moist"}))
+    assert result["type"] == "create_entry"
+    assert flow.created_entry["data"]["plant_name"] == "Tomato"
+    assert recorded["plant_name"] == "Tomato"


### PR DESCRIPTION
## Summary
- extend config flow with optional details and sensors steps
- save collected data and generate a plant profile
- document new setup process in the README
- test the new config flow behaviour

## Testing
- `pytest tests/test_config_flow.py -q`
- `pytest -q` *(fails: wsda_lookup related tests cannot find dataset)*

------
https://chatgpt.com/codex/tasks/task_e_6883c3738e488330be9103a9241bf629