### PR TITLE
Enhance nutrient scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ python -m custom_components.horticulture_assistant.analytics.export_all_growth_y
 - Call `plant_engine.datasets.refresh_datasets()` if dataset files change.
 - Tag plants (e.g. `"blueberry"`, `"fruiting"`) to generate grouped dashboards and reports.
 - `recommend_nutrient_mix` computes fertilizer grams needed to hit N/P/K targets and can include micronutrients. `recommend_nutrient_mix_with_cost` returns the same schedule with estimated cost. `generate_nutrient_management_report` consolidates analysis and correction grams for a solution volume.
+- `schedule_stock_injection` converts nutrient targets into stock solution injection volumes for a given batch size.
 - `get_pruning_instructions` provides stage-specific pruning tips from `pruning_guidelines.json`.
 - `generate_cycle_irrigation_plan` returns stage irrigation volumes using guideline intervals and durations.
 - `calculate_environment_stddev` computes standard deviation of environment sensor series for tighter control.

--- a/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
@@ -276,4 +276,37 @@ def schedule_nutrient_corrections(
     return NutrientAdjustments(adjustments)
 
 
-__all__ = ["schedule_nutrients", "schedule_nutrient_corrections"]
+__all__ = [
+    "schedule_nutrients",
+    "schedule_nutrient_corrections",
+    "schedule_stock_injection",
+]
+
+
+def schedule_stock_injection(
+    plant_id: str,
+    volume_l: float,
+    hass: HomeAssistant = None,
+    *,
+    include_micro: bool = False,
+) -> dict[str, float]:
+    """Return stock solution volumes (mL) for ``plant_id`` and ``volume_l``.
+
+    The function first calls :func:`schedule_nutrients` to obtain nutrient
+    targets in parts per million and then converts those targets into stock
+    solution injection volumes using
+    :func:`plant_engine.fertigation.recommend_stock_solution_injection`.
+    """
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    targets = schedule_nutrients(
+        plant_id, hass=hass, include_micro=include_micro
+    ).as_dict()
+    if not targets:
+        return {}
+
+    from plant_engine.fertigation import recommend_stock_solution_injection
+
+    return recommend_stock_solution_injection(targets, volume_l)

--- a/tests/test_nutrient_scheduler.py
+++ b/tests/test_nutrient_scheduler.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import types
 import json
+import pytest
 import plant_engine.utils as utils
 
 MODULE_PATH = (
@@ -143,3 +144,17 @@ def test_schedule_nutrient_corrections(tmp_path):
         "corr", {"N": 0.0, "P": 0.0, "K": 0.0}, hass=hass
     ).as_dict()
     assert adjustments["N"] > 0
+
+
+def test_schedule_stock_injection(tmp_path):
+    plant_dir = tmp_path / "plants"
+    plant_dir.mkdir()
+    (plant_dir / "inj.json").write_text(
+        '{"general": {"plant_type": "citrus", "stage": "vegetative"}}'
+    )
+    hass = _hass_for(tmp_path)
+    from custom_components.horticulture_assistant.utils import nutrient_scheduler as ns
+
+    volumes = ns.schedule_stock_injection("inj", 10.0, hass=hass)
+    assert volumes["stock_a"] == pytest.approx(14.0, rel=1e-2)
+    assert volumes["stock_b"] == pytest.approx(7.5, rel=1e-2)


### PR DESCRIPTION
## Summary
- expose `schedule_stock_injection` helper to convert nutrient targets into stock solution volumes
- document the new helper in the README
- test `schedule_stock_injection`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d9bc9708330bbb99de774b13cde