### PR TITLE
Improve pest management summary utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Nutrient deficiency severity and treatment recommendations
 - Daily report files summarizing environment and nutrient targets
 - Infiltration-aware irrigation burst scheduling
+- Risk-adjusted pest monitoring summaries and scheduling
 
 ---
 

--- a/data/pest_monitoring_intervals.json
+++ b/data/pest_monitoring_intervals.json
@@ -14,5 +14,10 @@
     "seedling": 7,
     "fruiting": 3,
     "optimal": 5
+  },
+  "spinach": {
+    "vegetative": 5,
+    "harvest": 3,
+    "optimal": 4
   }
 }

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -12,6 +12,7 @@ from plant_engine.pest_monitor import (
     next_monitor_date,
     generate_monitoring_schedule,
     risk_adjusted_monitor_interval,
+    summarize_pest_management,
 )
 
 
@@ -115,4 +116,20 @@ def test_risk_adjusted_monitor_interval_low():
     env = {"temperature": 10, "humidity": 55}
     interval = risk_adjusted_monitor_interval("citrus", "vegetative", env)
     assert interval == 5
+
+
+def test_summarize_pest_management():
+    obs = {"aphids": 6}
+    env = {"temperature": 26, "humidity": 80}
+    last = date(2023, 1, 1)
+    summary = summarize_pest_management(
+        "citrus",
+        "vegetative",
+        obs,
+        environment=env,
+        last_date=last,
+    )
+    assert summary["severity"]["aphids"] in {"moderate", "severe"}
+    assert summary["risk"]["aphids"] == "high"
+    assert "next_monitor_date" in summary
 


### PR DESCRIPTION
## Summary
- expand dataset with spinach intervals
- add `summarize_pest_management` helper for pest risk and scheduling
- document pest monitoring summaries
- test new pest monitoring helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856835fb208330bbf40d412fc4acf0