### PR TITLE
Improve leaching module with cumulative calculations

### DIFF
--- a/tests/test_nutrient_leaching.py
+++ b/tests/test_nutrient_leaching.py
@@ -1,7 +1,11 @@
+import pytest
+
 from plant_engine.nutrient_leaching import (
     get_leaching_rate,
     estimate_leaching_loss,
     compensate_for_leaching,
+    estimate_cumulative_leaching_loss,
+    project_levels_after_leaching,
 )
 
 
@@ -21,3 +25,17 @@ def test_estimate_leaching_loss():
 def test_compensate_for_leaching():
     adjusted = compensate_for_leaching({"K": 100})
     assert adjusted == {"K": 115.0}
+
+
+def test_estimate_cumulative_leaching_loss():
+    losses = estimate_cumulative_leaching_loss({"N": 100}, "tomato", 3)
+    expected = 100 * (1 - (1 - 0.25) ** 3)
+    assert round(losses["N"], 2) == round(expected, 2)
+    with pytest.raises(ValueError):
+        estimate_cumulative_leaching_loss({"N": 100}, "tomato", 0)
+
+
+def test_project_levels_after_leaching():
+    remaining = project_levels_after_leaching({"N": 100}, "lettuce", 2)
+    expected = 100 * (1 - 0.15) ** 2
+    assert round(remaining["N"], 2) == round(expected, 2)


### PR DESCRIPTION
## Summary
- extend `nutrient_leaching` with helpers to estimate cumulative leaching
- expose new functions via `__all__`
- add tests for cumulative leaching calculations

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_nutrient_leaching.py::test_estimate_cumulative_leaching_loss -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688582d1545c8330b231e4e7fcea9272