### PR TITLE
Add stage end date helpers

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -29,6 +29,8 @@ __all__ = [
     "stage_progress",
     "days_until_harvest",
     "predict_next_stage_date",
+    "predict_stage_end_date",
+    "stage_progress_from_dates",
     "get_germination_duration",
 ]
 
@@ -172,6 +174,31 @@ def predict_next_stage_date(
     if duration is None:
         return None
     return stage_start + timedelta(days=duration)
+
+
+def predict_stage_end_date(
+    plant_type: str, stage: str, stage_start: date
+) -> date | None:
+    """Return the expected end date of ``stage`` for ``plant_type``."""
+
+    duration = get_stage_duration(plant_type, stage)
+    if duration is None:
+        return None
+    return stage_start + timedelta(days=duration)
+
+
+def stage_progress_from_dates(
+    plant_type: str,
+    stage: str,
+    start_date: date,
+    current_date: date,
+) -> float | None:
+    """Return completion percent of ``stage`` based on dates."""
+
+    if current_date < start_date:
+        raise ValueError("current_date cannot be before start_date")
+    days = (current_date - start_date).days
+    return stage_progress(plant_type, stage, days)
 
 
 def days_until_next_stage(

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -11,6 +11,8 @@ from plant_engine.growth_stage import (
     stage_progress,
     days_until_harvest,
     predict_next_stage_date,
+    predict_stage_end_date,
+    stage_progress_from_dates,
     get_germination_duration,
     days_until_next_stage,
 )
@@ -111,5 +113,22 @@ def test_days_until_next_stage():
 def test_get_total_cycle_duration():
     assert get_total_cycle_duration("tomato") == 120
     assert get_total_cycle_duration("unknown") is None
+
+
+def test_predict_stage_end_date():
+    start = date(2025, 1, 1)
+    end = predict_stage_end_date("tomato", "seedling", start)
+    assert end == date(2025, 1, 31)
+    assert predict_stage_end_date("unknown", "seedling", start) is None
+
+
+def test_stage_progress_from_dates():
+    start = date(2025, 1, 1)
+    current = date(2025, 1, 16)
+    progress = stage_progress_from_dates("tomato", "seedling", start, current)
+    assert progress == 50.0
+
+    with pytest.raises(ValueError):
+        stage_progress_from_dates("tomato", "seedling", current, start)
 
 


### PR DESCRIPTION
## Summary
- add `predict_stage_end_date` and `stage_progress_from_dates` helpers
- test new growth stage helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688576a1a45c83308ce3d7db3136f821