### PR TITLE
Enhance nutrient reporting in daily cycle

### DIFF
--- a/tests/test_run_daily_cycle_nutrient_analysis.py
+++ b/tests/test_run_daily_cycle_nutrient_analysis.py
@@ -26,3 +26,6 @@ def test_run_daily_cycle_nutrient_analysis(tmp_path):
     # verify nutrient deficiency detection
     assert "deficiency_actions" in report
     assert report["deficiency_actions"]["Ca"]["severity"] == "severe"
+    # new expected uptake reporting
+    assert report["expected_uptake"]["N"] == 50
+    assert report["uptake_gap"]["K"] == 20


### PR DESCRIPTION
## Summary
- track expected daily nutrient uptake and gaps in `run_daily_cycle`
- test nutrient uptake reporting

## Testing
- `pytest tests/test_run_daily_cycle_nutrient_analysis.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688568260aa88330a8d8028067d2bc77