### PR TITLE
Enhance environment guidance

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -51,6 +51,7 @@
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",
   "humidity_actions.json": "Recommended actions for low or high humidity.",
   "temperature_actions.json": "Recommended actions for hot or cold temperature stress.",
+  "environment_strategies.json": "Strategies for optimizing environment when conditions are outside targets.",
   "nutrient_deficiency_symptoms.json": "Visual cues for nutrient deficiencies.",
   "nutrient_deficiency_treatments.json": "Corrective actions for deficiencies.",
   "nutrient_deficiency_thresholds.json": "Deficiency ppm thresholds for severity classification.",

--- a/data/environment_strategies.json
+++ b/data/environment_strategies.json
@@ -1,0 +1,18 @@
+{
+  "temperature": {
+    "low": "Increase heating or insulation to raise temperature gradually.",
+    "high": "Increase ventilation and shading to reduce temperature."
+  },
+  "humidity": {
+    "low": "Increase misting frequency and reduce ventilation.",
+    "high": "Use dehumidifiers and increase airflow."
+  },
+  "light": {
+    "low": "Use supplemental lighting to raise intensity.",
+    "high": "Deploy shade cloth to reduce light levels."
+  },
+  "co2": {
+    "low": "Check injection system and reduce ventilation losses.",
+    "high": "Increase ventilation or pause injection to lower CO2."
+  }
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -668,6 +668,15 @@ def test_temperature_actions():
     assert em.recommend_temperature_action(25, 50, "citrus") is None
 
 
+def test_environment_strategies():
+    from plant_engine import environment_manager as em
+
+    assert "ventilation" in em.get_environment_strategy("temperature", "high")
+    status = {"temperature": "high", "humidity": "low"}
+    rec = em.recommend_environment_strategies(status)
+    assert set(rec) == {"temperature", "humidity"}
+
+
 def test_evaluate_ph_stress():
     assert evaluate_ph_stress(5.0, "citrus") == "low"
     assert evaluate_ph_stress(7.0, "citrus") == "high"


### PR DESCRIPTION
## Summary
- add new dataset `environment_strategies.json`
- expose dataset in `dataset_catalog.json`
- support retrieving and recommending environment optimization strategies
- test new environment strategy helpers

## Testing
- `pytest tests/test_environment_manager.py::test_environment_strategies -q`
- `pytest tests/test_dataset_catalog.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885769ea8588330a38d2a9a70b1f92c