### PR TITLE
Refactor sensor map creation

### DIFF
--- a/custom_components/horticulture_assistant/binary_sensor.py
+++ b/custom_components/horticulture_assistant/binary_sensor.py
@@ -15,6 +15,7 @@ from .const import DOMAIN, CATEGORY_DIAGNOSTIC, CATEGORY_CONTROL
 from .utils.entry_helpers import get_entry_data, store_entry_data
 from .entity_base import HorticultureBaseEntity
 from .utils.state_helpers import normalize_entities
+from .utils.sensor_map import build_sensor_map
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,20 +30,16 @@ async def async_setup_entry(
     plant_id = stored["plant_id"]
     plant_name = stored["plant_name"]
 
-    sensor_map = {
-        "moisture_sensors": normalize_entities(
-            entry.data.get("moisture_sensors"), f"sensor.{plant_id}_raw_moisture"
+    sensor_map = build_sensor_map(
+        entry.data,
+        plant_id,
+        keys=(
+            "moisture_sensors",
+            "temperature_sensors",
+            "humidity_sensors",
+            "ec_sensors",
         ),
-        "temperature_sensors": normalize_entities(
-            entry.data.get("temperature_sensors"), f"sensor.{plant_id}_raw_temperature"
-        ),
-        "humidity_sensors": normalize_entities(
-            entry.data.get("humidity_sensors"), f"sensor.{plant_id}_raw_humidity"
-        ),
-        "ec_sensors": normalize_entities(
-            entry.data.get("ec_sensors"), f"sensor.{plant_id}_raw_ec"
-        ),
-    }
+    )
 
     sensors: list[BinarySensorEntity] = [
         SensorHealthBinarySensor(hass, plant_name, plant_id, sensor_map),
@@ -66,12 +63,16 @@ class HorticultureBaseBinarySensor(HorticultureBaseEntity, BinarySensorEntity):
         super().__init__(plant_name, plant_id, model="AI Monitored Plant")
         self.hass = hass
         if sensor_map is None:
-            sensor_map = {
-                "moisture_sensors": [f"sensor.{plant_id}_raw_moisture"],
-                "temperature_sensors": [f"sensor.{plant_id}_raw_temperature"],
-                "humidity_sensors": [f"sensor.{plant_id}_raw_humidity"],
-                "ec_sensors": [f"sensor.{plant_id}_raw_ec"],
-            }
+            sensor_map = build_sensor_map(
+                {},
+                plant_id,
+                keys=(
+                    "moisture_sensors",
+                    "temperature_sensors",
+                    "humidity_sensors",
+                    "ec_sensors",
+                ),
+            )
         self._sensor_map = sensor_map
 
 

--- a/custom_components/horticulture_assistant/sensor.py
+++ b/custom_components/horticulture_assistant/sensor.py
@@ -22,6 +22,7 @@ from .utils.state_helpers import (
     normalize_entities,
     aggregate_sensor_values,
 )
+from .utils.sensor_map import build_sensor_map
 from .utils.entry_helpers import get_entry_data, store_entry_data
 
 from plant_engine.environment_manager import (
@@ -56,26 +57,18 @@ async def async_setup_entry(
     plant_id = stored["plant_id"]
     plant_name = stored["plant_name"]
 
-    sensor_map = {
-        "moisture_sensors": normalize_entities(
-            entry.data.get("moisture_sensors"), f"sensor.{plant_id}_raw_moisture"
+    sensor_map = build_sensor_map(
+        entry.data,
+        plant_id,
+        keys=(
+            "moisture_sensors",
+            "temperature_sensors",
+            "humidity_sensors",
+            "light_sensors",
+            "ec_sensors",
+            "co2_sensors",
         ),
-        "temperature_sensors": normalize_entities(
-            entry.data.get("temperature_sensors"), f"sensor.{plant_id}_raw_temperature"
-        ),
-        "humidity_sensors": normalize_entities(
-            entry.data.get("humidity_sensors"), f"sensor.{plant_id}_raw_humidity"
-        ),
-        "light_sensors": normalize_entities(
-            entry.data.get("light_sensors"), f"sensor.{plant_id}_raw_light"
-        ),
-        "ec_sensors": normalize_entities(
-            entry.data.get("ec_sensors"), f"sensor.{plant_id}_raw_ec"
-        ),
-        "co2_sensors": normalize_entities(
-            entry.data.get("co2_sensors"), f"sensor.{plant_id}_raw_co2"
-        ),
-    }
+    )
 
     sensors: list[SensorEntity] = [
         SmoothedMoistureSensor(hass, plant_name, plant_id, sensor_map),
@@ -106,14 +99,7 @@ class HorticultureBaseSensor(HorticultureBaseEntity, SensorEntity):
         super().__init__(plant_name, plant_id, model="AI Monitored Plant")
         self.hass = hass
         if sensor_map is None:
-            sensor_map = {
-                "moisture_sensors": [f"sensor.{plant_id}_raw_moisture"],
-                "temperature_sensors": [f"sensor.{plant_id}_raw_temperature"],
-                "humidity_sensors": [f"sensor.{plant_id}_raw_humidity"],
-                "light_sensors": [f"sensor.{plant_id}_raw_light"],
-                "ec_sensors": [f"sensor.{plant_id}_raw_ec"],
-                "co2_sensors": [f"sensor.{plant_id}_raw_co2"],
-            }
+            sensor_map = build_sensor_map({}, plant_id)
         self._sensor_map = sensor_map
 
     def _get_state_value(self, entity_id: str | list[str] | None) -> float | None:

--- a/custom_components/horticulture_assistant/utils/sensor_map.py
+++ b/custom_components/horticulture_assistant/utils/sensor_map.py
@@ -1,0 +1,37 @@
+"""Helpers for constructing sensor entity mappings."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Dict
+
+from .state_helpers import normalize_entities
+
+DEFAULT_SENSORS = {
+    "moisture_sensors": "sensor.{plant_id}_raw_moisture",
+    "temperature_sensors": "sensor.{plant_id}_raw_temperature",
+    "humidity_sensors": "sensor.{plant_id}_raw_humidity",
+    "light_sensors": "sensor.{plant_id}_raw_light",
+    "ec_sensors": "sensor.{plant_id}_raw_ec",
+    "co2_sensors": "sensor.{plant_id}_raw_co2",
+}
+
+__all__ = ["build_sensor_map", "DEFAULT_SENSORS"]
+
+
+def build_sensor_map(
+    entry_data: Mapping[str, object],
+    plant_id: str,
+    keys: Iterable[str] | None = None,
+) -> Dict[str, list[str]]:
+    """Return normalized sensor map for ``plant_id`` based on ``entry_data``."""
+    if keys is None:
+        keys = DEFAULT_SENSORS.keys()
+
+    result: Dict[str, list[str]] = {}
+    for key in keys:
+        default = DEFAULT_SENSORS.get(key)
+        if not default:
+            continue
+        result[key] = normalize_entities(
+            entry_data.get(key), default.format(plant_id=plant_id)
+        )
+    return result

--- a/tests/test_sensor_map.py
+++ b/tests/test_sensor_map.py
@@ -1,0 +1,29 @@
+import types
+import sys
+
+# Minimal Home Assistant stub so the module imports without the real package
+ha = types.ModuleType("homeassistant")
+ha.core = types.ModuleType("homeassistant.core")
+ha.core.HomeAssistant = object
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.core", ha.core)
+
+from custom_components.horticulture_assistant.utils.sensor_map import build_sensor_map, DEFAULT_SENSORS
+
+
+def test_build_sensor_map_defaults():
+    result = build_sensor_map({}, "pid")
+    expected = {k: [v.format(plant_id="pid")] for k, v in DEFAULT_SENSORS.items()}
+    assert result == expected
+
+
+def test_build_sensor_map_custom_entries():
+    data = {
+        "moisture_sensors": "sensor.a, sensor.b",
+        "ec_sensors": ["sensor.ec1", "sensor.ec2"],
+    }
+    result = build_sensor_map(data, "pid", keys=("moisture_sensors", "ec_sensors"))
+    assert result == {
+        "moisture_sensors": ["sensor.a", "sensor.b"],
+        "ec_sensors": ["sensor.ec1", "sensor.ec2"],
+    }


### PR DESCRIPTION
## Summary
- add helper for creating sensor maps
- use helper in binary sensor and sensor platforms
- test new helper

## Testing
- `pytest tests/test_sensor_map.py tests/test_binary_sensors.py tests/test_sensor_moving_average.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688576adcd988330b222c6e8b2951d1f