### PR TITLE
Add growth stage summary utility

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -32,6 +32,7 @@ __all__ = [
     "predict_stage_end_date",
     "stage_progress_from_dates",
     "get_germination_duration",
+    "growth_stage_summary",
 ]
 
 
@@ -239,3 +240,37 @@ def get_germination_duration(plant_type: str) -> int | None:
     if isinstance(value, (int, float)):
         return int(value)
     return None
+
+
+def growth_stage_summary(
+    plant_type: str, start_date: date | None = None
+) -> Dict[str, Any]:
+    """Return growth stage durations and optional harvest date."""
+
+    stages = list_growth_stages(plant_type)
+    summary = [
+        {
+            "stage": stage,
+            "duration_days": get_stage_duration(plant_type, stage),
+        }
+        for stage in stages
+    ]
+
+    result = {"plant_type": plant_type, "stages": summary}
+
+    total = get_total_cycle_duration(plant_type)
+    if total is not None:
+        result["total_cycle_days"] = total
+
+    germ = get_germination_duration(plant_type)
+    if germ is not None:
+        result["germination_days"] = germ
+
+    if start_date and total is not None:
+        result["predicted_harvest_date"] = start_date + timedelta(days=total)
+    elif start_date:
+        harvest = predict_harvest_date(plant_type, start_date)
+        if harvest:
+            result["predicted_harvest_date"] = harvest
+
+    return result

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -15,6 +15,7 @@ from plant_engine.growth_stage import (
     stage_progress_from_dates,
     get_germination_duration,
     days_until_next_stage,
+    growth_stage_summary,
 )
 
 
@@ -130,5 +131,19 @@ def test_stage_progress_from_dates():
 
     with pytest.raises(ValueError):
         stage_progress_from_dates("tomato", "seedling", current, start)
+
+
+def test_growth_stage_summary():
+    start = date(2025, 1, 1)
+    summary = growth_stage_summary("tomato", start)
+    assert summary["total_cycle_days"] == 120
+    assert summary["predicted_harvest_date"] == date(2025, 5, 1)
+    stages = {item["stage"]: item["duration_days"] for item in summary["stages"]}
+    assert stages["seedling"] == 30
+
+
+def test_growth_stage_summary_unknown():
+    result = growth_stage_summary("unknown")
+    assert result["stages"] == []
 
 


### PR DESCRIPTION
## Summary
- add `growth_stage_summary` helper for summarising growth stages
- test new helper in growth stage tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688582d58e708330be0253a75bd47a2e