### PR TITLE
Add HVAC cost series utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ python -m custom_components.horticulture_assistant.analytics.export_all_growth_y
 - `get_pruning_instructions` provides stage-specific pruning tips from `pruning_guidelines.json`.
 - `generate_cycle_irrigation_plan` returns stage irrigation volumes using guideline intervals and durations.
 - `calculate_environment_stddev` computes standard deviation of environment sensor series for tighter control.
+- `estimate_hvac_energy_series` and `estimate_hvac_cost_series` evaluate energy
+  use and cost for sequential HVAC temperature setpoints.
 
 ### Garden Summary Lovelace Card
 Add `garden-summary-card.js` as a Lovelace resource (HACS places it under

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -4,6 +4,8 @@ from plant_engine.energy_manager import (
     get_energy_coefficient,
     estimate_hvac_energy,
     estimate_hvac_cost,
+    estimate_hvac_energy_series,
+    estimate_hvac_cost_series,
     get_electricity_rate,
     estimate_lighting_energy,
     estimate_lighting_cost,
@@ -51,6 +53,15 @@ def test_estimate_hvac_cost():
     cost = estimate_hvac_cost(18, 20, 12, "heating", region="california")
     expected_kwh = 0.5 * (2 * 12 / 24)
     assert cost == pytest.approx(expected_kwh * 0.18, 0.01)
+
+
+def test_estimate_hvac_energy_and_cost_series():
+    temps = [20, 22, 18]
+    energy = estimate_hvac_energy_series(18, temps, 4, "heating")
+    cost = estimate_hvac_cost_series(18, temps, 4, "heating", region="california")
+    assert len(energy) == len(temps)
+    assert len(cost) == len(temps)
+    assert cost[0] == pytest.approx(energy[0] * 0.18, abs=0.005)
 
 
 def test_light_efficiency_and_dli():


### PR DESCRIPTION
## Summary
- extend energy_manager with HVAC series energy & cost helpers
- add tests for the new utilities
- document energy-series helpers in Advanced Usage section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688585f9f58c83309e30ca563470c0d1