### PR TITLE
Add canopy area utilities and dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Important categories include:
 - **Nutrient guidelines** – macronutrient and micronutrient targets by stage
 - **Pest and disease references** – thresholds, prevention tips and treatment options
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
+- **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions
 
 The WSDA fertilizer dataset resides under `feature/wsda_refactored_sharded/` which contains an

--- a/data/canopy_area.json
+++ b/data/canopy_area.json
@@ -1,0 +1,12 @@
+{
+  "lettuce": {
+    "seedling": 0.05,
+    "vegetative": 0.1,
+    "flowering": 0.15
+  },
+  "strawberry": {
+    "seedling": 0.07,
+    "vegetative": 0.15,
+    "flowering": 0.25
+  }
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -89,6 +89,7 @@
   "fertilizers/fertilizer_application_rates.json": "Recommended grams per liter of fertilizer product.",
   "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
   "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
+  "canopy_area.json": "Approximate canopy area (m²) per plant stage.",
   "nutrient_leaching_rates.json": "Leaching loss fractions by nutrient.",
   "nutrient_volatilization_rates.json": "Volatilization loss fractions by nutrient.",
   "nutrient_recovery_factors.json": "Fractional nutrient recovery after application.",

--- a/plant_engine/canopy.py
+++ b/plant_engine/canopy.py
@@ -1,0 +1,38 @@
+"""Helpers for canopy area lookups."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .utils import load_dataset, normalize_key
+from .plant_density import get_spacing_cm
+
+DATA_FILE = "canopy_area.json"
+
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = ["get_canopy_area", "estimate_canopy_area"]
+
+@lru_cache(maxsize=None)
+def get_canopy_area(plant_type: str, stage: str | None = None) -> float | None:
+    """Return canopy area for ``plant_type`` and ``stage`` if defined."""
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return None
+    if stage:
+        val = plant.get(normalize_key(stage))
+        if isinstance(val, (int, float)):
+            return float(val)
+    default = plant.get("default")
+    return float(default) if isinstance(default, (int, float)) else None
+
+
+def estimate_canopy_area(plant_type: str, stage: str | None = None) -> float:
+    """Return canopy area using dataset or spacing guidelines."""
+    area = get_canopy_area(plant_type, stage)
+    if area is not None:
+        return area
+    spacing = get_spacing_cm(plant_type)
+    if spacing is not None and spacing > 0:
+        return round((spacing / 100) ** 2, 3)
+    return 0.25

--- a/plant_engine/compute_transpiration.py
+++ b/plant_engine/compute_transpiration.py
@@ -7,6 +7,7 @@ from typing import Dict, Mapping, Iterable
 
 from .utils import load_dataset, normalize_key
 from .constants import DEFAULT_ENV
+from .canopy import estimate_canopy_area
 
 MODIFIER_FILE = "crop_coefficient_modifiers.json"
 # cached via load_dataset
@@ -114,7 +115,11 @@ def compute_transpiration(plant_profile: Mapping, env_data: Mapping) -> Dict[str
     kc = adjust_crop_coefficient(kc, env.get("temp_c"), env.get("rh_pct"))
     et_actual = calculate_eta(et0, kc)
 
-    canopy_m2 = plant_profile.get("canopy_m2", 0.25)
+    canopy_m2 = plant_profile.get("canopy_m2")
+    if canopy_m2 is None:
+        canopy_m2 = estimate_canopy_area(
+            plant_profile.get("plant_type"), plant_profile.get("stage")
+        )
     mm_per_day = et_actual
     ml_per_day = mm_per_day * MM_TO_ML_PER_M2 * canopy_m2
 

--- a/tests/test_canopy.py
+++ b/tests/test_canopy.py
@@ -1,0 +1,23 @@
+from plant_engine.canopy import get_canopy_area, estimate_canopy_area
+
+
+def test_get_canopy_area_known():
+    assert get_canopy_area("lettuce", "vegetative") == 0.1
+
+
+def test_get_canopy_area_unknown():
+    assert get_canopy_area("unknown") is None
+
+
+def test_estimate_canopy_area_dataset():
+    assert estimate_canopy_area("strawberry", "flowering") == 0.25
+
+
+def test_estimate_canopy_area_spacing_fallback():
+    # lettuce spacing is 25 cm -> area ~0.0625 m^2
+    val = estimate_canopy_area("lettuce", stage=None)
+    assert round(val, 3) == 0.062
+
+
+def test_estimate_canopy_area_default():
+    assert estimate_canopy_area("unknown") == 0.25

--- a/tests/test_compute_transpiration.py
+++ b/tests/test_compute_transpiration.py
@@ -70,6 +70,13 @@ def test_compute_transpiration_missing_env_defaults():
     assert result["transpiration_ml_day"] > 0
 
 
+def test_compute_transpiration_auto_canopy():
+    profile = {"plant_type": "strawberry", "stage": "flowering"}
+    env = {"temp_c": 24, "rh_pct": 60, "par_w_m2": 420}
+    result = compute_transpiration(profile, env)
+    assert result["transpiration_ml_day"] > 0
+
+
 def test_adjust_crop_coefficient():
     from plant_engine.compute_transpiration import adjust_crop_coefficient
 


### PR DESCRIPTION
## Summary
- integrate canopy area dataset for improved transpiration calculations
- expose new helper functions `get_canopy_area` and `estimate_canopy_area`
- use `estimate_canopy_area` in `compute_transpiration`
- document canopy dataset in README
- test new helpers and updated transpiration logic

## Testing
- `pytest tests/test_canopy.py tests/test_compute_transpiration.py -q`
- `pytest tests/test_dataset_catalog.py -q`
- `pytest tests/test_irrigation_manager.py -q`
- `pytest tests/test_environment_manager.py::test_get_environmental_targets_seedling -q`

------
https://chatgpt.com/codex/tasks/task_e_6885681f84cc83308a3cf2b13301e1a7