### PR TITLE
Add deficiency index helper

### DIFF
--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -13,6 +13,7 @@ from plant_engine.nutrient_manager import (
     get_stage_ratio,
     score_nutrient_levels,
     score_nutrient_series,
+    calculate_deficiency_index,
 )
 
 
@@ -181,3 +182,13 @@ def test_calculate_all_deficiencies_with_ph():
     deficits = calculate_all_deficiencies_with_ph(current, "tomato", "fruiting", 5.0)
     assert deficits["P"] > 0
     assert deficits["Fe"] > 0
+
+
+def test_calculate_deficiency_index():
+    guidelines = get_all_recommended_levels("tomato", "fruiting")
+    current = {n: 0 for n in guidelines}
+    index = calculate_deficiency_index(current, "tomato", "fruiting")
+    assert 99 <= index <= 100
+
+    index2 = calculate_deficiency_index(guidelines, "tomato", "fruiting")
+    assert index2 == 0.0


### PR DESCRIPTION
## Summary
- add `calculate_deficiency_index` utility to quantify overall deficiency severity
- export new helper in `nutrient_manager`
- test new functionality

## Testing
- `pytest tests/test_nutrient_manager.py::test_calculate_deficiency_index -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688568100f808330b9084ef19177310d