### PR TITLE
Add guideline summary script

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables 
 Helper scripts live in the `scripts/` directory.
 
 - `generate_plant_sensors.py` converts daily reports into Home Assistant template sensor YAML.
+- `generate_guideline_summary.py` outputs consolidated environment, nutrient and pest guidance for a crop stage.
 - `wsda_search.py` queries the bundled WSDA fertilizer database.
 - `log_runoff_ec.py` records manual runoff EC measurements for calibration.
 - `train_ec_model.py` generates EC estimator coefficients from a CSV dataset. Use

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict, field as dataclass_field
 from typing import Any, Dict, List, Optional
 
+from functools import lru_cache
 from . import (
     environment_manager,
     nutrient_manager,
@@ -49,6 +50,7 @@ class GuidelineSummary:
         return asdict(self)
 
 
+@lru_cache(maxsize=None)
 def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str, Any]:
     """Return combined environment, nutrient and pest guidelines.
 

--- a/scripts/generate_guideline_summary.py
+++ b/scripts/generate_guideline_summary.py
@@ -1,0 +1,48 @@
+"""Generate a consolidated guideline summary for a crop stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+# Ensure project root on path when executed directly
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine import guidelines
+
+
+def generate_summary(plant_type: str, stage: str | None = None) -> dict:
+    """Return guideline summary for ``plant_type`` and optional ``stage``."""
+    return guidelines.get_guideline_summary(plant_type, stage)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Show guideline summary for a plant stage"
+    )
+    parser.add_argument("plant_type", help="crop identifier")
+    parser.add_argument("stage", nargs="?", default=None, help="growth stage")
+    parser.add_argument(
+        "--yaml", action="store_true", help="output YAML instead of JSON"
+    )
+    args = parser.parse_args(argv)
+
+    data = generate_summary(args.plant_type, args.stage)
+    if args.yaml:
+        try:
+            import yaml
+        except Exception as exc:  # pragma: no cover - optional dependency
+            parser.error("PyYAML required for --yaml output")
+        print(yaml.safe_dump(data, sort_keys=False))
+    else:
+        print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_generate_guideline_summary_script.py
+++ b/tests/test_generate_guideline_summary_script.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import subprocess
+import sys
+import json
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/generate_guideline_summary.py"
+
+
+def test_cli_json():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "citrus", "fruiting"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    assert data["environment"]["temp_c"] == [18, 28]
+    assert "aphids" in data["pest_guidelines"]
+
+
+def test_cli_yaml():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "citrus", "fruiting", "--yaml"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "temp_c" in result.stdout


### PR DESCRIPTION
## Summary
- cache guideline summaries for repeated lookups
- add `generate_guideline_summary.py` utility script
- document new script in README
- test CLI helper for JSON and YAML output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885683e51248330aec5f9fb13d74f8d