### PR TITLE
Add dissolved oxygen management utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -77,6 +77,7 @@
   "soil_moisture_guidelines.json": "Recommended soil moisture percentages for common crops.",
   "soil_temperature_guidelines.json": "Recommended soil temperature ranges for germination and growth stages.",
   "solution_temperature_guidelines.json": "Recommended nutrient solution temperature ranges.",
+  "dissolved_oxygen_guidelines.json": "Recommended dissolved oxygen ppm for nutrient solutions.",
   "soil_ec_guidelines.json": "Recommended soil salinity EC ranges for common crops.",
   "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
   "yield_estimates.json": "Expected total yields for common cultivars.",

--- a/data/dissolved_oxygen_guidelines.json
+++ b/data/dissolved_oxygen_guidelines.json
@@ -1,0 +1,7 @@
+{
+  "default": {"min": 6, "max": 10},
+  "lettuce": {"min": 7, "max": 10},
+  "tomato": {"min": 6, "max": 9},
+  "cucumber": {"min": 6, "max": 9},
+  "basil": {"min": 6, "max": 10}
+}

--- a/plant_engine/dissolved_oxygen.py
+++ b/plant_engine/dissolved_oxygen.py
@@ -1,0 +1,60 @@
+"""Dissolved oxygen management utilities."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "dissolved_oxygen_guidelines.json"
+
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_oxygen_range",
+    "evaluate_dissolved_oxygen",
+    "recommend_oxygen_adjustment",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with dissolved oxygen guidelines."""
+    return list_dataset_entries(_DATA)
+
+
+def get_oxygen_range(plant_type: str) -> tuple[float, float] | None:
+    """Return the recommended (min, max) dissolved oxygen range."""
+    entry = _DATA.get(normalize_key(plant_type)) or _DATA.get("default")
+    if not isinstance(entry, Mapping):
+        return None
+    try:
+        low = float(entry.get("min"))
+        high = float(entry.get("max"))
+    except (TypeError, ValueError):
+        return None
+    return low, high
+
+
+def evaluate_dissolved_oxygen(do_ppm: float | None, plant_type: str) -> str | None:
+    """Return ``"low"`` or ``"high"`` if ``do_ppm`` is outside the recommended range."""
+    if do_ppm is None:
+        return None
+    rng = get_oxygen_range(plant_type)
+    if not rng:
+        return None
+    low, high = rng
+    if do_ppm < low:
+        return "low"
+    if do_ppm > high:
+        return "high"
+    return None
+
+
+def recommend_oxygen_adjustment(do_ppm: float | None, plant_type: str) -> str | None:
+    """Return ``"aerate"`` if oxygen is low or ``"reduce_aeration"`` if high."""
+    level = evaluate_dissolved_oxygen(do_ppm, plant_type)
+    if level == "low":
+        return "aerate"
+    if level == "high":
+        return "reduce_aeration"
+    return None

--- a/tests/test_dissolved_oxygen.py
+++ b/tests/test_dissolved_oxygen.py
@@ -1,0 +1,28 @@
+from plant_engine.dissolved_oxygen import (
+    list_supported_plants,
+    get_oxygen_range,
+    evaluate_dissolved_oxygen,
+    recommend_oxygen_adjustment,
+)
+
+
+def test_get_oxygen_range():
+    assert get_oxygen_range("lettuce") == (7.0, 10.0)
+    assert get_oxygen_range("unknown") == (6.0, 10.0)
+
+
+def test_evaluate_dissolved_oxygen():
+    assert evaluate_dissolved_oxygen(5, "lettuce") == "low"
+    assert evaluate_dissolved_oxygen(11, "lettuce") == "high"
+    assert evaluate_dissolved_oxygen(8, "lettuce") is None
+
+
+def test_recommend_oxygen_adjustment():
+    assert recommend_oxygen_adjustment(5, "tomato") == "aerate"
+    assert recommend_oxygen_adjustment(11, "tomato") == "reduce_aeration"
+    assert recommend_oxygen_adjustment(8, "tomato") is None
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "lettuce" in plants and "basil" in plants


### PR DESCRIPTION
## Summary
- add new `dissolved_oxygen_guidelines.json` dataset
- register dataset in `dataset_catalog.json`
- implement `plant_engine.dissolved_oxygen` helpers
- test dissolved oxygen utilities

## Testing
- `pytest -q tests/test_dissolved_oxygen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885682928e48330aedede3c6062f114