### PR TITLE
Add YAML dataset support and environment tips

### DIFF
--- a/data/environment_tips.yaml
+++ b/data/environment_tips.yaml
@@ -1,0 +1,6 @@
+citrus:
+  high_temp: "Provide shade cloth to reduce temperature"
+  low_humidity: "Use misting system to increase humidity"
+tomato:
+  high_temp: "Increase ventilation and shading"
+  low_nutrients: "Apply balanced fertilizer" 

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from importlib import import_module
 
-from . import utils
+from . import utils, environment_tips
 from .utils import *  # noqa: F401,F403
+from .environment_tips import *  # noqa: F401,F403
 
-__all__ = sorted(set(utils.__all__))
+__all__ = sorted(set(utils.__all__) | set(environment_tips.__all__))
 
 
 def __getattr__(name: str):

--- a/plant_engine/environment_tips.py
+++ b/plant_engine/environment_tips.py
@@ -1,0 +1,30 @@
+"""Access to general environment management tips."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "environment_tips.yaml"
+
+# cached dataset
+_DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_environment_tips",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with environment tips defined."""
+    return list_dataset_entries(_DATA)
+
+
+@lru_cache(maxsize=None)
+def get_environment_tips(plant_type: str) -> Dict[str, str]:
+    """Return environment management tips for ``plant_type``."""
+    return _DATA.get(normalize_key(plant_type), {})
+

--- a/tests/test_environment_tips.py
+++ b/tests/test_environment_tips.py
@@ -1,0 +1,12 @@
+from plant_engine.environment_tips import get_environment_tips, list_supported_plants
+
+
+def test_environment_tips_basic():
+    tips = get_environment_tips("citrus")
+    assert tips["high_temp"].startswith("Provide shade")
+    assert "citrus" in list_supported_plants()
+
+
+def test_environment_tips_unknown():
+    assert get_environment_tips("unknown") == {}
+

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,0 +1,22 @@
+import json
+import pytest
+from plant_engine.utils import load_data
+
+
+def test_load_yaml(tmp_path):
+    path = tmp_path / "sample.yaml"
+    path.write_text("a: 1\nb: 2\n")
+    assert load_data(str(path)) == {"a": 1, "b": 2}
+
+
+def test_load_data_invalid_yaml(tmp_path):
+    path = tmp_path / "bad.yaml"
+    path.write_text("- [unterminated")
+    with pytest.raises(ValueError):
+        load_data(str(path))
+
+
+def test_load_data_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_data(str(tmp_path / 'none.yaml'))
+


### PR DESCRIPTION
## Summary
- support YAML files in dataset utilities
- expose environment_tips helper module and dataset
- update dataset catalog to detect YAML files
- export new helpers from plant_engine
- add tests for YAML loader and environment tips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688582c5f24c83309af9593aa0db545f