### PR TITLE
Add update_sensors service with profile writer helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ If multiple entity IDs are provided, their values are averaged. When more than
 two sensors are listed, the median of the available readings is used instead to
 reduce the effect of outliers.
 
+You can update the sensor mapping later using the ``horticulture_assistant.update_sensors`` service:
+
+```yaml
+service: horticulture_assistant.update_sensors
+data:
+  plant_id: citrus_backyard_spring2025
+  sensors:
+    moisture_sensors:
+      - sensor.new_moisture
+    temperature_sensors:
+      - sensor.new_temp
+      - sensor.backup_temp
+```
+
 ### Plant Registry
 Multiple profiles can be indexed in `plant_registry.json` so automations can discover them easily. Example:
 ```json

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -71,3 +71,29 @@ def test_list_available_profiles(tmp_path):
 
     result = loader.list_available_profiles(plants)
     assert result == ["one", "two"]
+
+
+def test_save_and_update_sensors(tmp_path):
+    plants = tmp_path / "plants"
+    plants.mkdir()
+    profile = {"general": {"sensor_entities": {"moisture_sensors": ["old"]}}}
+    assert loader.save_profile_by_id("p1", profile, plants)
+
+    loader.update_profile_sensors(
+        "p1",
+        {"moisture_sensors": ["new"], "temperature_sensors": "temp1"},
+        plants,
+    )
+
+    updated = json.load(open(plants / "p1.json", "r", encoding="utf-8"))
+    sensors = updated["general"]["sensor_entities"]
+    assert sensors["moisture_sensors"] == ["new"]
+    assert sensors["temperature_sensors"] == ["temp1"]
+
+
+def test_update_profile_sensors_missing(tmp_path):
+    plants = tmp_path / "plants"
+    plants.mkdir()
+
+    result = loader.update_profile_sensors("missing", {"moisture_sensors": ["x"]}, plants)
+    assert result is False

--- a/tests/test_update_sensors_service.py
+++ b/tests/test_update_sensors_service.py
@@ -1,0 +1,44 @@
+import json
+import asyncio
+from pathlib import Path
+from custom_components.horticulture_assistant.__init__ import update_sensors_service
+
+class DummyConfig:
+    def __init__(self, base: Path):
+        self._base = base
+    def path(self, name: str) -> str:
+        return str(self._base / name)
+
+class DummyHass:
+    def __init__(self, base: Path):
+        self.config = DummyConfig(base)
+
+
+class DummyCall:
+    def __init__(self, **data):
+        self.data = data
+
+
+def test_update_service(tmp_path: Path):
+    plants = tmp_path / "plants"
+    plants.mkdir()
+    profile = {"sensor_entities": {"moisture_sensors": ["old"]}}
+    (plants / "p1.json").write_text(json.dumps(profile))
+
+    hass = DummyHass(tmp_path)
+    call = DummyCall(plant_id="p1", sensors={"moisture_sensors": ["new"]})
+
+    asyncio.run(update_sensors_service(hass, call))
+
+    updated = json.load(open(plants / "p1.json", "r", encoding="utf-8"))
+    sensors = updated.get("general", {}).get("sensor_entities", {})
+    assert sensors["moisture_sensors"] == ["new"]
+
+
+def test_update_service_invalid_data(tmp_path: Path):
+    hass = DummyHass(tmp_path)
+    call = DummyCall()
+
+    # Should not raise even though data is missing
+    asyncio.run(update_sensors_service(hass, call))
+


### PR DESCRIPTION
## Summary
- add `update_sensors` service implementation
- write profile saving helpers to plant_profile_loader
- document new service usage in README
- test new helpers and service
- improve sensor update helpers

## Testing
- `pytest tests/test_profile_loader.py tests/test_update_sensors_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6883dff01bec833093e7ec438fdad3b9