### PR TITLE
Enhance pesticide management utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -115,6 +115,7 @@
   "pesticide_modes.json": "Mode of action classification for common pesticides.",
   "pesticide_rotation_intervals.json": "Recommended days to wait before reusing the same pesticide mode of action.",
   "pesticide_phytotoxicity.json": "Crop-specific phytotoxicity risk levels for pesticide products.",
+  "pesticide_application_rates.json": "Recommended pesticide application rates in ml or g per liter.",
   "risk_score_map.json": "Numeric weights for risk level scoring.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/pesticide_application_rates.json
+++ b/data/pesticide_application_rates.json
@@ -1,0 +1,5 @@
+{
+  "neem_oil": 5.0,
+  "copper_sulfate": 2.0,
+  "spinosad": 1.5
+}

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 
 from plant_engine.pesticide_manager import (
     get_withdrawal_days,
@@ -125,5 +126,24 @@ def test_is_safe_for_crop():
 
     assert not is_safe_for_crop("tomato", "copper_sulfate")
     assert is_safe_for_crop("tomato", "neem_oil")
+
+
+def test_get_application_rate():
+    from plant_engine.pesticide_manager import get_application_rate
+
+    assert get_application_rate("neem_oil") == 5.0
+    assert get_application_rate("unknown") is None
+
+
+def test_calculate_application_amount():
+    from plant_engine.pesticide_manager import calculate_application_amount
+
+    amount = calculate_application_amount("neem_oil", 2.0)
+    assert amount == 10.0
+
+    with pytest.raises(ValueError):
+        calculate_application_amount("neem_oil", 0)
+    with pytest.raises(KeyError):
+        calculate_application_amount("unknown", 1.0)
 
 


### PR DESCRIPTION
## Summary
- add `pesticide_application_rates.json` with basic rate data
- expose pesticide application rate helpers
- document dataset in `dataset_catalog.json`
- test new pesticide utilities

## Testing
- `pytest tests/test_pesticide_manager.py::test_get_application_rate tests/test_pesticide_manager.py::test_calculate_application_amount -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d757e8c833083008134bd7265c7