### PR TITLE
Improve garden summary card

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Horticulture Assistant integrates per-plant automation and crop monitoring into 
 - [Reference Data](#reference-data)
 - [Command Line Utilities](#command-line-utilities)
 - [Advanced Usage](#advanced-usage)
+- [Garden Summary Lovelace Card](#garden-summary-lovelace-card)
 - [Repository Structure](#repository-structure)
 - [Troubleshooting](#troubleshooting)
 - [Running Tests](#running-tests)
@@ -209,6 +210,58 @@ python -m custom_components.horticulture_assistant.analytics.export_all_growth_y
 - `recommend_nutrient_mix` computes fertilizer grams needed to hit N/P/K targets and can include micronutrients. `recommend_nutrient_mix_with_cost` returns the same schedule with estimated cost.
 - `get_pruning_instructions` provides stage-specific pruning tips from `pruning_guidelines.json`.
 - `generate_cycle_irrigation_plan` returns stage irrigation volumes using guideline intervals and durations.
+
+### Garden Summary Lovelace Card
+Add `garden-summary-card.js` as a Lovelace resource (HACS places it under
+`/hacsfiles/horticulture_assistant/dashboard/`) to quickly see the status of all
+plants and highlight any requiring attention.
+
+```yaml
+resources:
+  - url: /hacsfiles/horticulture_assistant/dashboard/garden-summary-card.js
+    type: module
+```
+
+Example card configuration:
+
+```yaml
+type: custom:garden-summary-card
+title: Garden Overview
+# optional card-wide thresholds
+depletion_threshold: 80
+bad_quality_state: poor
+plants:
+  - id: citrus_backyard_spring2025
+    name: Backyard Citrus
+    moisture_entity: sensor.citrus_moisture
+    quality_entity: sensor.citrus_env_quality
+    depletion_entity: sensor.citrus_depletion
+    # plant-specific overrides
+    depletion_threshold: 75
+    bad_quality_state: critical
+  - id: basil_kitchen_2025
+    name: Kitchen Basil
+    # uses default sensor names
+```
+
+The Priority column displays a check or alert icon. Plants with a root zone
+depletion above 80% or an environment quality rated `poor` show the alert
+icon. The card reads the following
+sensors for each `plant_id`:
+
+- `sensor.<plant_id>_smoothed_moisture`
+- `sensor.<plant_id>_env_quality`
+- `sensor.<plant_id>_depletion`
+
+Sensors can be overridden per plant using `moisture_entity`, `quality_entity`
+and `depletion_entity` keys. When omitted, the default entity IDs above are
+assumed. Each plant entry may also override `depletion_threshold` and
+`bad_quality_state` to fine tune the warning criteria.
+
+Two optional card-level settings control the priority criteria:
+
+- `depletion_threshold` &ndash; numeric percentage for the depletion warning (default `80`)
+- `bad_quality_state` &ndash; environment quality state that triggers a warning (default `poor`)
 
 ---
 

--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -18,7 +18,7 @@ try:
     from homeassistant.core import HomeAssistant, ServiceCall
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.typing import ConfigType
-except ModuleNotFoundError:  # pragma: no cover
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
     # Allow running tests without Home Assistant installed
     HomeAssistant = object  # type: ignore
     ServiceCall = object  # type: ignore

--- a/custom_components/horticulture_assistant/dashboard/garden-summary-card.js
+++ b/custom_components/horticulture_assistant/dashboard/garden-summary-card.js
@@ -1,0 +1,127 @@
+// Home Assistant already bundles the `lit` library so we can import it directly
+// without relying on an external CDN.
+import { LitElement, html, css } from "lit";
+
+/**
+ * Garden Summary Card
+ * Displays key sensor values for a list of plants and highlights
+ * any that require attention. An alert icon appears when the
+ * root zone is depleted above the configured threshold or the
+ * environment quality is rated "poor". Plant objects can override
+ * the default sensor names with `moisture_entity`, `quality_entity`,
+ * and `depletion_entity` keys.
+ */
+class GardenSummaryCard extends LitElement {
+  static properties = {
+    hass: {},
+    _config: {},
+  };
+
+  static styles = css`
+    table {
+      width: 100%;
+      border-spacing: 0;
+    }
+    th,
+    td {
+      padding: 4px;
+      text-align: left;
+    }
+    th {
+      font-weight: bold;
+    }
+    tr.priority-high td {
+      color: var(--error-color);
+      font-weight: bold;
+    }
+    ha-icon {
+      --mdc-icon-size: 20px;
+    }
+  `;
+
+  setConfig(config) {
+    if (!Array.isArray(config.plants)) {
+      throw new Error("plants array required");
+    }
+    this._config = {
+      depletion_threshold: 80,
+      bad_quality_state: "poor",
+      ...config,
+    };
+  }
+
+  createRenderRoot() {
+    // Render into the main DOM so HA themes and fonts apply
+    return this;
+  }
+
+  getCardSize() {
+    return 3;
+  }
+
+  render() {
+    if (!this.hass || !this._config) {
+      return html``;
+    }
+
+    const rows = this._config.plants.map((p) => {
+      const id = p.id;
+      const name = p.name || id;
+      const moisture =
+        this.hass.states[p.moisture_entity || `sensor.${id}_smoothed_moisture`];
+      const quality =
+        this.hass.states[p.quality_entity || `sensor.${id}_env_quality`];
+      const depletion =
+        this.hass.states[p.depletion_entity || `sensor.${id}_depletion`];
+      const moistVal = moisture ? moisture.state : "n/a";
+      const qualVal = quality ? quality.state : "n/a";
+      const depleteVal = depletion ? depletion.state : "n/a";
+      const threshold =
+        p.depletion_threshold ?? this._config.depletion_threshold;
+      const badQuality = String(
+        p.bad_quality_state ?? this._config.bad_quality_state
+      ).toLowerCase();
+      const depletionPct = depletion ? parseFloat(depletion.state) : NaN;
+      const isHighPriority =
+        (!Number.isNaN(depletionPct) && depletionPct > threshold) ||
+        (quality && String(quality.state).toLowerCase() === badQuality);
+      const icon = isHighPriority ? "mdi:alert-circle" : "mdi:check-circle";
+      const rowClass = isHighPriority ? "priority-high" : "";
+
+      return html`
+        <tr class=${rowClass}>
+          <td>${name}</td>
+          <td>${moistVal}</td>
+          <td>${qualVal}</td>
+          <td>${depleteVal}</td>
+          <td>
+            <ha-icon icon="${icon}" title="${isHighPriority ? "Attention" : "OK"}"></ha-icon>
+          </td>
+        </tr>`;
+    });
+
+    return html`
+      <ha-card header=${this._config.title || "Garden Summary"}>
+        <table class="plants">
+          <thead>
+            <tr>
+              <th>Plant</th>
+              <th>Moisture</th>
+              <th>Env Quality</th>
+              <th>Depletion</th>
+              <th>Priority</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>
+      </ha-card>
+    `;
+  }
+}
+
+if (!customElements.get("garden-summary-card")) {
+  customElements.define("garden-summary-card", GardenSummaryCard);
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pyyaml>=6.0
+pandas>=2.3
+voluptuous>=0.15


### PR DESCRIPTION
## Summary
- refine `garden-summary-card.js` to parse depletion values and add icon titles
- document the custom Lovelace card with configuration examples
- install missing dependencies for tests and relax the Home Assistant import fallback

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e4c9b8308330bf232c1f4a7d53b8