### PR TITLE
Add detailed pest monitoring schedule

### DIFF
--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -18,6 +18,7 @@ from .pest_manager import (
     recommend_treatments,
     recommend_beneficials,
     get_pest_resistance,
+    list_known_pests,
 )
 
 DATA_FILE = "pest_thresholds.json"
@@ -55,6 +56,7 @@ __all__ = [
     "risk_adjusted_monitor_interval",
     "next_monitor_date",
     "generate_monitoring_schedule",
+    "generate_detailed_monitoring_schedule",
     "PestReport",
     "summarize_pest_management",
 ]
@@ -122,6 +124,20 @@ def generate_monitoring_schedule(
     """Return list of upcoming monitoring dates."""
 
     return _generate_schedule(_MONITOR_INTERVALS, plant_type, stage, start, events)
+
+
+def generate_detailed_monitoring_schedule(
+    plant_type: str,
+    stage: str | None,
+    start: date,
+    events: int,
+) -> list[dict[str, object]]:
+    """Return monitoring dates with scouting methods for each pest."""
+
+    dates = generate_monitoring_schedule(plant_type, stage, start, events)
+    pests = list_known_pests(plant_type)
+    methods = {p: get_scouting_method(p) for p in pests}
+    return [{"date": d, "methods": methods} for d in dates]
 
 
 def get_severity_action(level: str) -> str:

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -12,6 +12,7 @@ from plant_engine.pest_monitor import (
     get_monitoring_interval,
     next_monitor_date,
     generate_monitoring_schedule,
+    generate_detailed_monitoring_schedule,
     risk_adjusted_monitor_interval,
     get_scouting_method,
     summarize_pest_management,
@@ -146,4 +147,13 @@ def test_summarize_pest_management():
 def test_get_scouting_method():
     method = get_scouting_method("mites")
     assert "paper" in method
+
+
+def test_generate_detailed_monitoring_schedule():
+    start = date(2023, 1, 1)
+    plan = generate_detailed_monitoring_schedule("tomato", "fruiting", start, 2)
+    assert len(plan) == 2
+    entry = plan[0]
+    assert entry["date"] == date(2023, 1, 4)
+    assert "aphids" in entry["methods"]
 


### PR DESCRIPTION
## Summary
- provide `generate_detailed_monitoring_schedule` to include scouting methods
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885965b9ad08330ac326e2ae8a65466