### PR TITLE
Add integrated monitoring schedule CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Helper scripts live in the `scripts/` directory.
 - `fertigation_plan.py` creates a JSON fertigation schedule for any crop stage.
 - `precision_fertigation.py` generates a detailed fertigation plan with stock
   solution injection volumes.
+- `monitor_schedule.py` outputs an integrated pest and disease monitoring
+  schedule for a plant stage.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
 - `profile_manager.py` manages sensors, preferences, and templates.  `attach-sensor` appends new sensors, while `detach-sensor` removes them.  Other subcommands include `list-sensors`, `set-pref`, `load-default`, `show-history`, and `list-globals`.  `--plants-dir` and `--global-dir` operate on alternate directories.
 

--- a/scripts/monitor_schedule.py
+++ b/scripts/monitor_schedule.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Generate integrated pest and disease monitoring schedules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+import sys
+
+# Ensure project root is on the Python path when executed directly
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.integrated_monitor import generate_integrated_monitoring_schedule
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate combined pest and disease monitoring schedule"
+    )
+    parser.add_argument("plant_type", help="Plant type identifier")
+    parser.add_argument("stage", nargs="?", help="Growth stage", default=None)
+    parser.add_argument("start", help="Start date YYYY-MM-DD")
+    parser.add_argument("events", type=int, help="Number of events to return")
+    parser.add_argument(
+        "--json", action="store_true", dest="as_json", help="Output as JSON"
+    )
+    args = parser.parse_args(argv)
+
+    start_date = date.fromisoformat(args.start)
+    schedule = generate_integrated_monitoring_schedule(
+        args.plant_type, args.stage, start_date, args.events
+    )
+
+    if args.as_json:
+        print(json.dumps([d.isoformat() for d in schedule]))
+    else:
+        for d in schedule:
+            print(d.isoformat())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_monitor_schedule_script.py
+++ b/tests/test_monitor_schedule_script.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import subprocess
+import sys
+import json
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/monitor_schedule.py"
+
+
+def test_cli_json():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "citrus", "fruiting", "2023-01-01", "3", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    assert data == ["2023-01-04", "2023-01-05", "2023-01-07"]


### PR DESCRIPTION
## Summary
- add `monitor_schedule.py` script to output combined pest and disease monitoring dates
- document the new script in README
- cover the script with a test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d70d7108330b9c03936ecc12cfb