### PR TITLE
Add helper for pesticide rotation dates

### DIFF
--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -33,6 +33,7 @@ __all__ = [
     "list_known_pesticides",
     "get_rotation_interval",
     "suggest_rotation_schedule",
+    "next_rotation_date",
     "suggest_rotation_plan",
     "get_phytotoxicity_risk",
     "is_safe_for_crop",
@@ -165,6 +166,15 @@ def suggest_rotation_schedule(product: str, start_date: date, cycles: int) -> Li
         return []
 
     return [start_date + timedelta(days=interval * i) for i in range(cycles)]
+
+
+def next_rotation_date(product: str, last_date: date) -> date | None:
+    """Return the next application date after ``last_date``."""
+
+    interval = get_rotation_interval(product)
+    if interval is None:
+        return None
+    return last_date + timedelta(days=interval)
 
 
 def suggest_rotation_plan(

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -13,6 +13,7 @@ from plant_engine.pesticide_manager import (
     list_known_pesticides,
     get_rotation_interval,
     suggest_rotation_schedule,
+    next_rotation_date,
     suggest_rotation_plan,
 )
 
@@ -99,6 +100,13 @@ def test_suggest_rotation_schedule():
         datetime.date(2024, 1, 31),
         datetime.date(2024, 3, 1),
     ]
+
+
+def test_next_rotation_date():
+    last = datetime.date(2024, 6, 1)
+    result = next_rotation_date("spinosad", last)
+    assert result == last + datetime.timedelta(days=10)
+    assert next_rotation_date("unknown", last) is None
 
 
 def test_suggest_rotation_plan():


### PR DESCRIPTION
## Summary
- add `next_rotation_date` helper to pesticide manager
- test next rotation date functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68859677048083309c3933ba17e008ed