### PR TITLE
Add fungicide recommendations dataset and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 
 ### Data & Analytics
 - Disease and pest treatment recommendations
+- Organic fungicide suggestions for common diseases
 - Environment optimization suggestions with pH guidance
 - Precise pH adjustment volume calculations
 - Heat, humidity and light stress warnings
@@ -223,6 +224,7 @@ Important categories include:
 - **Environment actions** – recommended steps when temperature or humidity are out of range
 - **Nutrient guidelines** – macronutrient and micronutrient targets by stage
 - **Pest and disease references** – thresholds, prevention tips and treatment options
+- **Fungicide recommendations** – suggested organic products for common diseases
 - **Pest scouting methods** – recommended techniques for monitoring common pests
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -51,6 +51,7 @@
   "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
   "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",
   "foliar_spray_volume.json": "Recommended foliar spray volume per plant in mL.",
+  "fungicide_recommendations.json": "Organic fungicide options for common diseases.",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",

--- a/data/fungicide_recommendations.json
+++ b/data/fungicide_recommendations.json
@@ -1,0 +1,6 @@
+{
+  "blight": ["copper fungicide", "bacillus subtilis"],
+  "powdery mildew": ["sulfur spray", "potassium bicarbonate"],
+  "downy mildew": ["phosphorous acid", "copper fungicide"],
+  "botrytis": ["bacillus subtilis", "copper fungicide"]
+}

--- a/plant_engine/disease_manager.py
+++ b/plant_engine/disease_manager.py
@@ -9,6 +9,7 @@ RESISTANCE_FILE = "disease_resistance_ratings.json"
 
 DATA_FILE = "disease_guidelines.json"
 PREVENTION_FILE = "disease_prevention.json"
+FUNGICIDE_FILE = "fungicide_recommendations.json"
 
 
 
@@ -16,6 +17,11 @@ PREVENTION_FILE = "disease_prevention.json"
 _DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
 _PREVENTION: Dict[str, Dict[str, str]] = load_dataset(PREVENTION_FILE)
 _RESISTANCE: Dict[str, Dict[str, float]] = load_dataset(RESISTANCE_FILE)
+_FUNGICIDES_RAW: Dict[str, list[str]] = load_dataset(FUNGICIDE_FILE)
+_FUNGICIDES: Dict[str, list[str]] = {
+    normalize_key(k): list(v) if isinstance(v, list) else []
+    for k, v in _FUNGICIDES_RAW.items()
+}
 
 
 def list_supported_plants() -> list[str]:
@@ -68,6 +74,24 @@ def get_disease_resistance(plant_type: str, disease: str) -> float | None:
     return float(value) if isinstance(value, (int, float)) else None
 
 
+def get_fungicide_options(disease: str) -> list[str]:
+    """Return recommended fungicide products for ``disease``."""
+
+    options = _FUNGICIDES.get(normalize_key(disease))
+    if isinstance(options, list):
+        return list(options)
+    return []
+
+
+def recommend_fungicides(diseases: Iterable[str]) -> Dict[str, list[str]]:
+    """Return fungicide suggestions for each disease in ``diseases``."""
+
+    recs: Dict[str, list[str]] = {}
+    for dis in diseases:
+        recs[dis] = get_fungicide_options(dis)
+    return recs
+
+
 __all__ = [
     "list_supported_plants",
     "get_disease_guidelines",
@@ -76,4 +100,6 @@ __all__ = [
     "get_disease_prevention",
     "recommend_prevention",
     "get_disease_resistance",
+    "get_fungicide_options",
+    "recommend_fungicides",
 ]

--- a/tests/test_disease_manager.py
+++ b/tests/test_disease_manager.py
@@ -3,6 +3,8 @@ from plant_engine.disease_manager import (
     recommend_treatments,
     list_known_diseases,
     get_disease_resistance,
+    get_fungicide_options,
+    recommend_fungicides,
 )
 
 
@@ -31,3 +33,18 @@ def test_list_known_diseases():
 def test_get_disease_resistance():
     assert get_disease_resistance("citrus", "greasy_spot") == 4.0
     assert get_disease_resistance("citrus", "unknown") is None
+
+
+def test_get_fungicide_options():
+    opts = get_fungicide_options("blight")
+    assert "copper fungicide" in opts
+    assert "bacillus subtilis" in opts
+
+
+def test_recommend_fungicides():
+    recs = recommend_fungicides(["powdery mildew", "unknown"])
+    assert recs["powdery mildew"] == [
+        "sulfur spray",
+        "potassium bicarbonate",
+    ]
+    assert recs["unknown"] == []


### PR DESCRIPTION
## Summary
- add fungicide dataset for common disease treatments
- extend `disease_manager` with helpers for fungicide options
- document new data file and features in README
- cover new functionality with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d8914f083309b595b9f9995c3ce