### PR TITLE
Add environment plan CLI

### DIFF
--- a/scripts/environment_plan.py
+++ b/scripts/environment_plan.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Generate environment setpoint plans for a plant type."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+# Ensure project root is on the Python path when executed directly
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.environment_manager import (
+    generate_stage_environment_plan,
+    generate_zone_environment_plan,
+)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate recommended environment setpoints for each growth stage"
+    )
+    parser.add_argument("plant_type", help="Plant type to generate the plan for")
+    parser.add_argument(
+        "--zone",
+        help="Optional climate zone to adjust recommendations",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the plan JSON",
+    )
+    args = parser.parse_args(argv)
+
+    if args.zone:
+        plan = generate_zone_environment_plan(args.plant_type, args.zone)
+    else:
+        plan = generate_stage_environment_plan(args.plant_type)
+
+    text = json.dumps(plan, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_environment_plan_script.py
+++ b/tests/test_environment_plan_script.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/environment_plan.py"
+
+
+def test_environment_plan_cli(tmp_path: Path):
+    out_file = tmp_path / "plan.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "citrus", "--output", str(out_file)],
+        check=True,
+    )
+    data = json.loads(out_file.read_text())
+    assert "seedling" in data
+    assert "temp_c" in data["seedling"]
+
+
+def test_environment_plan_cli_zone():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "citrus", "--zone", "cool"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(result.stdout)
+    assert "vegetative" in data


### PR DESCRIPTION
## Summary
- add `environment_plan.py` script to generate recommended environment setpoints
- test new script

## Testing
- `pytest tests/test_environment_plan_script.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885683928288330a6daa52ceb19f6b1