### PR TITLE
Add profile validation helper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ If multiple entity IDs are provided, their values are averaged. When more than
 two sensors are listed, the median of the available readings is used instead to
 reduce the effect of outliers.
 
+Use `validate_profile` to verify required fields before saving a profile:
+
+```python
+from custom_components.horticulture_assistant.utils import plant_profile_loader
+
+errors = plant_profile_loader.validate_profile(profile)
+if errors:
+    print("Profile missing:", errors)
+else:
+    plant_profile_loader.save_profile_by_id("myplant", profile)
+```
+
 ### Zones and Irrigation Scheduling
 Profiles can declare a `zone_id` to group plants under a common irrigation
 zone. Zones and their associated solenoids are defined in `zones.json`. Each

--- a/custom_components/horticulture_assistant/utils/plant_profile_loader.py
+++ b/custom_components/horticulture_assistant/utils/plant_profile_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from functools import lru_cache
+from typing import Any, Mapping
 
 from .json_io import load_json, save_json
 
@@ -243,6 +244,28 @@ def delete_profile_by_id(plant_id: str, base_dir: str | Path | None = None) -> b
     return deleted
 
 
+def validate_profile(profile: Mapping[str, Any]) -> list[str]:
+    """Return a list of missing required keys for ``profile``.
+
+    The function checks for ``plant_id``, ``display_name`` and ``stage`` at the
+    top level, along with a ``sensor_entities`` mapping either in the root or
+    under ``general``. The returned list is empty when the profile appears
+    valid.
+    """
+
+    missing: list[str] = []
+
+    for key in ("plant_id", "display_name", "stage"):
+        if key not in profile:
+            missing.append(key)
+
+    container = profile.get("general", profile)
+    if not isinstance(container, Mapping) or "sensor_entities" not in container:
+        missing.append("sensor_entities")
+
+    return missing
+
+
 def update_profile_sensors(
     plant_id: str,
     sensors: dict,
@@ -349,6 +372,7 @@ __all__ = [
     "save_profile_by_id",
     "profile_exists",
     "delete_profile_by_id",
+    "validate_profile",
     "update_profile_sensors",
     "attach_profile_sensors",
     "detach_profile_sensors",

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -1,0 +1,19 @@
+from custom_components.horticulture_assistant.utils import plant_profile_loader as loader
+
+
+def test_validate_profile_complete():
+    profile = {
+        "plant_id": "p1",
+        "display_name": "Plant 1",
+        "stage": "seedling",
+        "general": {"sensor_entities": {"moisture": "s1"}},
+    }
+    assert loader.validate_profile(profile) == []
+
+
+def test_validate_profile_missing():
+    profile = {"plant_id": "p1"}
+    missing = loader.validate_profile(profile)
+    assert "display_name" in missing
+    assert "stage" in missing
+    assert "sensor_entities" in missing


### PR DESCRIPTION
## Summary
- document using `validate_profile` in the profile section of the README
- add `validate_profile` utility to check required keys in plant profiles
- expose the helper via `__all__`
- test profile validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858d795b1083309737529707d31ee0