### PR TITLE
Enhance nutrient tools

### DIFF
--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -48,6 +48,7 @@ __all__ = [
     "calculate_deficiencies_with_ph",
     "get_all_ph_adjusted_levels",
     "calculate_all_deficiencies_with_ph",
+    "calculate_cycle_deficiency_index",
 ]
 
 
@@ -469,5 +470,17 @@ def apply_tag_modifiers(
             except (TypeError, ValueError):
                 continue
     return adjusted
+
+
+def calculate_cycle_deficiency_index(
+    stage_levels: Mapping[str, Mapping[str, float]],
+    plant_type: str,
+) -> Dict[str, float]:
+    """Return deficiency index for each growth stage in a cycle."""
+
+    results: Dict[str, float] = {}
+    for stage, levels in stage_levels.items():
+        results[stage] = calculate_deficiency_index(levels, plant_type, stage)
+    return results
 
 

--- a/tests/test_cycle_deficiency_index.py
+++ b/tests/test_cycle_deficiency_index.py
@@ -1,0 +1,13 @@
+import pytest
+from plant_engine.nutrient_manager import calculate_cycle_deficiency_index
+
+
+def test_calculate_cycle_deficiency_index():
+    levels = {
+        "vegetative": {"N": 50, "P": 40, "K": 60, "Ca": 30, "Mg": 20, "Fe": 0.5, "Mn": 0.2, "Zn": 0.1},
+        "fruiting": {"N": 60, "P": 50, "K": 100, "Ca": 40, "Mg": 25, "Fe": 0.5, "Mn": 0.2, "Zn": 0.1},
+    }
+    result = calculate_cycle_deficiency_index(levels, "tomato")
+    assert set(result.keys()) == {"vegetative", "fruiting"}
+    assert pytest.approx(result["vegetative"], rel=1e-2) == 49.0
+    assert pytest.approx(result["fruiting"], rel=1e-2) == 45.1


### PR DESCRIPTION
## Summary
- expose cycle-level deficiency index API
- test cycle deficiency calculations

## Testing
- `pytest tests/test_cycle_deficiency_index.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688582dad40c8330b2727f7d43190429