### PR TITLE
Improve profile manager features

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Helper scripts live in the `scripts/` directory.
 - `load_all_profiles` validates and aggregates every profile in the `plants/` directory.
 - `list_available_profiles` quickly lists profile IDs without loading them.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
+- `profile_manager.py` manages sensors, preferences, and templates.  `attach-sensor` appends new sensors, while `detach-sensor` removes them.  Other subcommands include `list-sensors`, `set-pref`, `load-default`, `show-history`, and `list-globals`.  `--plants-dir` and `--global-dir` operate on alternate directories.
 
 Example usage:
 ```bash
@@ -207,6 +208,8 @@ python scripts/generate_plant_sensors.py <plant_id>
 python scripts/wsda_search.py "EARTH-CARE" --limit 5
 python scripts/log_runoff_ec.py <plant_id> <ec_value>
 python scripts/train_ec_model.py samples.csv --plant-id myplant
+python scripts/profile_manager.py load-default tomato my_plant
+python scripts/profile_manager.py list-sensors my_plant
 python -m custom_components.horticulture_assistant.analytics.export_all_growth_yield
 ```
 

--- a/data/global_profiles/basil.json
+++ b/data/global_profiles/basil.json
@@ -1,0 +1,18 @@
+{
+  "general": {
+    "plant_type": "basil",
+    "cultivar": "generic",
+    "auto_lifecycle_mode": false,
+    "auto_approve_all": false,
+    "sensor_entities": {
+      "moisture_sensors": [],
+      "temperature_sensors": []
+    }
+  },
+  "thresholds": {
+    "soil_moisture_pct": 25
+  },
+  "stages": {
+    "vegetative": {"stage_duration": 20}
+  }
+}

--- a/data/global_profiles/tomato.json
+++ b/data/global_profiles/tomato.json
@@ -1,0 +1,18 @@
+{
+  "general": {
+    "plant_type": "tomato",
+    "cultivar": "generic",
+    "auto_lifecycle_mode": false,
+    "auto_approve_all": false,
+    "sensor_entities": {
+      "moisture_sensors": [],
+      "temperature_sensors": []
+    }
+  },
+  "thresholds": {
+    "soil_moisture_pct": 30
+  },
+  "stages": {
+    "vegetative": {"stage_duration": 30}
+  }
+}

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -97,3 +97,35 @@ def test_update_profile_sensors_missing(tmp_path):
 
     result = loader.update_profile_sensors("missing", {"moisture_sensors": ["x"]}, plants)
     assert result is False
+
+
+def test_detach_profile_sensors(tmp_path):
+    plants = tmp_path / "plants"
+    plants.mkdir()
+    profile = {
+        "general": {"sensor_entities": {"moisture_sensors": ["a", "b"], "temp_sensors": ["t1"]}}
+    }
+    loader.save_profile_by_id("p1", profile, plants)
+
+    loader.detach_profile_sensors("p1", {"moisture_sensors": ["a"]}, plants)
+
+    updated = json.load(open(plants / "p1.json", "r", encoding="utf-8"))
+    sensors = updated["general"]["sensor_entities"]
+    assert sensors["moisture_sensors"] == ["b"]
+    assert sensors["temp_sensors"] == ["t1"]
+
+
+def test_attach_profile_sensors(tmp_path):
+    plants = tmp_path / "plants"
+    plants.mkdir()
+    profile = {
+        "general": {"sensor_entities": {"moisture_sensors": ["a"], "temp_sensors": ["t1"]}}
+    }
+    loader.save_profile_by_id("p1", profile, plants)
+
+    loader.attach_profile_sensors("p1", {"moisture_sensors": ["b"]}, plants)
+
+    updated = json.load(open(plants / "p1.json", "r", encoding="utf-8"))
+    sensors = updated["general"]["sensor_entities"]
+    assert sensors["moisture_sensors"] == ["a", "b"]
+    assert sensors["temp_sensors"] == ["t1"]

--- a/tests/test_profile_manager_script.py
+++ b/tests/test_profile_manager_script.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+import scripts.profile_manager as pm
+
+
+def test_load_default_profile(tmp_path: Path):
+    global_dir = tmp_path / "data/global_profiles"
+    global_dir.mkdir(parents=True)
+    sample = {
+        "general": {"plant_type": "demo", "cultivar": "std"},
+        "thresholds": {"soil_moisture_pct": 10},
+    }
+    (global_dir / "demo.json").write_text(json.dumps(sample))
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+
+    ok = pm.load_default_profile("demo", "demo1", plants_dir, global_dir)
+    assert ok
+    created = json.load(open(plants_dir / "demo1.json", "r", encoding="utf-8"))
+    assert created["general"]["plant_id"] == "demo1"
+    assert created["general"]["plant_type"] == "demo"
+
+
+def test_show_history(tmp_path: Path):
+    plants_dir = tmp_path / "plants"
+    plant_home = plants_dir / "demo"
+    plant_home.mkdir(parents=True)
+    log_data = [{"val": i} for i in range(5)]
+    (plant_home / "events.json").write_text(json.dumps(log_data))
+
+    entries = pm.show_history("demo", "events", plants_dir, lines=2)
+    assert entries == log_data[-2:]
+
+
+def test_list_profile_sensors(tmp_path: Path):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    profile = {
+        "general": {
+            "sensor_entities": {"moisture_sensors": ["a"], "temp_sensors": ["t"]}
+        }
+    }
+    (plants_dir / "p1.json").write_text(json.dumps(profile))
+
+    sensors = pm.list_profile_sensors("p1", plants_dir)
+    assert sensors == profile["general"]["sensor_entities"]
+
+
+def test_list_global_profiles(tmp_path: Path):
+    global_dir = tmp_path / "data/global_profiles"
+    global_dir.mkdir(parents=True)
+    (global_dir / "a.json").write_text("{}")
+    (global_dir / "b.json").write_text("{}")
+
+    profiles = pm.list_global_profiles(global_dir)
+    assert profiles == ["a", "b"]
+
+
+def test_attach_and_detach_sensor(tmp_path: Path):
+    plants_dir = tmp_path / "plants"
+    plants_dir.mkdir()
+    profile = {"general": {"sensor_entities": {"moisture_sensors": ["a"]}}}
+    (plants_dir / "p1.json").write_text(json.dumps(profile))
+
+    ok = pm.attach_sensor("p1", "moisture_sensors", ["b"], plants_dir)
+    assert ok
+    sensors = json.load(open(plants_dir / "p1.json", "r", encoding="utf-8"))["general"]["sensor_entities"]
+    assert sensors["moisture_sensors"] == ["a", "b"]
+
+    ok = pm.detach_sensor("p1", "moisture_sensors", ["a"], plants_dir)
+    assert ok
+    sensors = json.load(open(plants_dir / "p1.json", "r", encoding="utf-8"))["general"]["sensor_entities"]
+    assert sensors["moisture_sensors"] == ["b"]


### PR DESCRIPTION
## Summary
- update README with new profile_manager functionality
- add global profile listing and sensor listing features
- improve profile_manager CLI and expose new subcommands
- expand tests for profile_manager utilities
- add sensor attachment helper and update profile manager

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688568ff38048330913d96a515090b23