### PR TITLE
Add default EC model dataset with caching

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -40,6 +40,7 @@
   "crop_coefficient_modifiers.json": "Environmental adjustment factors for crop coefficients.",
   "disease_thresholds.json": "Severity thresholds triggering treatments.",
   "ec_guidelines.json": "Electrical conductivity ranges for nutrient solutions.",
+  "ec_model_defaults.json": "Default coefficients for EC estimation model.",
   "fertilizer_purity.json": "Nutrient purity factors for fertilizer products.",
   "fertilizer_solubility.json": "Solubility limits for common fertilizers.",
   "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",

--- a/data/ec_model_defaults.json
+++ b/data/ec_model_defaults.json
@@ -1,0 +1,9 @@
+{
+  "intercept": 0.0,
+  "coeffs": {
+    "moisture": 0.02,
+    "temperature": 0.05,
+    "irrigation_ml": 0.001,
+    "solution_ec": 0.8
+  }
+}


### PR DESCRIPTION
## Summary
- provide default coefficients for EC estimator via `ec_model_defaults.json`
- cache `load_model` results for efficiency and expose `clear_model_cache`
- clear cache when saving a model
- document new dataset in catalog
- test new dataset loading and caching logic

## Testing
- `pytest tests/test_ec_estimator.py::test_default_model_dataset tests/test_ec_estimator.py::test_load_model_cache -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688582cda6c08330a94ac1dac7c087df