### PR TITLE
Enhance recommendation engine with deficiency severity

### DIFF
--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -30,6 +30,7 @@ def test_recommendation_engine_requires_approval():
     assert rec.requires_approval is True
     assert rec.fertilizers[0].product_name == "n_fert"
     assert rec.fertilizers[0].reason == "N deficit"
+    assert rec.fertilizers[0].severity == "severe"
     assert rec.irrigation.volume_liters == 0.05
     assert "check drainage" in rec.notes
 
@@ -53,3 +54,10 @@ def test_recommendation_engine_recommend_all_and_reset():
     eng.reset_state()
     assert eng.plant_profiles == {}
     assert eng._element_map == {}
+
+
+def test_fertilizer_recommendation_severity():
+    eng = _setup_engine(auto=False)
+    rec = eng.recommend("p1")
+    fert = rec.fertilizers[0]
+    assert fert.severity in {"mild", "moderate", "severe"}


### PR DESCRIPTION
## Summary
- include severity information when generating fertilizer recommendations
- update tests for `RecommendationEngine` to validate new field

## Testing
- `pytest tests/test_recommendation_engine.py::test_recommendation_engine_requires_approval -q`
- `pytest tests/test_recommendation_engine.py -q`
- `pytest tests/test_deficiency_manager.py::test_assess_deficiency_severity -q`
- `pytest tests/test_environment_manager.py::test_get_environmental_targets_seedling -q`


------
https://chatgpt.com/codex/tasks/task_e_688576a3986483308a813b406835cc75