### PR TITLE
Add lighting efficiency data and DLI calculation

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -43,6 +43,7 @@
   "fertilizer_purity.json": "Nutrient purity factors for fertilizer products.",
   "fertilizer_solubility.json": "Solubility limits for common fertilizers.",
   "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",
+  "light_efficiency.json": "Photon efficiency (\u03bcmol/J) for common lighting types.",
   "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
   "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",
   "foliar_spray_volume.json": "Recommended foliar spray volume per plant in mL.",

--- a/data/light_efficiency.json
+++ b/data/light_efficiency.json
@@ -1,0 +1,6 @@
+{
+  "led": {"umol_per_j": 2.5},
+  "hps": {"umol_per_j": 1.7},
+  "fluorescent": {"umol_per_j": 1.2},
+  "default": {"umol_per_j": 2.0}
+}

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -7,6 +7,8 @@ from plant_engine.energy_manager import (
     get_electricity_rate,
     estimate_lighting_energy,
     estimate_lighting_cost,
+    get_light_efficiency,
+    estimate_dli_from_power,
 )
 
 
@@ -49,3 +51,10 @@ def test_estimate_hvac_cost():
     cost = estimate_hvac_cost(18, 20, 12, "heating", region="california")
     expected_kwh = 0.5 * (2 * 12 / 24)
     assert cost == pytest.approx(expected_kwh * 0.18, 0.01)
+
+
+def test_light_efficiency_and_dli():
+    assert get_light_efficiency("led") == 2.5
+    dli = estimate_dli_from_power(200, 5, "led")
+    # 200W for 5h at 2.5 umol/J over 1 m^2 -> 9 mol
+    assert dli == pytest.approx(9.0, 0.1)


### PR DESCRIPTION
## Summary
- add new `light_efficiency.json` dataset and reference in catalog
- expose `get_light_efficiency` and `estimate_dli_from_power` utilities
- test new utilities in `energy_manager`

## Testing
- `pytest tests/test_energy_manager.py::test_light_efficiency_and_dli -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688576a539c083308ebd199861f74c64