### PR TITLE
Add zone selection to config flow

### DIFF
--- a/custom_components/horticulture_assistant/config_flow.py
+++ b/custom_components/horticulture_assistant/config_flow.py
@@ -26,7 +26,10 @@ class HorticultureAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
         """Collect minimal information and create the entry."""
-        data_schema = vol.Schema({vol.Required("plant_name"): TextSelector()})
+        data_schema = vol.Schema({
+            vol.Required("plant_name"): TextSelector(),
+            vol.Optional("zone_id"): TextSelector(),
+        })
 
         if user_input is not None:
             self._data.update(user_input)

--- a/custom_components/horticulture_assistant/utils/irrigation_schedule.py
+++ b/custom_components/horticulture_assistant/utils/irrigation_schedule.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Utilities for parsing irrigation schedule preferences."""
+
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional
+
+__all__ = ["Schedule", "parse_schedule"]
+
+
+@dataclass(slots=True)
+class Schedule:
+    """Representation of an irrigation schedule."""
+
+    method: str
+    time: Optional[str] = None
+    duration_min: Optional[float] = None
+    volume_l: Optional[float] = None
+    target_moisture_pct: Optional[float] = None
+    pulses: Optional[Dict[str, List[str]]] = None
+
+    def as_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def parse_schedule(data: Dict[str, object]) -> Schedule:
+    """Return :class:`Schedule` parsed from ``data``."""
+
+    method = str(data.get("method")) if data.get("method") else ""
+    schedule = Schedule(method=method)
+    schedule.time = data.get("time")
+    try:
+        schedule.duration_min = float(data["duration_min"])
+    except Exception:
+        pass
+    try:
+        schedule.volume_l = float(data["volume_l"])
+    except Exception:
+        pass
+    try:
+        schedule.target_moisture_pct = float(data["target_moisture_pct"])
+    except Exception:
+        pass
+    pulses = data.get("pulses")
+    if isinstance(pulses, dict):
+        parsed: Dict[str, List[str]] = {}
+        for phase, times in pulses.items():
+            if isinstance(times, list):
+                parsed[phase] = [str(t) for t in times]
+        schedule.pulses = parsed or None
+    return schedule
+

--- a/custom_components/horticulture_assistant/utils/profile_generator.py
+++ b/custom_components/horticulture_assistant/utils/profile_generator.py
@@ -90,7 +90,8 @@ def generate_profile(metadata: dict, hass: 'HomeAssistant' = None, overwrite: bo
         "plant_type": _slugify(str(plant_type_val)) if plant_type_val else "TBD",
         "cultivar": _slugify(str(cultivar_val)) if cultivar_val else "TBD",
         "species": species_val if species_val else "TBD",
-        "location": location_val if location_val else "TBD"
+        "location": location_val if location_val else "TBD",
+        "zone_id": metadata.get("zone_id") or None,
     }
     if "start_date" in metadata:
         general_data["start_date"] = metadata["start_date"]

--- a/custom_components/horticulture_assistant/utils/validate_profile_structure.py
+++ b/custom_components/horticulture_assistant/utils/validate_profile_structure.py
@@ -28,7 +28,7 @@ def validate_profile_structure(plant_id: str, base_path: str = None, verbose: bo
     # Define expected keys for each known profile file
     expected_keys = {
         "general.json": {"plant_id", "display_name", "plant_type", "cultivar", "species", "location",
-                         "lifecycle_stage", "auto_lifecycle_mode", "auto_approve_all", "tags",
+                         "zone_id", "lifecycle_stage", "auto_lifecycle_mode", "auto_approve_all", "tags",
                          "sensor_entities", "actuator_entities", "start_date"},
         "environment.json": {"light", "temperature", "humidity", "hardiness_zone", "EC", "pH"},
         "nutrition.json": {"leaf_nitrogen_ppm", "leaf_phosphorus_ppm", "leaf_potassium_ppm", "leaf_calcium_ppm",

--- a/custom_components/horticulture_assistant/utils/zone_registry.py
+++ b/custom_components/horticulture_assistant/utils/zone_registry.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+"""Helpers for managing irrigation zone definitions."""
+
+from dataclasses import dataclass, asdict
+from functools import lru_cache
+from typing import Dict, List, Optional
+
+from .json_io import load_json, save_json
+from .path_utils import config_path
+
+ZONE_REGISTRY_FILE = "zones.json"
+
+__all__ = [
+    "ZoneConfig",
+    "load_zones",
+    "get_zone",
+    "list_zones",
+    "save_zones",
+    "add_zone",
+    "attach_plants",
+    "detach_plants",
+    "attach_solenoids",
+    "detach_solenoids",
+]
+
+
+@dataclass(slots=True)
+class ZoneConfig:
+    """Configuration for an irrigation zone."""
+
+    zone_id: str
+    solenoids: List[str]
+    plant_ids: List[str]
+
+    def as_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@lru_cache(maxsize=1)
+def _load_registry(path: str) -> Dict[str, ZoneConfig]:
+    try:
+        raw = load_json(path)
+    except FileNotFoundError:
+        return {}
+    except Exception:  # pragma: no cover - invalid file
+        return {}
+    registry: Dict[str, ZoneConfig] = {}
+    for zid, data in raw.items():
+        sol = data.get("solenoids") or []
+        plants = data.get("plant_ids") or []
+        registry[str(zid)] = ZoneConfig(str(zid), list(sol), list(plants))
+    return registry
+
+
+def load_zones(hass=None) -> Dict[str, ZoneConfig]:
+    """Return mapping of zone_id to :class:`ZoneConfig`."""
+
+    path = config_path(hass, ZONE_REGISTRY_FILE)
+    return _load_registry(path)
+
+
+def get_zone(zone_id: str, hass=None) -> Optional[ZoneConfig]:
+    """Return zone configuration for ``zone_id`` if available."""
+
+    zones = load_zones(hass)
+    return zones.get(str(zone_id))
+
+
+def list_zones(hass=None) -> List[str]:
+    """Return all known zone IDs sorted alphabetically."""
+
+    return sorted(load_zones(hass).keys())
+
+
+def save_zones(zones: Dict[str, ZoneConfig], hass=None) -> bool:
+    """Persist ``zones`` to ``zones.json``."""
+
+    path = config_path(hass, ZONE_REGISTRY_FILE)
+    data = {zid: zone.as_dict() for zid, zone in zones.items()}
+    try:
+        save_json(path, data)
+    except Exception:  # pragma: no cover - unexpected write errors
+        return False
+    _load_registry.cache_clear()
+    return True
+
+
+def add_zone(zone_id: str, solenoids: List[str] | None = None,
+             plant_ids: List[str] | None = None, hass=None) -> bool:
+    """Add a new irrigation zone and persist it.
+
+    Returns ``False`` if the zone already exists.
+    """
+
+    zones = load_zones(hass)
+    if str(zone_id) in zones:
+        return False
+    zones[str(zone_id)] = ZoneConfig(
+        str(zone_id), list(solenoids or []), list(plant_ids or [])
+    )
+    return save_zones(zones, hass)
+
+
+def attach_plants(zone_id: str, plant_ids: List[str], hass=None) -> bool:
+    """Attach ``plant_ids`` to ``zone_id`` and persist the registry."""
+
+    zones = load_zones(hass)
+    zone = zones.get(str(zone_id))
+    if not zone:
+        return False
+    for pid in plant_ids:
+        if pid not in zone.plant_ids:
+            zone.plant_ids.append(pid)
+    return save_zones(zones, hass)
+
+
+def detach_plants(zone_id: str, plant_ids: List[str], hass=None) -> bool:
+    """Remove ``plant_ids`` from ``zone_id`` and persist the registry."""
+
+    zones = load_zones(hass)
+    zone = zones.get(str(zone_id))
+    if not zone:
+        return False
+    zone.plant_ids = [pid for pid in zone.plant_ids if pid not in plant_ids]
+    return save_zones(zones, hass)
+
+
+def attach_solenoids(zone_id: str, solenoids: List[str], hass=None) -> bool:
+    """Attach ``solenoids`` to ``zone_id`` and persist the registry."""
+
+    zones = load_zones(hass)
+    zone = zones.get(str(zone_id))
+    if not zone:
+        return False
+    for sid in solenoids:
+        if sid not in zone.solenoids:
+            zone.solenoids.append(sid)
+    return save_zones(zones, hass)
+
+
+def detach_solenoids(zone_id: str, solenoids: List[str], hass=None) -> bool:
+    """Remove ``solenoids`` from ``zone_id`` and persist the registry."""
+
+    zones = load_zones(hass)
+    zone = zones.get(str(zone_id))
+    if not zone:
+        return False
+    zone.solenoids = [sid for sid in zone.solenoids if sid not in solenoids]
+    return save_zones(zones, hass)
+

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -83,10 +83,11 @@ def test_full_flow(monkeypatch):
 
     flow = Flow()
     flow.hass = object()
-    result = asyncio.run(flow.async_step_user({"plant_name": "Tomato"}))
+    result = asyncio.run(flow.async_step_user({"plant_name": "Tomato", "zone_id": "4"}))
     assert result["type"] == "create_entry"
     assert flow.created_entry["data"]["plant_name"] == "Tomato"
     assert recorded["plant_name"] == "Tomato"
+    assert recorded["zone_id"] == "4"
     assert recorded["hass"] is flow.hass
     assert flow.created_entry["data"]["plant_id"] == "pid42"
     assert flow.created_entry["data"]["profile_generated"] is True

--- a/tests/test_irrigation_schedule.py
+++ b/tests/test_irrigation_schedule.py
@@ -1,0 +1,28 @@
+from custom_components.horticulture_assistant.utils.irrigation_schedule import (
+    Schedule,
+    parse_schedule,
+)
+
+
+def test_parse_schedule_basic():
+    data = {
+        "method": "time_pattern",
+        "time": "06:00",
+        "duration_min": 15,
+    }
+    sched = parse_schedule(data)
+    assert sched.method == "time_pattern"
+    assert sched.time == "06:00"
+    assert sched.duration_min == 15
+    assert sched.volume_l is None
+    assert sched.pulses is None
+
+
+def test_parse_schedule_pulsed():
+    data = {
+        "method": "pulsed",
+        "pulses": {"p1": ["08:00", "08:30"], "p2": ["12:00"]},
+    }
+    sched = parse_schedule(data)
+    assert sched.pulses == {"p1": ["08:00", "08:30"], "p2": ["12:00"]}
+

--- a/tests/test_zone_registry.py
+++ b/tests/test_zone_registry.py
@@ -1,0 +1,66 @@
+from custom_components.horticulture_assistant.utils.zone_registry import (
+    ZoneConfig,
+    load_zones,
+    get_zone,
+    list_zones,
+    save_zones,
+    add_zone,
+    attach_plants,
+    detach_plants,
+    attach_solenoids,
+    detach_solenoids,
+)
+
+
+def test_zone_registry_roundtrip(tmp_path, monkeypatch):
+    data = {
+        "1": {"solenoids": ["a"], "plant_ids": ["p1"]},
+        "2": {"solenoids": ["b", "c"], "plant_ids": []},
+    }
+    file_path = tmp_path / "zones.json"
+    file_path.write_text("{}")
+
+    def fake_config_path(hass, *parts):
+        return str(file_path)
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.utils.zone_registry.config_path",
+        fake_config_path,
+    )
+
+    zones = {zid: ZoneConfig(zid, info["solenoids"], info["plant_ids"]) for zid, info in data.items()}
+    assert save_zones(zones)
+    loaded = load_zones()
+    assert set(loaded.keys()) == {"1", "2"}
+    assert get_zone("1").solenoids == ["a"]
+    assert list_zones() == ["1", "2"]
+
+
+def test_zone_registry_modify(tmp_path, monkeypatch):
+    file_path = tmp_path / "zones.json"
+    file_path.write_text("{}")
+
+    def fake_config_path(hass, *parts):
+        return str(file_path)
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.utils.zone_registry.config_path",
+        fake_config_path,
+    )
+
+    assert add_zone("3", ["x"], ["p3"])
+    zones = load_zones()
+    assert zones["3"].plant_ids == ["p3"]
+
+    assert attach_plants("3", ["p4", "p5"])
+    assert sorted(load_zones()["3"].plant_ids) == ["p3", "p4", "p5"]
+
+    assert detach_plants("3", ["p4"])
+    assert load_zones()["3"].plant_ids == ["p3", "p5"]
+
+    assert attach_solenoids("3", ["y"])
+    assert load_zones()["3"].solenoids == ["x", "y"]
+
+    assert detach_solenoids("3", ["x"])
+    assert load_zones()["3"].solenoids == ["y"]
+

--- a/zones.json
+++ b/zones.json
@@ -1,0 +1,11 @@
+{
+  "1": {
+    "solenoids": ["switch.zone1_valve_a", "switch.zone1_valve_b"],
+    "plant_ids": []
+  },
+  "2": {
+    "solenoids": ["switch.zone2_valve"],
+    "plant_ids": []
+  }
+}
+


### PR DESCRIPTION
## Summary
- allow specifying `zone_id` when creating a plant entry
- capture `zone_id` in generated profiles and validation helper
- document zone option in Quick Start and zone section
- extend `test_config_flow` for new zone field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68857902985c83308c2e507a83eda3ff