### PR TITLE
Improve dataset overlay caching

### DIFF
--- a/tests/test_dataset_paths.py
+++ b/tests/test_dataset_paths.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import plant_engine.utils as utils
 
 
@@ -30,3 +29,15 @@ def test_clear_dataset_cache_resets_paths(monkeypatch, tmp_path):
     assert paths1 != paths2
     utils.clear_dataset_cache()
 
+
+def test_overlay_dir_cache(monkeypatch, tmp_path):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+    importlib.reload(utils)
+    assert utils.overlay_dir() == overlay
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(tmp_path / "other"))
+    utils.clear_dataset_cache()
+    importlib.reload(utils)
+    assert utils.overlay_dir() != overlay
+    utils.clear_dataset_cache()


### PR DESCRIPTION
## Summary
- add `overlay_dir` helper to cache overlay dataset directory
- update `load_dataset` and `clear_dataset_cache` to use the cached path
- extend dataset path tests for overlay directory support

## Testing
- `pytest tests/test_dataset_paths.py -q`
- `pytest tests/test_dataset_catalog.py::test_catalog_custom_dir -q`


------
https://chatgpt.com/codex/tasks/task_e_688585ffef1c8330b85100c12f207b70