### PR TITLE
Add environment scoring to daily reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Nutrient deficiency severity and treatment recommendations
 - Combined nutrient management reports with correction schedules
 - Daily report files summarizing environment and nutrient targets
+- Environment score and quality rating for sensor data
 - Infiltration-aware irrigation burst scheduling
 - Risk-adjusted pest monitoring summaries and scheduling
 - Automatic pesticide rotation planning

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -22,7 +22,12 @@ from custom_components.horticulture_assistant.utils.path_utils import (
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_profile_by_id,
 )
-from plant_engine.environment_manager import compare_environment, optimize_environment
+from plant_engine.environment_manager import (
+    compare_environment,
+    optimize_environment,
+    score_environment,
+    classify_environment_quality,
+)
 from plant_engine.growth_stage import predict_harvest_date, stage_progress
 from plant_engine.pest_manager import recommend_beneficials, recommend_treatments
 from plant_engine.disease_manager import (
@@ -62,6 +67,8 @@ class DailyReport:
     sensor_summary: dict[str, object] = field(default_factory=dict)
     environment_comparison: dict[str, object] = field(default_factory=dict)
     environment_optimization: dict[str, object] = field(default_factory=dict)
+    environment_score: float | None = None
+    environment_quality: str | None = None
     pest_actions: dict[str, str] = field(default_factory=dict)
     disease_actions: dict[str, str] = field(default_factory=dict)
     deficiency_actions: dict[str, dict[str, str]] = field(default_factory=dict)
@@ -227,6 +234,10 @@ def run_daily_cycle(
     env_compare = compare_environment(current_env, thresholds)
     report.environment_comparison = env_compare
     report.environment_optimization = optimize_environment(
+        current_env, plant_type, stage_name
+    )
+    report.environment_score = score_environment(current_env, plant_type, stage_name)
+    report.environment_quality = classify_environment_quality(
         current_env, plant_type, stage_name
     )
     # Pest and disease alerts (if any observed in profile)

--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -41,6 +41,8 @@ def test_run_daily_cycle_extended(tmp_path):
     assert report["predicted_harvest_date"] == "2025-05-01"
     assert report["stage_progress_pct"] is not None
     assert "environment_optimization" in report
+    assert "environment_score" in report
+    assert "environment_quality" in report
     assert "fertigation_schedule" in report
     assert "fertigation_cost" in report
     assert (out_dir / f"sample_{report['timestamp'][:10]}.json").exists()

--- a/tests/test_run_daily_cycle_nutrient_analysis.py
+++ b/tests/test_run_daily_cycle_nutrient_analysis.py
@@ -29,3 +29,5 @@ def test_run_daily_cycle_nutrient_analysis(tmp_path):
     # new expected uptake reporting
     assert report["expected_uptake"]["N"] == 50
     assert report["uptake_gap"]["K"] == 20
+    assert "environment_score" in report
+    assert "environment_quality" in report

--- a/tests/test_run_daily_cycle_stage_tasks.py
+++ b/tests/test_run_daily_cycle_stage_tasks.py
@@ -16,3 +16,5 @@ def test_run_daily_cycle_stage_tasks(tmp_path):
     report = run_daily_cycle("plant1", base_path=str(plants_dir), output_path=str(out_dir))
 
     assert report["stage_tasks"] == ["Prune side shoots", "Apply balanced fertilizer"]
+    assert "environment_score" in report
+    assert "environment_quality" in report

--- a/tests/test_run_daily_cycle_transpiration.py
+++ b/tests/test_run_daily_cycle_transpiration.py
@@ -24,3 +24,5 @@ def test_run_daily_cycle_transpiration(tmp_path):
 
     assert "transpiration" in report
     assert report["transpiration"]["transpiration_ml_day"] > 0
+    assert "environment_score" in report
+    assert "environment_quality" in report


### PR DESCRIPTION
## Summary
- compute environment score/quality in `run_daily_cycle`
- expose new data fields in daily reports
- check environment fields in tests
- document the new analytics feature in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d84f9f08330aea4b7a55ef3a6c6