### PR TITLE
Add weekly fertigation cost helper

### DIFF
--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -230,6 +230,7 @@ __all__ = [
     "estimate_solution_ec",
     "estimate_stage_cost",
     "estimate_cycle_cost",
+    "estimate_weekly_fertigation_cost",
     "generate_cycle_fertigation_plan",
     "generate_cycle_fertigation_plan_with_cost",
     "optimize_fertigation_schedule",
@@ -1063,6 +1064,33 @@ def estimate_cycle_cost(
 
     schedule = _schedule_from_totals(totals, num_plants, fertilizers, purity_overrides)
     return estimate_mix_cost(schedule)
+
+
+def estimate_weekly_fertigation_cost(
+    plant_type: str,
+    stage: str,
+    daily_volume_l: float,
+    *,
+    fertilizers: Mapping[str, str] | None = None,
+    purity_overrides: Mapping[str, float] | None = None,
+) -> float:
+    """Return estimated cost for a week of fertigation at ``daily_volume_l``.
+
+    This helper uses :func:`recommend_nutrient_mix_with_cost` to calculate the
+    daily fertilizer mix and multiplies the result by seven days.
+    """
+
+    if daily_volume_l <= 0:
+        raise ValueError("daily_volume_l must be positive")
+
+    _, cost = recommend_nutrient_mix_with_cost(
+        plant_type,
+        stage,
+        daily_volume_l,
+        fertilizers=fertilizers,
+        purity_overrides=purity_overrides,
+    )
+    return round(cost * 7, 2)
 
 
 def optimize_fertigation_schedule(

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -444,3 +444,17 @@ def test_recommend_recovery_adjusted_schedule():
     assert schedule["N"] == pytest.approx(1.667, rel=1e-3)
     assert schedule["P"] == pytest.approx(1.429, rel=1e-3)
     assert schedule["K"] == pytest.approx(1.231, rel=1e-3)
+
+
+def test_estimate_weekly_fertigation_cost():
+    from plant_engine.fertigation import estimate_weekly_fertigation_cost
+    fert_map = {
+        "N": "foxfarm_grow_big",
+        "P": "foxfarm_grow_big",
+        "K": "intrepid_granular_potash_0_0_60",
+    }
+    cost = estimate_weekly_fertigation_cost(
+        "tomato", "vegetative", 10.0, fertilizers=fert_map
+    )
+    assert cost > 0
+


### PR DESCRIPTION
## Summary
- implement `estimate_weekly_fertigation_cost` helper in `fertigation`
- export function via `__all__`
- test weekly cost calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885967269708330a362500482b9aba9