### PR TITLE
Add risk scoring for pest monitoring

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -113,6 +113,7 @@
   "pesticide_modes.json": "Mode of action classification for common pesticides.",
   "pesticide_rotation_intervals.json": "Recommended days to wait before reusing the same pesticide mode of action.",
   "pesticide_phytotoxicity.json": "Crop-specific phytotoxicity risk levels for pesticide products.",
+  "risk_score_map.json": "Numeric weights for risk level scoring.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",

--- a/data/risk_score_map.json
+++ b/data/risk_score_map.json
@@ -1,0 +1,5 @@
+{
+  "low": 1,
+  "moderate": 2,
+  "high": 3
+}

--- a/tests/test_monitor_utils.py
+++ b/tests/test_monitor_utils.py
@@ -1,6 +1,11 @@
 from datetime import date
 
-from plant_engine.monitor_utils import get_interval, next_date, generate_schedule
+from plant_engine.monitor_utils import (
+    get_interval,
+    next_date,
+    generate_schedule,
+    calculate_risk_score,
+)
 
 DATA = {
     "citrus": {"fruiting": 4, "optimal": 5},
@@ -24,3 +29,9 @@ def test_generate_schedule():
     sched = generate_schedule(DATA, "citrus", "fruiting", start, 3)
     assert sched == [date(2023, 1, 5), date(2023, 1, 9), date(2023, 1, 13)]
     assert generate_schedule(DATA, "unknown", None, start, 2) == []
+
+
+def test_calculate_risk_score():
+    risks = {"a": "low", "b": "high", "c": "moderate"}
+    score = calculate_risk_score(risks)
+    assert 1.0 < score < 3.1

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -139,6 +139,7 @@ def test_summarize_pest_management():
     )
     assert summary["severity"]["aphids"] in {"moderate", "severe"}
     assert summary["risk"]["aphids"] == "high"
+    assert summary.get("risk_score") is not None
     assert "next_monitor_date" in summary
 
 


### PR DESCRIPTION
## Summary
- integrate `risk_score_map.json` into dataset catalog
- add `calculate_risk_score` helper in `monitor_utils`
- include risk score output in pest summaries
- test risk scoring utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858606403083309b48cfaa36ba0833