### PR TITLE
Enhance nutrient uptake utilities

### DIFF
--- a/plant_engine/nutrient_uptake.py
+++ b/plant_engine/nutrient_uptake.py
@@ -14,6 +14,7 @@ __all__ = [
     "get_daily_uptake",
     "estimate_stage_totals",
     "estimate_total_uptake",
+    "estimate_average_daily_uptake",
     "get_uptake_ratio",
 ]
 
@@ -75,3 +76,20 @@ def estimate_total_uptake(plant_type: str) -> Dict[str, float]:
         for nutrient, mg in stage_totals.items():
             totals[nutrient] = round(totals.get(nutrient, 0.0) + mg, 2)
     return totals
+
+
+def estimate_average_daily_uptake(plant_type: str) -> Dict[str, float]:
+    """Return average daily nutrient demand for the full crop cycle."""
+
+    totals = estimate_total_uptake(plant_type)
+    if not totals:
+        return {}
+
+    from .growth_stage import get_total_cycle_duration
+
+    days = get_total_cycle_duration(plant_type)
+    if not days:
+        return {}
+
+    return {nutrient: round(mg / days, 2) for nutrient, mg in totals.items()}
+

--- a/tests/test_nutrient_uptake.py
+++ b/tests/test_nutrient_uptake.py
@@ -4,6 +4,7 @@ from plant_engine.nutrient_uptake import (
     list_supported_plants,
     get_daily_uptake,
     get_uptake_ratio,
+    estimate_average_daily_uptake,
 )
 from plant_engine.fertigation import recommend_uptake_fertigation
 
@@ -31,3 +32,8 @@ def test_recommend_uptake_fertigation():
 def test_get_uptake_ratio():
     ratio = get_uptake_ratio("citrus", "vegetative")
     assert ratio == {"N": 0.4, "P": 0.12, "K": 0.48}
+
+
+def test_estimate_average_daily_uptake():
+    avg = estimate_average_daily_uptake("tomato")
+    assert avg == {"N": 51.67, "P": 15.83, "K": 60.0}


### PR DESCRIPTION
## Summary
- add `estimate_average_daily_uptake` helper for nutrient planning
- test average daily uptake calculation

## Testing
- `pytest tests/test_nutrient_uptake.py::test_estimate_average_daily_uptake -q`
- `pytest -k nutrient_uptake -q`

------
https://chatgpt.com/codex/tasks/task_e_68858607a35c83309b6b9fecd98309b9