### PR TITLE
Add pesticide rotation guidelines

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -100,6 +100,7 @@
   "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",
   "pesticide_reentry_intervals.json": "Hours to wait before reentering treated areas after application.",
   "pesticide_modes.json": "Mode of action classification for common pesticides.",
+  "pesticide_rotation_intervals.json": "Recommended days to wait before reusing the same pesticide mode of action.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",

--- a/data/pesticide_rotation_intervals.json
+++ b/data/pesticide_rotation_intervals.json
@@ -1,0 +1,5 @@
+{
+  "neonicotinoid": 30,
+  "spinosyn": 10,
+  "pyrethroid": 14
+}

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -10,6 +10,8 @@ from plant_engine.pesticide_manager import (
     calculate_reentry_window,
     get_mode_of_action,
     list_known_pesticides,
+    get_rotation_interval,
+    suggest_rotation_schedule,
 )
 
 
@@ -79,4 +81,21 @@ def test_list_known_pesticides():
     pesticides = list_known_pesticides()
     assert "imidacloprid" in pesticides
     assert "pyrethrin" in pesticides
+
+
+def test_get_rotation_interval():
+    assert get_rotation_interval("imidacloprid") == 30
+    assert get_rotation_interval("spinosad") == 10
+    assert get_rotation_interval("unknown") is None
+
+
+def test_suggest_rotation_schedule():
+    start = datetime.date(2024, 1, 1)
+    schedule = suggest_rotation_schedule("imidacloprid", start, 3)
+    assert schedule == [
+        datetime.date(2024, 1, 1),
+        datetime.date(2024, 1, 31),
+        datetime.date(2024, 3, 1),
+    ]
+
 


### PR DESCRIPTION
## Summary
- maintain dataset catalog
- support pesticide rotation intervals
- track pesticide rotation scheduling
- test pesticide rotation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885681808f0833082dcb23a0e75ccac