### PR TITLE
Improve parse_range behavior

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -246,9 +246,11 @@ def parse_range(value: Iterable[float]) -> tuple[float, float] | None:
     """
 
     try:
-        low, high = value
-        return float(low), float(high)
-    except (TypeError, ValueError):
+        iterator = iter(value)
+        low = float(next(iterator))
+        high = float(next(iterator))
+        return low, high
+    except (StopIteration, TypeError, ValueError):
         return None
 
 

--- a/tests/test_parse_range.py
+++ b/tests/test_parse_range.py
@@ -11,3 +11,11 @@ def test_parse_range_tuple():
 def test_parse_range_invalid():
     assert parse_range([1]) is None
     assert parse_range("bad") is None
+
+
+def test_parse_range_extra_items():
+    assert parse_range([1, 2, 3]) == (1.0, 2.0)
+
+
+def test_parse_range_iterable():
+    assert parse_range(iter([4, "5", 6])) == (4.0, 5.0)


### PR DESCRIPTION
## Summary
- update `parse_range` in utils to handle iterables with more than two values
- add tests for new `parse_range` behavior

## Testing
- `pytest tests/test_parse_range.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885965d72548330bd5ee74fd39e7acd