### PR TITLE
Centralize config path handling

### DIFF
--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -28,6 +28,7 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
 
 from .const import DOMAIN, PLATFORMS
 from .utils.plant_profile_loader import update_profile_sensors
+from .utils.path_utils import plants_path
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ async def update_sensors_service(hass: HomeAssistant, call: ServiceCall) -> None
         _LOGGER.error("update_sensors called with invalid data")
         return
 
-    base_dir = hass.config.path("plants")
+    base_dir = plants_path(hass)
     # Run potentially blocking disk IO in a thread to avoid slowing the event loop
     result = await asyncio.to_thread(
         update_profile_sensors, plant_id, sensors, base_dir

--- a/custom_components/horticulture_assistant/analytics/growth_yield_exporter.py
+++ b/custom_components/horticulture_assistant/analytics/growth_yield_exporter.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from plant_engine.utils import load_json, save_json
+from custom_components.horticulture_assistant.utils.path_utils import data_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ def export_growth_yield(plant_id: str, base_path: str = "plants", output_path: s
     
     # Load growth trend data (if available)
     growth_by_date = {}
-    growth_trends_file = Path("data") / "growth_trends.json"
+    growth_trends_file = Path(data_path(None, "growth_trends.json"))
     if growth_trends_file.is_file():
         growth_trends = load_json(growth_trends_file, default={})
         if isinstance(growth_trends, dict) and plant_id in growth_trends:

--- a/custom_components/horticulture_assistant/automation/fertilizer_trigger.py
+++ b/custom_components/horticulture_assistant/automation/fertilizer_trigger.py
@@ -2,18 +2,25 @@ import json
 import logging
 from pathlib import Path
 
+from custom_components.horticulture_assistant.utils.path_utils import plants_path
+
 _LOGGER = logging.getLogger(__name__)
 
-def fertilizer_trigger(plant_id: str, base_path: str = "plants", sensor_data: dict = None) -> bool:
+def fertilizer_trigger(
+    plant_id: str, base_path: str | None = None, sensor_data: dict | None = None
+) -> bool:
     """
     Determine whether to trigger fertilization for a given plant based on nutrient levels and thresholds.
     Args:
         plant_id: Identifier of the plant profile.
-        base_path: Base directory path where plant profiles are stored (defaults to "plants").
+        base_path: Base directory path where plant profiles are stored. Defaults
+            to the configured ``plants`` directory.
         sensor_data: Dictionary of current sensor readings (keys like 'EC', 'leaf_nitrogen', etc).
     Returns:
         True if fertilization should be triggered, False otherwise.
     """
+    if base_path is None:
+        base_path = plants_path(None)
     if sensor_data is None:
         sensor_data = {}
     # Load plant profile from JSON file

--- a/custom_components/horticulture_assistant/automation/irrigation_trigger.py
+++ b/custom_components/horticulture_assistant/automation/irrigation_trigger.py
@@ -2,18 +2,25 @@ import json
 import logging
 from pathlib import Path
 
+from custom_components.horticulture_assistant.utils.path_utils import plants_path
+
 _LOGGER = logging.getLogger(__name__)
 
-def irrigation_trigger(plant_id: str, base_path: str = "plants", sensor_data: dict = None) -> bool:
+def irrigation_trigger(
+    plant_id: str, base_path: str | None = None, sensor_data: dict | None = None
+) -> bool:
     """
     Determine whether to trigger irrigation for a given plant based on soil moisture.
     Args:
         plant_id: Identifier of the plant profile.
-        base_path: Base directory path where plant profiles are stored (defaults to "plants").
+        base_path: Base directory path where plant profiles are stored. Defaults
+            to the configured ``plants`` directory.
         sensor_data: Dictionary of current sensor readings (keys like 'soil_moisture', 'EC', 'temp', etc).
     Returns:
         True if irrigation should be triggered, False otherwise.
     """
+    if base_path is None:
+        base_path = plants_path(None)
     if sensor_data is None:
         sensor_data = {}
     # Load plant profile from JSON file

--- a/custom_components/horticulture_assistant/automation/run_automation_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_automation_cycle.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from dataclasses import dataclass
 from datetime import datetime
 
+from custom_components.horticulture_assistant.utils.path_utils import plants_path
+
 from .helpers import iter_profiles, append_json_log
 
 # Global override: disable automation if False
@@ -70,17 +72,21 @@ class MoistureInfo:
     current: float
     threshold: float
 
-def run_automation_cycle(base_path: str = "plants") -> None:
+def run_automation_cycle(base_path: str | None = None) -> None:
     """
     Run one cycle of automated irrigation checks for all plant profiles.
-    Scans the plants directory for profile JSON files, checks soil moisture against thresholds,
-    and triggers irrigation actuators if needed.
+    Scans the plants directory for profile JSON files, checks soil moisture
+    against thresholds, and triggers irrigation actuators if needed.
+
+    ``base_path`` defaults to the configured ``plants`` directory.
     """
     # Global override check
     if not ENABLE_AUTOMATION:
         _LOGGER.info("Automation is globally disabled (ENABLE_AUTOMATION=False). Skipping automation cycle.")
         return
 
+    if base_path is None:
+        base_path = plants_path(None)
     plants_dir = Path(base_path)
     if not plants_dir.is_dir():
         _LOGGER.error("Plants directory not found: %s", plants_dir)

--- a/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from datetime import datetime
 
+from custom_components.horticulture_assistant.utils.path_utils import plants_path
+
 from .helpers import iter_profiles, append_json_log
 
 # Global override: disable automation if False
@@ -9,17 +11,21 @@ ENABLE_AUTOMATION = False
 
 _LOGGER = logging.getLogger(__name__)
 
-def run_fertilizer_cycle(base_path: str = "plants") -> None:
+def run_fertilizer_cycle(base_path: str | None = None) -> None:
     """
     Run one cycle of automated fertilization checks for all plant profiles.
-    Scans the plants directory for profile JSON files, checks nutrient levels against thresholds,
-    and triggers fertilizer actuators if needed.
+    Scans the plants directory for profile JSON files, checks nutrient levels
+    against thresholds, and triggers fertilizer actuators if needed.
+
+    ``base_path`` defaults to the configured ``plants`` directory.
     """
     # Global override check
     if not ENABLE_AUTOMATION:
         _LOGGER.info("Automation is globally disabled (ENABLE_AUTOMATION=False). Skipping fertilization cycle.")
         return
 
+    if base_path is None:
+        base_path = plants_path(None)
     plants_dir = Path(base_path)
     if not plants_dir.is_dir():
         _LOGGER.error("Plants directory not found: %s", plants_dir)

--- a/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
+++ b/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
@@ -8,6 +8,7 @@ except ImportError:
     HomeAssistant = None  # if Home Assistant not available, ignore for standalone use
 
 from ..utils.json_io import load_json, save_json
+from ..utils.path_utils import data_path, plants_path
 from plant_engine.utils import get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,8 +19,8 @@ def approve_threshold_queue(hass: "HomeAssistant" = None) -> None:
     For each pending threshold change in data/pending_thresholds, prompt user (y/n/s) and update status.
     Approved changes are applied to the plant's profile (thresholds) and all actions are logged.
     """
-    base_data_dir = hass.config.path("data") if hass else "data"
-    base_plants_dir = hass.config.path("plants") if hass else "plants"
+    base_data_dir = data_path(hass)
+    base_plants_dir = plants_path(hass)
     pending_dir = str(get_pending_dir(base_data_dir))
     # Pattern for pending threshold files: {plant_id}_YYYY-MM-DD.json
     file_pattern = re.compile(r"^.+_\d{4}-\d{2}-\d{2}\.json$")

--- a/custom_components/horticulture_assistant/engine/load_ai_insight_context.py
+++ b/custom_components/horticulture_assistant/engine/load_ai_insight_context.py
@@ -1,11 +1,20 @@
 import logging
 from pathlib import Path
 
+from custom_components.horticulture_assistant.utils.path_utils import (
+    plants_path,
+    data_path,
+)
+
 from ..utils.json_io import load_json
 
 _LOGGER = logging.getLogger(__name__)
 
-def load_ai_insight_context(plant_id: str, base_path: str = "plants", analytics_path: str = "analytics"):
+def load_ai_insight_context(
+    plant_id: str,
+    base_path: str | None = None,
+    analytics_path: str | None = None,
+) -> dict:
     """
     Load recent plant data and compile context for AI insights.
     
@@ -16,7 +25,11 @@ def load_ai_insight_context(plant_id: str, base_path: str = "plants", analytics_
       - growth_trend: list of recent growth metric values (last 7 data points, most recent last)
       - yield_cumulative: latest cumulative yield value for the plant (float or int)
     
-    The plant profile is expected at `{base_path}/{plant_id}.json` and growth/yield data at `{analytics_path}/{plant_id}_growth_yield.json`.
+    The plant profile is expected at `{base_path}/{plant_id}.json` and
+    growth/yield data at `{analytics_path}/{plant_id}_growth_yield.json`.
+
+    ``base_path`` and ``analytics_path`` default to the configured ``plants``
+    and ``data/analytics`` directories, respectively.
     Returns:
       A dictionary with the keys listed above, for use in downstream AI evaluation.
     """
@@ -29,6 +42,11 @@ def load_ai_insight_context(plant_id: str, base_path: str = "plants", analytics_
         "yield_cumulative": 0.0
     }
     
+    if base_path is None:
+        base_path = plants_path(None)
+    if analytics_path is None:
+        analytics_path = data_path(None, "analytics")
+
     # Construct file paths
     profile_path = Path(base_path) / f"{plant_id}.json"
     analytics_file = Path(analytics_path) / f"{plant_id}_growth_yield.json"

--- a/custom_components/horticulture_assistant/engine/report_packager.py
+++ b/custom_components/horticulture_assistant/engine/report_packager.py
@@ -4,6 +4,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from statistics import mean
 
+from custom_components.horticulture_assistant.utils.path_utils import (
+    plants_path,
+    data_path,
+)
+
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_plant_profile,
 )
@@ -31,8 +36,20 @@ def _filter_last_24h(entries):
 
 
 def build_daily_report(
-    plant_id: str, base_path: str = "plants", output_path: str = "data/daily_reports"
+    plant_id: str,
+    base_path: str | None = None,
+    output_path: str | None = None,
 ) -> dict:
+    """Build and save a 24 hour summary report for ``plant_id``.
+
+    ``base_path`` and ``output_path`` default to the configured ``plants`` and
+    ``data/daily_reports`` directories, respectively.
+    """
+    if base_path is None:
+        base_path = plants_path(None)
+    if output_path is None:
+        output_path = data_path(None, "daily_reports")
+
     plant_dir = Path(base_path) / plant_id
     report = {
         "plant_id": plant_id,

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -14,6 +14,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from statistics import mean
 
+from custom_components.horticulture_assistant.utils.path_utils import (
+    plants_path,
+    data_path,
+)
+
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_profile_by_id,
 )
@@ -110,13 +115,23 @@ def _load_recent_entries(log_path: Path, hours: float = 24.0) -> list[dict]:
 
 
 def run_daily_cycle(
-    plant_id: str, base_path: str = "plants", output_path: str = "data/daily_reports"
+    plant_id: str,
+    base_path: str | None = None,
+    output_path: str | None = None,
 ) -> dict:
     """Return an aggregated 24h report for ``plant_id``.
 
     The report includes irrigation, nutrients, sensor averages, environment
     analysis and optional fertigation recommendations.
+
+    ``base_path`` and ``output_path`` default to the configured ``plants`` and
+    ``data/daily_reports`` directories, respectively.
     """
+
+    if base_path is None:
+        base_path = plants_path(None)
+    if output_path is None:
+        output_path = data_path(None, "daily_reports")
 
     plant_dir = Path(base_path) / plant_id
     report = DailyReport(plant_id)

--- a/custom_components/horticulture_assistant/utils/ai_feedback_handler.py
+++ b/custom_components/horticulture_assistant/utils/ai_feedback_handler.py
@@ -4,6 +4,10 @@ import logging
 from datetime import datetime
 
 from ..engine import ai_model
+from custom_components.horticulture_assistant.utils.path_utils import (
+    plants_path,
+    data_path,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +67,7 @@ def process_ai_feedback(plant_id: str, daily_report: dict) -> str:
         auto_approve = not daily_report.get("ai_feedback_required", True)
     else:
         # Fallback: check plant profile for an auto_approve flag
-        profile_path = os.path.join("plants", f"{plant_id}.json")
+        profile_path = plants_path(None, f"{plant_id}.json")
         if os.path.exists(profile_path):
             try:
                 with open(profile_path, "r", encoding="utf-8") as pf:
@@ -88,7 +92,7 @@ def process_ai_feedback(plant_id: str, daily_report: dict) -> str:
     # Apply or queue changes based on auto_approve
     if auto_approve:
         # Auto-approve: apply changes directly to the plant's profile
-        profile_path = os.path.join("plants", f"{plant_id}.json")
+        profile_path = plants_path(None, f"{plant_id}.json")
         if not os.path.exists(profile_path):
             _LOGGER.error("Plant profile not found at %s; cannot auto-apply thresholds", profile_path)
         else:
@@ -123,7 +127,7 @@ def process_ai_feedback(plant_id: str, daily_report: dict) -> str:
                 "changes": changes
             }
             # Load existing pending approvals
-            pending_path = os.path.join("data", "pending_approvals.json")
+            pending_path = data_path(None, "pending_approvals.json")
             try:
                 if os.path.exists(pending_path):
                     with open(pending_path, "r", encoding="utf-8") as pf:

--- a/custom_components/horticulture_assistant/utils/cec_model.py
+++ b/custom_components/horticulture_assistant/utils/cec_model.py
@@ -12,6 +12,7 @@ import logging
 from typing import Optional, Dict
 
 from . import media_inference  # use media_inference.infer_media_type for media-based CEC estimation
+from custom_components.horticulture_assistant.utils.path_utils import data_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ def log_measured_cec(plant_id: str, cec_value: float, include_warnings: bool = F
         # Include category label for reference
         result_data["category"] = category
     # Write to JSON records
-    output_path = os.path.join("data", "cec_records.json")
+    output_path = data_path(None, "cec_records.json")
     _write_cec_record(output_path, plant_id, result_data)
     _LOGGER.info("Logged measured CEC for plant %s: %.2f meq/100g", plant_id, cec_val)
     return result_data
@@ -135,7 +136,7 @@ def estimate_cec_from_media(plant_id: str, moisture_retention: float, ec_behavio
             result_data["warning"] = "High nutrient retention (CEC is high; monitor nutrient buildup)"
         result_data["category"] = category
     # Write to JSON records
-    output_path = os.path.join("data", "cec_records.json")
+    output_path = data_path(None, "cec_records.json")
     _write_cec_record(output_path, plant_id, result_data)
     _LOGGER.info("Estimated CEC for plant %s: %.2f meq/100g (media: %s, confidence: %.3f)", plant_id, estimated_cec, media_type, confidence)
     return result_data

--- a/custom_components/horticulture_assistant/utils/media_inference.py
+++ b/custom_components/horticulture_assistant/utils/media_inference.py
@@ -10,6 +10,8 @@ import json
 import logging
 from typing import Optional, Dict
 
+from custom_components.horticulture_assistant.utils.path_utils import data_path
+
 _LOGGER = logging.getLogger(__name__)
 
 # Define characteristic profiles for common media types.
@@ -83,7 +85,7 @@ def infer_media_type(moisture_retention: float, ec_behavior: float, dryback_rate
     result_data = {"media_type": best_match, "confidence": confidence}
 
     # Prepare to save result to file
-    output_path = os.path.join("data", "media_type_estimates.json")
+    output_path = data_path(None, "media_type_estimates.json")
     if plant_id:
         # Store results in a dictionary per plant
         try:

--- a/custom_components/horticulture_assistant/utils/nutrient_use_efficiency.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_use_efficiency.py
@@ -13,6 +13,8 @@ import logging
 from datetime import datetime, date
 from typing import Dict, List, Optional, Union
 
+from custom_components.horticulture_assistant.utils.path_utils import data_path, config_path
+
 try:
     from homeassistant.core import HomeAssistant
 except ImportError:
@@ -35,7 +37,7 @@ class NutrientUseEfficiency:
         """
         # Determine the data file path
         if data_file is None:
-            data_file = hass.config.path("data", "nutrient_use.json") if hass is not None else os.path.join("data", "nutrient_use.json")
+            data_file = data_path(hass, "nutrient_use.json")
         self._data_file = data_file
         self._hass = hass
         # Internal logs
@@ -77,9 +79,9 @@ class NutrientUseEfficiency:
             self.application_log[pid] = total_nutrients
         # Load existing yield totals from yield tracker logs if available
         try:
-            yield_file = hass.config.path("data", "yield_logs.json") if hass is not None else os.path.join("data", "yield_logs.json")
+            yield_file = data_path(hass, "yield_logs.json")
         except Exception:
-            yield_file = os.path.join("data", "yield_logs.json")
+            yield_file = data_path(None, "yield_logs.json")
         try:
             with open(yield_file, "r", encoding="utf-8") as yf:
                 yield_data = json.load(yf)
@@ -132,7 +134,7 @@ class NutrientUseEfficiency:
         stage_name = stage
         if stage_name is None:
             # Try to retrieve current stage from plant registry if available
-            reg_path = self._hass.config.path("plant_registry.json") if self._hass is not None else "plant_registry.json"
+            reg_path = config_path(self._hass, "plant_registry.json") if self._hass is not None else "plant_registry.json"
             try:
                 with open(reg_path, "r", encoding="utf-8") as rf:
                     reg_data = json.load(rf)

--- a/custom_components/horticulture_assistant/utils/plant_registry.py
+++ b/custom_components/horticulture_assistant/utils/plant_registry.py
@@ -12,6 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover - tests run without HA
     HomeAssistant = None  # type: ignore
 
 from .json_io import load_json
+from custom_components.horticulture_assistant.utils.path_utils import config_path
 
 PLANT_REGISTRY_FILE = "plant_registry.json"
 
@@ -27,7 +28,7 @@ def _load_registry(path: str) -> Dict[str, Any]:
 
 def get_plant_metadata(plant_id: str, hass: HomeAssistant | None = None) -> Dict[str, Any]:
     """Return metadata for ``plant_id`` from the plant registry."""
-    reg_path = hass.config.path(PLANT_REGISTRY_FILE) if hass else PLANT_REGISTRY_FILE
+    reg_path = config_path(hass, PLANT_REGISTRY_FILE)
     data = _load_registry(reg_path)
     return data.get(plant_id, {})
 

--- a/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
@@ -6,6 +6,7 @@ except ImportError:  # pragma: no cover - outside Home Assistant
     HomeAssistant = None
 
 from .profile_helpers import write_profile_sections
+from custom_components.horticulture_assistant.utils.path_utils import plants_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,12 +22,12 @@ def initialize_nutrient_logs(
         base_path = Path(base_dir)
     elif hass is not None:
         try:
-            base_path = Path(hass.config.path("plants"))
+            base_path = Path(plants_path(hass))
         except Exception as err:  # pragma: no cover - path resolution failure
             _LOGGER.error("Error resolving Home Assistant plants directory: %s", err)
-            base_path = Path("plants")
+            base_path = Path(plants_path(None))
     else:
-        base_path = Path("plants")
+        base_path = Path(plants_path(None))
     sections = {
         "nutrient_application_log.json": [],
         "fertilizer_cost_tracking.json": [],

--- a/scripts/generate_plant_sensors.py
+++ b/scripts/generate_plant_sensors.py
@@ -8,6 +8,8 @@ from itertools import repeat
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
+
+from custom_components.horticulture_assistant.utils.path_utils import data_path
 from typing import Dict, Iterable, List
 
 try:
@@ -19,7 +21,7 @@ from custom_components.horticulture_assistant.utils.json_io import load_json
 
 
 DEFAULT_OUTPUT_DIR = Path("templates/generated")
-DEFAULT_REPORT_DIR = Path("data/reports")
+DEFAULT_REPORT_DIR = Path(data_path(None, "reports"))
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- centralize data and plant directory resolution in various modules
- use path helper utilities across more files
- update generate_plant_sensors script
- refactor automation and reporting modules to use path utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68852828b9b483309718dbf178a56a9a