### PR TITLE
Add nutrient balance series calculation

### DIFF
--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -35,6 +35,7 @@ __all__ = [
     "calculate_surplus",
     "calculate_all_surplus",
     "calculate_all_nutrient_balance",
+    "calculate_nutrient_balance_series",
     "get_npk_ratio",
     "get_stage_ratio",
     "get_nutrient_weight",
@@ -302,6 +303,25 @@ def calculate_all_nutrient_balance(
             continue
         ratios[nutrient] = round(current / target, 2)
     return ratios
+
+
+def calculate_nutrient_balance_series(
+    series: Iterable[Mapping[str, float]], plant_type: str, stage: str
+) -> Dict[str, float]:
+    """Return average nutrient balance ratios for a sequence of readings."""
+
+    totals: Dict[str, float] = {}
+    count = 0
+    for levels in series:
+        ratios = calculate_nutrient_balance(dict(levels), plant_type, stage)
+        for nutrient, value in ratios.items():
+            totals[nutrient] = totals.get(nutrient, 0.0) + value
+        count += 1
+
+    if count == 0:
+        return {}
+
+    return {n: round(v / count, 2) for n, v in totals.items()}
 
 
 def get_ph_adjusted_levels(plant_type: str, stage: str, ph: float) -> Dict[str, float]:

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -192,3 +192,21 @@ def test_calculate_deficiency_index():
 
     index2 = calculate_deficiency_index(guidelines, "tomato", "fruiting")
     assert index2 == 0.0
+
+
+def test_calculate_nutrient_balance_series():
+    from plant_engine.nutrient_manager import calculate_nutrient_balance_series
+
+    s1 = {"N": 80, "P": 60, "K": 120}
+    s2 = {"N": 60, "P": 50, "K": 100}
+    avg = calculate_nutrient_balance_series([s1, s2], "tomato", "fruiting")
+    r1 = calculate_nutrient_balance(s1, "tomato", "fruiting")
+    r2 = calculate_nutrient_balance(s2, "tomato", "fruiting")
+    expected = {k: round((r1[k] + r2[k]) / 2, 2) for k in r1}
+    assert avg == expected
+
+
+def test_calculate_nutrient_balance_series_empty():
+    from plant_engine.nutrient_manager import calculate_nutrient_balance_series
+
+    assert calculate_nutrient_balance_series([], "tomato", "fruiting") == {}


### PR DESCRIPTION
## Summary
- add calculate_nutrient_balance_series API to nutrient_manager
- test nutrient balance series helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688582c8230c8330a95bb2b1aba93dea