### PR TITLE
Add water blend utilities

### DIFF
--- a/tests/test_water_quality.py
+++ b/tests/test_water_quality.py
@@ -50,3 +50,22 @@ def test_summarize_water_profile():
     assert summary["baseline"]["Na"] == 60
     assert "Na" in summary["warnings"]
     assert "score" in summary
+
+
+def test_blend_water_profiles():
+    from plant_engine import water_quality
+
+    a = {"Na": 80, "Cl": 80}
+    b = {"Na": 20, "Cl": 20}
+    blend = water_quality.blend_water_profiles(a, b, 0.5)
+    assert blend["Na"] == 50
+    assert blend["Cl"] == 50
+
+
+def test_max_safe_blend_ratio():
+    from plant_engine import water_quality
+
+    a = {"Na": 80, "Cl": 80}
+    b = {"Na": 20, "Cl": 20}
+    ratio = water_quality.max_safe_blend_ratio(a, b)
+    assert 0.49 <= ratio <= 0.51


### PR DESCRIPTION
## Summary
- extend `water_quality` module with functions to blend water profiles
- expose the new utilities via the public API
- test blending helpers

## Testing
- `pytest tests/test_water_quality.py::test_blend_water_profiles -q`
- `pytest tests/test_water_quality.py::test_max_safe_blend_ratio -q`
- `pytest tests/test_water_quality.py -q`
- `pytest tests/test_environment_manager.py::test_summarize_environment_with_water_quality -q`


------
https://chatgpt.com/codex/tasks/task_e_688582e08050833080ea84ee53d69ac6