### PR TITLE
Add beneficial insect release rates

### DIFF
--- a/data/beneficial_release_rates.json
+++ b/data/beneficial_release_rates.json
@@ -1,0 +1,8 @@
+{
+  "ladybugs": 5,
+  "lacewings": 3,
+  "encarsia formosa": 2,
+  "predatory mites": 10,
+  "parasitic wasps": 4,
+  "diglyphus isaea": 4
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -33,6 +33,7 @@
   "root_depth_guidelines.json": "Typical maximum root depth per crop.",
   "plant_density_guidelines.json": "Recommended plant spacing for common crops.",
   "beneficial_insects.json": "Natural predators for common greenhouse pests.",
+  "beneficial_release_rates.json": "Recommended release rates of beneficial insects per m^2.",
   "bioinoculant_guidelines.json": "Recommended microbial inoculants for improved nutrient uptake.",
   "crop_coefficients.json": "Crop coefficients for evapotranspiration models.",
   "crop_coefficient_modifiers.json": "Environmental adjustment factors for crop coefficients.",

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -41,6 +41,20 @@ def test_recommend_beneficials():
     assert "parasitic wasps" in rec["scale"]
 
 
+def test_get_beneficial_release_rate():
+    from plant_engine.pest_manager import get_beneficial_release_rate
+
+    assert get_beneficial_release_rate("ladybugs") == 5.0
+    assert get_beneficial_release_rate("unknown") is None
+
+
+def test_recommend_release_rates():
+    from plant_engine.pest_manager import recommend_release_rates
+
+    rates = recommend_release_rates(["aphids"])
+    assert rates["aphids"]["ladybugs"] == 5.0
+
+
 def test_list_known_pests():
     pests = list_known_pests("citrus")
     assert "aphids" in pests


### PR DESCRIPTION
## Summary
- include new `beneficial_release_rates.json` dataset
- expose recommended release rates in `pest_manager`
- output release rate advice via `recommend_release_rates`
- add unit tests for new pest manager helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68856822d4848330884e993fba03d528