### PR TITLE
Add fertilizer compatibility checks and dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Important categories include:
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions
+- **Fertilizer compatibility** – warnings for mixing products that react poorly
 - **Soil pH guidelines** – optimal soil pH ranges for supported crops
 
 The WSDA fertilizer dataset resides under `feature/wsda_refactored_sharded/` which contains an

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -93,6 +93,7 @@
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
   "fertilizers/fertilizer_application_methods.json": "Recommended application methods for each fertilizer product.",
   "fertilizers/fertilizer_application_rates.json": "Recommended grams per liter of fertilizer product.",
+  "fertilizers/fertilizer_compatibility.json": "Compatibility warnings for mixing fertilizer products.",
   "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
   "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
   "canopy_area.json": "Approximate canopy area (m²) per plant stage.",

--- a/data/fertilizers/fertilizer_compatibility.json
+++ b/data/fertilizers/fertilizer_compatibility.json
@@ -1,0 +1,9 @@
+{
+  "calcium_nitrate": {
+    "magnesium_sulfate": "precipitation risk",
+    "potassium_phosphate": "insoluble reaction"
+  },
+  "magnesium_sulfate": {
+    "calcium_nitrate": "precipitation risk"
+  }
+}

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -29,6 +29,7 @@ calculate_mix_ppm = fert_mod.calculate_mix_ppm
 calculate_mix_density = fert_mod.calculate_mix_density
 estimate_solution_mass = fert_mod.estimate_solution_mass
 check_solubility_limits = fert_mod.check_solubility_limits
+check_schedule_compatibility = fert_mod.check_schedule_compatibility
 estimate_cost_per_nutrient = fert_mod.estimate_cost_per_nutrient
 calculate_fertilizer_ppm = fert_mod.calculate_fertilizer_ppm
 calculate_mass_for_target_ppm = fert_mod.calculate_mass_for_target_ppm
@@ -181,6 +182,16 @@ def test_check_solubility_limits():
 
     with pytest.raises(ValueError):
         check_solubility_limits(schedule, 0)
+
+
+def test_check_schedule_compatibility():
+    schedule = {
+        "calcium_nitrate": 10,
+        "magnesium_sulfate": 5,
+    }
+    issues = check_schedule_compatibility(schedule)
+    assert "calcium_nitrate" in issues
+    assert "magnesium_sulfate" in issues["calcium_nitrate"]
 
 
 def test_estimate_cost_per_nutrient():


### PR DESCRIPTION
## Summary
- add fertilizer compatibility dataset and expose loader
- provide `check_schedule_compatibility` helper
- document new compatibility dataset in README
- test fertilizer compatibility logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_fertilizer_formulator.py::test_check_schedule_compatibility -q`

------
https://chatgpt.com/codex/tasks/task_e_688582d8e3248330acf377c31191f6f1