### PR TITLE
Add nutrient management planner utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Heat, humidity and light stress warnings
 - Stage-adjusted nutrient targets and leaf tissue analysis
 - Nutrient deficiency severity and treatment recommendations
+- Combined nutrient management reports with correction schedules
 - Daily report files summarizing environment and nutrient targets
 - Infiltration-aware irrigation burst scheduling
 - Risk-adjusted pest monitoring summaries and scheduling
@@ -296,7 +297,7 @@ python -m custom_components.horticulture_assistant.analytics.export_all_growth_y
 - Edit `plant_engine/constants.py` to tweak default environment readings or nutrient multipliers when profiles omit them.
 - Call `plant_engine.datasets.refresh_datasets()` if dataset files change.
 - Tag plants (e.g. `"blueberry"`, `"fruiting"`) to generate grouped dashboards and reports.
-- `recommend_nutrient_mix` computes fertilizer grams needed to hit N/P/K targets and can include micronutrients. `recommend_nutrient_mix_with_cost` returns the same schedule with estimated cost.
+- `recommend_nutrient_mix` computes fertilizer grams needed to hit N/P/K targets and can include micronutrients. `recommend_nutrient_mix_with_cost` returns the same schedule with estimated cost. `generate_nutrient_management_report` consolidates analysis and correction grams for a solution volume.
 - `get_pruning_instructions` provides stage-specific pruning tips from `pruning_guidelines.json`.
 - `generate_cycle_irrigation_plan` returns stage irrigation volumes using guideline intervals and durations.
 - `calculate_environment_stddev` computes standard deviation of environment sensor series for tighter control.

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -7,8 +7,17 @@ from importlib import import_module
 from . import utils, environment_tips
 from .utils import *  # noqa: F401,F403
 from .environment_tips import *  # noqa: F401,F403
+from .nutrient_planner import (
+    NutrientManagementReport,
+    generate_nutrient_management_report,
+)
 
-__all__ = sorted(set(utils.__all__) | set(environment_tips.__all__))
+__all__ = sorted(
+    set(utils.__all__) | set(environment_tips.__all__) | {
+        "NutrientManagementReport",
+        "generate_nutrient_management_report",
+    }
+)
 
 
 def __getattr__(name: str):

--- a/plant_engine/nutrient_planner.py
+++ b/plant_engine/nutrient_planner.py
@@ -1,0 +1,57 @@
+"""High level nutrient management recommendations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Dict, Optional
+
+from .nutrient_analysis import analyze_nutrient_profile
+from .fertigation import recommend_correction_schedule
+
+__all__ = ["NutrientManagementReport", "generate_nutrient_management_report"]
+
+
+@dataclass(slots=True)
+class NutrientManagementReport:
+    """Combined nutrient analysis and correction schedule."""
+
+    analysis: Dict[str, object]
+    corrections_g: Dict[str, float]
+
+
+def generate_nutrient_management_report(
+    current_levels: Mapping[str, float],
+    plant_type: str,
+    stage: str,
+    volume_l: float,
+    *,
+    purity: Mapping[str, float] | None = None,
+    product: str | None = None,
+) -> NutrientManagementReport:
+    """Return holistic nutrient report with correction grams.
+
+    Parameters
+    ----------
+    current_levels : Mapping[str, float]
+        Measured nutrient solution in ppm.
+    plant_type : str
+        Crop identifier for guideline lookup.
+    stage : str
+        Growth stage for guideline lookup.
+    volume_l : float
+        Solution volume in liters used to compute corrections.
+    purity : Mapping[str, float], optional
+        Purity fractions per nutrient. Overrides values from ``product``.
+    product : str, optional
+        Fertilizer product identifier for purity lookup.
+    """
+
+    analysis = analyze_nutrient_profile(current_levels, plant_type, stage)
+    corrections = recommend_correction_schedule(
+        current_levels,
+        plant_type,
+        stage,
+        volume_l,
+        purity,
+        product=product,
+    )
+    return NutrientManagementReport(analysis=analysis, corrections_g=corrections)

--- a/tests/test_nutrient_planner.py
+++ b/tests/test_nutrient_planner.py
@@ -1,0 +1,19 @@
+from plant_engine.nutrient_planner import (
+    generate_nutrient_management_report,
+    NutrientManagementReport,
+)
+
+
+def test_generate_nutrient_management_report():
+    current = {"N": 50, "P": 10, "K": 40}
+    report = generate_nutrient_management_report(
+        current,
+        "lettuce",
+        "seedling",
+        volume_l=5.0,
+        purity={"N": 0.2, "P": 0.2, "K": 0.2},
+    )
+    assert isinstance(report, NutrientManagementReport)
+    assert report.analysis["recommended"]["N"] == 80
+    assert report.corrections_g["N"] > 0
+    assert "deficiencies" in report.analysis


### PR DESCRIPTION
## Summary
- add helper to build combined nutrient analysis and correction schedule
- export new helper from plant_engine
- document nutrient management report in README
- test nutrient planner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688585f8de2083309cb8cdbb24ad939e