### PR TITLE
Improve profile loading utilities

### DIFF
--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -27,7 +27,6 @@ SOLUBILITY_FILE = "fertilizer_solubility.json"
 APPLICATION_FILE = "fertilizers/fertilizer_application_methods.json"
 RATE_FILE = "fertilizers/fertilizer_application_rates.json"
 COMPAT_FILE = "fertilizers/fertilizer_compatibility.json"
-COMPAT_FILE = "fertilizers/fertilizer_compatibility.json"
 
 
 @dataclass(frozen=True)

--- a/custom_components/horticulture_assistant/utils/load_all_profiles.py
+++ b/custom_components/horticulture_assistant/utils/load_all_profiles.py
@@ -16,10 +16,11 @@ from custom_components.horticulture_assistant.utils.validate_profile_structure i
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class ProfileLoadResult:
     """Result container for :func:`load_all_profiles`."""
 
+    plant_id: str
     loaded: bool
     profile_data: dict
     issues: dict
@@ -83,6 +84,7 @@ def load_all_profiles(
                 issues = validation_issues
 
         profiles[plant_id] = ProfileLoadResult(
+            plant_id=plant_id,
             loaded=True,
             profile_data=profile_data,
             issues=issues,

--- a/custom_components/horticulture_assistant/utils/load_plant_profile.py
+++ b/custom_components/horticulture_assistant/utils/load_plant_profile.py
@@ -15,11 +15,7 @@ from typing import Any, Dict
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = [
-    "PlantProfile",
-    "load_plant_profile",
-    "clear_profile_cache",
-]
+__all__ = ["PlantProfile", "load_plant_profile", "clear_profile_cache"]
 
 
 @dataclass(slots=True)
@@ -44,33 +40,32 @@ def load_plant_profile(
     base_path: str | None = None,
     *,
     include_validation_files: bool = False,
-) -> dict:
-    """
-    Load a plant's profile by reading all JSON files in the plant's directory.
+) -> PlantProfile | dict:
+    """Return a :class:`PlantProfile` for ``plant_id``.
 
-    Scans the directory `plants/<plant_id>/` (or under the given base_path) for JSON files,
-    except for ``profile_index.json`` and, by default, any files intended for
-    validation only.
-    Parses each JSON file into a dictionary and aggregates them into a single profile structure.
+    All ``*.json`` files found under ``plants/<plant_id>/`` are parsed and
+    merged into one profile. ``profile_index.json`` and, by default,
+    any files intended solely for validation are skipped. Invalid JSON files are
+    logged and ignored so that loading continues for the rest of the profile.
 
-    Returns a dictionary with the structure:
-    {
-        'plant_id': <plant_id>,
-        'profile_data': {
-            <filename_base>: <parsed JSON content as dict>,
-            ...
-        }
-    }
+    If no valid profile data is found an empty dict is returned instead of a
+    dataclass instance.
 
-    Any JSON files that fail to parse are skipped with an error logged, while loading of other files continues.
-    Logs an info-level summary with the total number of profile modules successfully loaded.
+    Parameters
+    ----------
+    plant_id: str
+        Identifier for the plant (the profile directory name).
+    base_path: str | None, optional
+        Base directory of plant profiles, default ``plants/`` in the current
+        working directory.
+    include_validation_files: bool, optional
+        When ``True`` files containing ``validate`` or ``validation`` in the
+        name are also loaded.
 
-    :param plant_id: Identifier for the plant (also the directory name under the base path).
-    :param base_path: Optional base directory for plant profiles (defaults to
-        ``plants/`` in the current working directory).
-    :param include_validation_files: If ``True``, also load files whose name
-        contains ``validate`` or ``validation``.
-    :return: A dictionary containing the plant_id and loaded profile_data sections, or an empty dict on error.
+    Returns
+    -------
+    PlantProfile | dict
+        The aggregated profile information, or ``{}`` if nothing was loaded.
     """
     # Determine the base directory and plant profile directory
     base_dir = Path(base_path) if base_path else Path("plants")

--- a/tests/test_load_all_profiles.py
+++ b/tests/test_load_all_profiles.py
@@ -22,6 +22,7 @@ def test_load_all_profiles_basic(tmp_path):
     assert "demo" in result
     res = result["demo"]
     assert isinstance(res, ProfileLoadResult)
+    assert res.plant_id == "demo"
     assert res.loaded
     assert "general" in res.profile_data
     assert res.issues == {}
@@ -37,6 +38,7 @@ def test_load_all_profiles_pattern(tmp_path):
     result = load_all_profiles(base_path=tmp_path / "plants", pattern="data_*.json")
     assert "test" in result
     res = result["test"]
+    assert res.plant_id == "test"
     assert "data_one" in res.profile_data
     assert "skip" not in res.profile_data
 


### PR DESCRIPTION
## Summary
- clean up duplicate constant in `fertilizer_formulator`
- document and refine `load_plant_profile`
- extend `ProfileLoadResult` dataclass with `plant_id`
- adjust tests for new dataclass field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68858603b1148330959bdfb0705c7411