### PR TITLE
Improve dose calculator utilities

### DIFF
--- a/custom_components/horticulture_assistant/utils/dose_calculator.py
+++ b/custom_components/horticulture_assistant/utils/dose_calculator.py
@@ -133,3 +133,41 @@ class DoseCalculator:
 
         v1 = (desired_concentration * final_volume_l) / stock_concentration
         return round(v1, 3)
+
+    @staticmethod
+    def blend_solutions(
+        conc_a: float,
+        vol_a: float,
+        conc_b: float,
+        vol_b: float,
+        unit: Literal["mg/L", "g/L", "ppm"] = "ppm",
+    ) -> float:
+        """Return final concentration after mixing two solutions.
+
+        ``conc_a`` and ``conc_b`` are interpreted according to ``unit``.
+        Both solutions must use the same units. ``"ppm"`` is treated as
+        ``"mg/L"``. Volumes must be positive. The resulting concentration is
+        returned in the same units, rounded to two decimals.
+        """
+
+        if vol_a <= 0 or vol_b <= 0:
+            raise ValueError("Solution volumes must be positive")
+
+        u = unit
+        if u == "ppm":
+            u = "mg/L"
+
+        if u not in {"mg/L", "g/L"}:
+            raise ValueError("Unsupported unit")
+
+        # convert to mg/L for calculation
+        if u == "g/L":
+            conc_a *= 1000
+            conc_b *= 1000
+
+        total_volume = vol_a + vol_b
+        final_mg_l = (conc_a * vol_a + conc_b * vol_b) / total_volume
+
+        if unit == "g/L":
+            return round(final_mg_l / 1000, 2)
+        return round(final_mg_l, 2)

--- a/tests/test_dose_calculator.py
+++ b/tests/test_dose_calculator.py
@@ -49,3 +49,13 @@ def test_calculate_dilution_volume():
         DoseCalculator.calculate_dilution_volume(1000, 100, -1)
     with pytest.raises(ValueError):
         DoseCalculator.calculate_dilution_volume(500, 600, 1)
+
+
+def test_blend_solutions():
+    conc = DoseCalculator.blend_solutions(200, 1, 100, 1, "ppm")
+    assert conc == 150
+    conc = DoseCalculator.blend_solutions(0.5, 2, 1.5, 1, "g/L")
+    assert conc == pytest.approx(0.83, rel=1e-3)
+    with pytest.raises(ValueError):
+        DoseCalculator.blend_solutions(100, -1, 100, 1)
+


### PR DESCRIPTION
## Summary
- add `blend_solutions` helper to dose calculator for mixing nutrient solutions
- test solution blending logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885964ed3688330812e2171458e6d98