### PR TITLE
Add media guidelines module

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Important categories include:
 - **Fertilizer compatibility** – warnings for mixing products that react poorly
 - **Soil pH guidelines** – optimal soil pH ranges for supported crops
 - **Root temperature uptake factors** – relative nutrient uptake efficiency by root zone temperature
+- **Media properties** – recommended pH range and water retention for common substrates
 
 The WSDA fertilizer dataset resides under `feature/wsda_refactored_sharded/` which contains an
 `index_sharded/` directory of `.jsonl` shards and a `detail/` directory of per-product records.

--- a/data/media_properties.json
+++ b/data/media_properties.json
@@ -1,0 +1,5 @@
+{
+  "coco": {"ph_min": 5.5, "ph_max": 6.5, "water_retention_pct": 65, "aeration_pct": 25},
+  "peat": {"ph_min": 5.8, "ph_max": 6.2, "water_retention_pct": 70, "aeration_pct": 20},
+  "rockwool": {"ph_min": 5.8, "ph_max": 6.3, "water_retention_pct": 85, "aeration_pct": 10}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 from importlib import import_module
 
-from . import utils, environment_tips
+from . import utils, environment_tips, media_manager
 from .utils import *  # noqa: F401,F403
 from .environment_tips import *  # noqa: F401,F403
+from .media_manager import *  # noqa: F401,F403
 from .nutrient_planner import (
     NutrientManagementReport,
     generate_nutrient_management_report,
 )
 
 __all__ = sorted(
-    set(utils.__all__) | set(environment_tips.__all__) | {
+    set(utils.__all__) | set(environment_tips.__all__) | set(media_manager.__all__) | {
         "NutrientManagementReport",
         "generate_nutrient_management_report",
     }

--- a/plant_engine/media_manager.py
+++ b/plant_engine/media_manager.py
@@ -1,0 +1,29 @@
+"""Growing media guidelines and utilities."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "media_properties.json"
+
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_media",
+    "get_media_properties",
+]
+
+
+def list_supported_media() -> list[str]:
+    """Return available growing media types."""
+    return list_dataset_entries(_DATA)
+
+
+def get_media_properties(media_type: str) -> Dict[str, float]:
+    """Return property mapping for ``media_type``."""
+    return {
+        k: float(v)
+        for k, v in _DATA.get(normalize_key(media_type), {}).items()
+        if isinstance(v, (int, float))
+    }

--- a/tests/test_media_manager.py
+++ b/tests/test_media_manager.py
@@ -1,0 +1,12 @@
+import plant_engine.media_manager as media
+
+
+def test_list_supported_media():
+    media_types = media.list_supported_media()
+    assert "coco" in media_types
+
+
+def test_get_media_properties():
+    props = media.get_media_properties("coco")
+    assert props["ph_min"] == 5.5
+    assert props["aeration_pct"] == 25


### PR DESCRIPTION
## Summary
- include new `media_properties` dataset in reference data list
- support growing media lookups via new `media_manager` module
- expose `media_manager` through `plant_engine` package
- test media guideline helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68858d7d39488330ac59b2f282dc4a97