### PR TITLE
Improve sensor map utilities and profile loader

### DIFF
--- a/custom_components/horticulture_assistant/utils/sensor_map.py
+++ b/custom_components/horticulture_assistant/utils/sensor_map.py
@@ -14,7 +14,7 @@ DEFAULT_SENSORS = {
     "co2_sensors": "sensor.{plant_id}_raw_co2",
 }
 
-__all__ = ["build_sensor_map", "DEFAULT_SENSORS"]
+__all__ = ["build_sensor_map", "merge_sensor_maps", "DEFAULT_SENSORS"]
 
 
 def build_sensor_map(
@@ -35,3 +35,22 @@ def build_sensor_map(
             entry_data.get(key), default.format(plant_id=plant_id)
         )
     return result
+
+
+def merge_sensor_maps(
+    base: Mapping[str, Iterable[str]], update: Mapping[str, Iterable[str]]
+) -> Dict[str, list[str]]:
+    """Return ``base`` merged with ``update`` with duplicates removed."""
+
+    merged: Dict[str, list[str]] = {k: list(v) for k, v in base.items()}
+    for key, values in update.items():
+        if not values:
+            continue
+        if isinstance(values, str):
+            values = [values]
+        existing = merged.get(key, [])
+        for item in values:
+            if item not in existing:
+                existing.append(item)
+        merged[key] = existing
+    return merged

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -40,6 +40,12 @@ def test_load_profile_from_yaml(tmp_path):
     assert profile["stages"]["seedling"]["stage_duration"] == 14
 
 
+def test_parse_basic_yaml():
+    content = "a: 1\nb:\n  c: 2\n  d: [3, 4]"
+    result = loader.parse_basic_yaml(content)
+    assert result == {"a": 1, "b": {"c": 2, "d": [3, 4]}}
+
+
 def test_load_profile_by_id_custom_dir(tmp_path):
     plants = tmp_path / "plants"
     plants.mkdir()

--- a/tests/test_sensor_map.py
+++ b/tests/test_sensor_map.py
@@ -8,7 +8,11 @@ ha.core.HomeAssistant = object
 sys.modules.setdefault("homeassistant", ha)
 sys.modules.setdefault("homeassistant.core", ha.core)
 
-from custom_components.horticulture_assistant.utils.sensor_map import build_sensor_map, DEFAULT_SENSORS
+from custom_components.horticulture_assistant.utils.sensor_map import (
+    build_sensor_map,
+    merge_sensor_maps,
+    DEFAULT_SENSORS,
+)
 
 
 def test_build_sensor_map_defaults():
@@ -27,3 +31,21 @@ def test_build_sensor_map_custom_entries():
         "moisture_sensors": ["sensor.a", "sensor.b"],
         "ec_sensors": ["sensor.ec1", "sensor.ec2"],
     }
+
+
+def test_merge_sensor_maps():
+    base = {"moisture_sensors": ["a"], "ec_sensors": ["ec1"]}
+    update = {"moisture_sensors": ["b", "a"], "temperature_sensors": ["t1"]}
+    result = merge_sensor_maps(base, update)
+    assert result == {
+        "moisture_sensors": ["a", "b"],
+        "ec_sensors": ["ec1"],
+        "temperature_sensors": ["t1"],
+    }
+
+
+def test_merge_sensor_maps_ignore_empty():
+    base = {"moisture_sensors": ["a"]}
+    update = {"moisture_sensors": []}
+    result = merge_sensor_maps(base, update)
+    assert result == {"moisture_sensors": ["a"]}


### PR DESCRIPTION
## Summary
- add `parse_basic_yaml` for simple YAML parsing
- expose and use `parse_basic_yaml` in profile loader
- add `merge_sensor_maps` utility for combining sensor maps
- test YAML parser and sensor map merging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858608fb5c8330b2b751bd0eacef35