### PR TITLE
Improve nutrient scheduling with micro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Helper scripts live in the `scripts/` directory.
 - `export_all_growth_yield.py` aggregates growth and yield data from the `analytics/` directory.
 - `load_all_profiles` validates and aggregates every profile in the `plants/` directory.
 - `list_available_profiles` quickly lists profile IDs without loading them.
+- `fertigation_plan.py` creates a JSON fertigation schedule for any crop stage.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
 - `profile_manager.py` manages sensors, preferences, and templates.  `attach-sensor` appends new sensors, while `detach-sensor` removes them.  Other subcommands include `list-sensors`, `set-pref`, `load-default`, `show-history`, and `list-globals`.  `--plants-dir` and `--global-dir` operate on alternate directories.
 

--- a/scripts/fertigation_plan.py
+++ b/scripts/fertigation_plan.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Generate a fertigation plan for a crop stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.fertigation import generate_fertigation_plan
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate daily fertigation schedule for a plant stage"
+    )
+    parser.add_argument("plant_type", help="Crop identifier")
+    parser.add_argument("stage", help="Growth stage")
+    parser.add_argument("days", type=int, help="Number of days to generate")
+    parser.add_argument(
+        "--output", type=Path, help="Optional path to write the plan JSON"
+    )
+    args = parser.parse_args(argv)
+
+    plan = generate_fertigation_plan(args.plant_type, args.stage, args.days)
+    text = json.dumps(plan, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_nutrient_scheduler.py
+++ b/tests/test_nutrient_scheduler.py
@@ -117,3 +117,14 @@ def test_dataset_override(tmp_path, monkeypatch):
     result = schedule_nutrients("tag", hass=hass).as_dict()
     assert result["N"] == 60.0
     monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR", raising=False)
+
+
+def test_include_micro_guidelines(tmp_path):
+    plant_dir = tmp_path / "plants"
+    plant_dir.mkdir()
+    (plant_dir / "micro.json").write_text(
+        '{"general": {"plant_type": "lettuce", "stage": "seedling"}}'
+    )
+    hass = _hass_for(tmp_path)
+    result = schedule_nutrients("micro", hass=hass, include_micro=True).as_dict()
+    assert result["Fe"] > 0


### PR DESCRIPTION
## Summary
- include micronutrient guidelines when scheduling nutrients
- add `fertigation_plan.py` helper script to generate fertigation schedules
- document new script in README
- test micronutrient scheduling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688576aa2650833086ccb410ab7219ed