### PR TITLE
Improve environment normalization

### DIFF
--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -619,6 +619,12 @@ def test_normalize_environment_readings_unknown_key():
     assert result == {"foo": 1.0}
 
 
+def test_normalize_environment_readings_vpd_alias():
+    data = {"vpd_kpa": 1.2}
+    result = normalize_environment_readings(data)
+    assert result == {"vpd": 1.2}
+
+
 def test_average_environment_readings():
     series = [
         {"temp_c": 20, "humidity_pct": 60},


### PR DESCRIPTION
## Summary
- normalize vapor pressure deficit field under `vpd` key
- refactor `normalize_environment_readings` to convert temperature values via helper
- document conversions in `normalize_environment_readings`
- test VPD alias handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68859657d604833088661b73b6181356