### PR TITLE
Add pesticide rotation plan helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Daily report files summarizing environment and nutrient targets
 - Infiltration-aware irrigation burst scheduling
 - Risk-adjusted pest monitoring summaries and scheduling
+- Automatic pesticide rotation planning
 
 ---
 

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -29,6 +29,7 @@ __all__ = [
     "list_known_pesticides",
     "get_rotation_interval",
     "suggest_rotation_schedule",
+    "suggest_rotation_plan",
 ]
 
 
@@ -156,3 +157,31 @@ def suggest_rotation_schedule(product: str, start_date: date, cycles: int) -> Li
         return []
 
     return [start_date + timedelta(days=interval * i) for i in range(cycles)]
+
+
+def suggest_rotation_plan(
+    products: Iterable[str], start_date: date
+) -> List[tuple[str, date]]:
+    """Return sequential application schedule for multiple products.
+
+    Each product is scheduled after the rotation interval of the previous
+    product. Unknown products are scheduled with no additional delay.
+
+    Parameters
+    ----------
+    products:
+        Iterable of pesticide product identifiers in the desired order of
+        application.
+    start_date:
+        Date of the first application.
+    """
+
+    plan: List[tuple[str, date]] = []
+    current_date = start_date
+    for product in products:
+        plan.append((product, current_date))
+        interval = get_rotation_interval(product)
+        if interval is None:
+            interval = 0
+        current_date += timedelta(days=interval)
+    return plan

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -12,6 +12,7 @@ from plant_engine.pesticide_manager import (
     list_known_pesticides,
     get_rotation_interval,
     suggest_rotation_schedule,
+    suggest_rotation_plan,
 )
 
 
@@ -96,6 +97,18 @@ def test_suggest_rotation_schedule():
         datetime.date(2024, 1, 1),
         datetime.date(2024, 1, 31),
         datetime.date(2024, 3, 1),
+    ]
+
+
+def test_suggest_rotation_plan():
+    start = datetime.date(2024, 1, 1)
+    plan = suggest_rotation_plan(
+        ["imidacloprid", "spinosad", "imidacloprid"], start
+    )
+    assert plan == [
+        ("imidacloprid", start),
+        ("spinosad", start + datetime.timedelta(days=30)),
+        ("imidacloprid", start + datetime.timedelta(days=40)),
     ]
 
 


### PR DESCRIPTION
## Summary
- add helper to generate a pesticide rotation plan across multiple products
- document pesticide rotation planning capability
- test the new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688576b1aca08330a9c6fede5cafc1ce