### PR TITLE
Improve environment normalization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -64,6 +64,13 @@ ENV_ALIASES = {
     "soil_temp_f": ["soil_temp_f", "soil_temp_fahrenheit"],
     # Kelvin readings are converted to Celsius during normalization
     "soil_temp_k": ["soil_temp_k", "soil_temperature_k", "soil_temp_kelvin"],
+    # Leaf temperature aliases with unit variants
+    "leaf_temp_c": ["leaf_temp_c", "leaf_temp", "leaf_temperature"],
+    "leaf_temp_f": ["leaf_temp_f", "leaf_temp_fahrenheit"],
+    "leaf_temp_k": ["leaf_temp_k", "leaf_temp_kelvin"],
+    # Additional common names
+    "dli": ["dli", "daily_light_integral"],
+    "photoperiod_hours": ["photoperiod_hours", "photoperiod", "day_length"],
 }
 
 # reverse mapping for constant time alias lookups
@@ -202,10 +209,10 @@ def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, f
             val = float(value)
         except (TypeError, ValueError):
             continue
-        if canonical in {"temp_f", "soil_temp_f"}:
+        if canonical in {"temp_f", "soil_temp_f", "leaf_temp_f"}:
             val = (val - 32) * 5 / 9
             canonical = canonical.replace("_f", "_c")
-        elif canonical in {"temp_k", "soil_temp_k"}:
+        elif canonical in {"temp_k", "soil_temp_k", "leaf_temp_k"}:
             val = val - 273.15
             canonical = canonical.replace("_k", "_c")
         normalized[canonical] = val

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -561,6 +561,22 @@ def test_normalize_environment_readings_soil_temp_kelvin():
     assert result == {"soil_temp_c": 25.0}
 
 
+def test_normalize_environment_readings_leaf_temp_aliases():
+    data = {"leaf_temp": 27, "leaf_temp_f": 86, "leaf_temp_k": 300}
+    result = normalize_environment_readings(data)
+    assert "leaf_temp_c" in result
+    assert result["leaf_temp_c"] == pytest.approx(26.85, rel=1e-2)
+
+
+def test_normalize_environment_readings_light_aliases():
+    data = {"daily_light_integral": 18, "photoperiod": 14}
+    result = normalize_environment_readings(data)
+    assert result == {
+        "dli": 18.0,
+        "photoperiod_hours": 14.0,
+    }
+
+
 def test_normalize_environment_readings_unknown_key():
     result = normalize_environment_readings({"foo": 1})
     assert result == {"foo": 1.0}


### PR DESCRIPTION
## Summary
- support new aliases for leaf temperature, DLI, and photoperiod readings
- convert leaf temperature values from Fahrenheit and Kelvin
- test new alias normalization coverage

## Testing
- `pytest -k normalize_environment_readings -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688582c34f0883308fa57be52036d6a3