### PR TITLE
Improve environment quality tools

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -301,6 +301,7 @@ __all__ = [
     "compare_environment",
     "generate_environment_alerts",
     "classify_environment_quality",
+    "classify_environment_quality_series",
     "score_overall_environment",
     "clear_environment_cache",
     "summarize_environment",
@@ -850,6 +851,23 @@ def classify_environment_quality(
 
     thresh = thresholds or get_environment_quality_thresholds()
     score = score_environment(current, plant_type, stage)
+    if score >= thresh.get("good", 75):
+        return "good"
+    if score >= thresh.get("fair", 50):
+        return "fair"
+    return "poor"
+
+
+def classify_environment_quality_series(
+    series: Iterable[Mapping[str, float]],
+    plant_type: str,
+    stage: str | None = None,
+    thresholds: Mapping[str, float] | None = None,
+) -> str:
+    """Return quality classification for averaged environment ``series``."""
+
+    score = score_environment_series(series, plant_type, stage)
+    thresh = thresholds or get_environment_quality_thresholds()
     if score >= thresh.get("good", 75):
         return "good"
     if score >= thresh.get("fair", 50):

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -55,6 +55,7 @@ from plant_engine.environment_manager import (
     _check_range,
     generate_environment_alerts,
     classify_environment_quality,
+    classify_environment_quality_series,
     score_overall_environment,
     normalize_environment_readings,
     summarize_environment,
@@ -541,6 +542,27 @@ def test_classify_environment_quality_custom():
         classify_environment_quality(good, "citrus", "seedling", thresholds)
         == "fair"
     )
+
+
+def test_classify_environment_quality_series():
+    series = [
+        {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450},
+        {"temp_c": 24, "humidity_pct": 72, "light_ppfd": 260, "co2_ppm": 460},
+    ]
+    result = classify_environment_quality_series(series, "citrus", "seedling")
+    assert result == "good"
+
+
+def test_classify_environment_quality_series_custom():
+    series = [
+        {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450},
+        {"temp_c": 24, "humidity_pct": 72, "light_ppfd": 260, "co2_ppm": 460},
+    ]
+    thresholds = {"good": 105, "fair": 80}
+    result = classify_environment_quality_series(
+        series, "citrus", "seedling", thresholds
+    )
+    assert result == "fair"
 
 
 def test_normalize_environment_readings_aliases():


### PR DESCRIPTION
## Summary
- add `classify_environment_quality_series` helper to evaluate a sequence of readings
- test new environment quality classification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68858d9538f08330bc6b20069276214d