### PR TITLE
Add fertigation CLI and environment advice enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Helper scripts live in the `scripts/` directory.
 - `log_runoff_ec.py` records manual runoff EC measurements for calibration.
 - `train_ec_model.py` generates EC estimator coefficients from a CSV dataset. Use
   `--plant-id` to save a model under that plant's profile.
+- `fertigation_plan.py` outputs day-by-day fertilizer schedules for a plant stage.
 - `export_all_growth_yield.py` aggregates growth and yield data from the `analytics/` directory.
 - `load_all_profiles` validates and aggregates every profile in the `plants/` directory.
 - `list_available_profiles` quickly lists profile IDs without loading them.

--- a/scripts/fertigation_plan.py
+++ b/scripts/fertigation_plan.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Generate a daily fertigation plan for a plant stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.fertigation import generate_fertigation_plan
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate fertigation schedules for a growth stage"
+    )
+    parser.add_argument("plant_type", help="Plant type to generate the plan for")
+    parser.add_argument("stage", help="Growth stage name")
+    parser.add_argument("days", type=int, help="Number of days to generate")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the plan JSON",
+    )
+    args = parser.parse_args(argv)
+
+    plan = generate_fertigation_plan(args.plant_type, args.stage, args.days)
+    text = json.dumps(plan, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -3,6 +3,7 @@ import pytest
 from plant_engine.environment_manager import (
     get_environmental_targets,
     recommend_environment_adjustments,
+    recommend_environment_adjustments_verbose,
     suggest_environment_setpoints,
     suggest_environment_setpoints_advanced,
     saturation_vapor_pressure,
@@ -113,6 +114,24 @@ def test_recommend_environment_adjustments_aliases():
 def test_recommend_environment_adjustments_no_data():
     actions = recommend_environment_adjustments({"temp_c": 20}, "unknown")
     assert actions == {}
+
+
+def test_recommend_environment_adjustments_verbose():
+    actions = recommend_environment_adjustments_verbose(
+        {
+            "temp_c": 18,
+            "humidity_pct": 90,
+            "light_ppfd": 100,
+            "co2_ppm": 700,
+        },
+        "citrus",
+        "seedling",
+    )
+    assert "dehumidifier" in actions["humidity"].lower()
+    assert (
+        "heating" in actions["temperature"].lower()
+        or actions["temperature"] == "increase"
+    )
 
 
 def test_suggest_environment_setpoints():

--- a/tests/test_fertigation_plan_script.py
+++ b/tests/test_fertigation_plan_script.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import subprocess
+import sys
+import json
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/fertigation_plan.py"
+
+
+def test_fertigation_plan_cli(tmp_path: Path):
+    out_file = tmp_path / "plan.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "citrus", "vegetative", "2", "--output", str(out_file)],
+        check=True,
+    )
+    data = json.loads(out_file.read_text())
+    assert "1" in data
+    assert isinstance(data["1"], dict)


### PR DESCRIPTION
## Summary
- expose a new `recommend_environment_adjustments_verbose` helper that uses the humidity and temperature action datasets
- add CLI utility `fertigation_plan.py` for creating fertigation schedules
- document the new script in the README
- test the new CLI and verbose environment adjustment helper

## Testing
- `pytest -k 'fertigation_plan_cli or recommend_environment_adjustments_verbose' -q`

------
https://chatgpt.com/codex/tasks/task_e_6885769bf2108330b261126926a3a262