### PR TITLE
Add pesticide mix compatibility data and checks

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -115,6 +115,7 @@
   "pesticide_modes.json": "Mode of action classification for common pesticides.",
   "pesticide_rotation_intervals.json": "Recommended days to wait before reusing the same pesticide mode of action.",
   "pesticide_phytotoxicity.json": "Crop-specific phytotoxicity risk levels for pesticide products.",
+  "pesticide_compatibility.json": "Known mixing incompatibilities between pesticide products.",
   "risk_score_map.json": "Numeric weights for risk level scoring.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/pesticide_compatibility.json
+++ b/data/pesticide_compatibility.json
@@ -1,0 +1,9 @@
+{
+  "copper_sulfate": {
+    "sulfur": "reduced efficacy",
+    "pyrethrin": "physical incompatibility"
+  },
+  "neem_oil": {
+    "sulfur": "phytotoxic combination"
+  }
+}

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -127,3 +127,13 @@ def test_is_safe_for_crop():
     assert is_safe_for_crop("tomato", "neem_oil")
 
 
+def test_check_mix_compatibility():
+    from plant_engine.pesticide_manager import check_mix_compatibility, is_mix_compatible
+
+    warnings = check_mix_compatibility(["copper_sulfate", "sulfur", "neem_oil"])
+    assert ("copper_sulfate", "sulfur") in warnings
+    assert warnings[("copper_sulfate", "sulfur")] == "reduced efficacy"
+    assert ("neem_oil", "sulfur") in warnings or ("sulfur", "neem_oil") in warnings
+    assert not is_mix_compatible(["copper_sulfate", "sulfur"])
+
+


### PR DESCRIPTION
## Summary
- include new `pesticide_compatibility.json` dataset with sample incompatibilities
- document dataset in `dataset_catalog.json`
- extend `pesticide_manager` with `check_mix_compatibility` and `is_mix_compatible`
- test new compatibility helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d67af508330898f58c269cf1aa5