### PR TITLE
Add pest scouting method dataset and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Important categories include:
 - **Environment actions** – recommended steps when temperature or humidity are out of range
 - **Nutrient guidelines** – macronutrient and micronutrient targets by stage
 - **Pest and disease references** – thresholds, prevention tips and treatment options
+- **Pest scouting methods** – recommended techniques for monitoring common pests
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -11,6 +11,7 @@
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",
   "pest_monitoring_intervals.json": "Recommended days between scouting events.",
   "pest_risk_interval_modifiers.json": "Multipliers adjusting monitoring frequency based on risk level.",
+  "pest_scouting_methods.json": "Recommended scouting techniques for common pests.",
   "ipm_guidelines.json": "Integrated pest management practices by crop.",
   "disease_guidelines.json": "Treatment guidance for common plant diseases.",
   "disease_prevention.json": "Preventative measures to reduce disease incidence.",

--- a/data/pest_scouting_methods.json
+++ b/data/pest_scouting_methods.json
@@ -1,0 +1,5 @@
+{
+  "aphids": "Inspect underside of leaves for clusters and honeydew; observe ant activity as an indicator.",
+  "mites": "Shake foliage over white paper and examine with a hand lens for moving specks.",
+  "thrips": "Use blue sticky traps and tap flowers or leaves to dislodge adults for counting."
+}

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -23,6 +23,7 @@ SEVERITY_ACTIONS_FILE = "pest_severity_actions.json"
 MONITOR_INTERVAL_FILE = "pest_monitoring_intervals.json"
 # Adjustment factors for risk-based interval modifications
 RISK_INTERVAL_MOD_FILE = "pest_risk_interval_modifiers.json"
+SCOUTING_METHOD_FILE = "pest_scouting_methods.json"
 
 # Load once with caching
 _THRESHOLDS: Dict[str, Dict[str, int]] = load_dataset(DATA_FILE)
@@ -30,6 +31,7 @@ _RISK_FACTORS: Dict[str, Dict[str, Dict[str, list]]] = load_dataset(RISK_DATA_FI
 _SEVERITY_ACTIONS: Dict[str, str] = load_dataset(SEVERITY_ACTIONS_FILE)
 _MONITOR_INTERVALS: Dict[str, Dict[str, int]] = load_dataset(MONITOR_INTERVAL_FILE)
 _RISK_MODIFIERS: Dict[str, float] = load_dataset(RISK_INTERVAL_MOD_FILE)
+_SCOUTING_METHODS: Dict[str, str] = load_dataset(SCOUTING_METHOD_FILE)
 
 __all__ = [
     "list_supported_plants",
@@ -43,6 +45,7 @@ __all__ = [
     "adjust_risk_with_resistance",
     "estimate_adjusted_pest_risk",
     "generate_pest_report",
+    "get_scouting_method",
     "get_severity_action",
     "get_monitoring_interval",
     "risk_adjusted_monitor_interval",
@@ -121,6 +124,12 @@ def get_severity_action(level: str) -> str:
     """Return recommended action for a severity ``level``."""
 
     return _SEVERITY_ACTIONS.get(level.lower(), "")
+
+
+def get_scouting_method(pest: str) -> str:
+    """Return recommended scouting approach for ``pest``."""
+
+    return _SCOUTING_METHODS.get(normalize_key(pest), "")
 
 
 def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -13,6 +13,7 @@ from plant_engine.pest_monitor import (
     next_monitor_date,
     generate_monitoring_schedule,
     risk_adjusted_monitor_interval,
+    get_scouting_method,
     summarize_pest_management,
 )
 
@@ -139,4 +140,9 @@ def test_summarize_pest_management():
     assert summary["severity"]["aphids"] in {"moderate", "severe"}
     assert summary["risk"]["aphids"] == "high"
     assert "next_monitor_date" in summary
+
+
+def test_get_scouting_method():
+    method = get_scouting_method("mites")
+    assert "paper" in method
 


### PR DESCRIPTION
## Summary
- add `pest_scouting_methods.json` dataset
- expose `get_scouting_method` in `pest_monitor`
- document pest scouting methods dataset
- test new helper

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688582ca02108330baceda5e1dc0a623