### PR TITLE
Add ET estimation helper

### DIFF
--- a/tests/test_et_model.py
+++ b/tests/test_et_model.py
@@ -1,5 +1,9 @@
 import math
-from plant_engine.et_model import calculate_et0, calculate_eta
+from plant_engine.et_model import (
+    calculate_et0,
+    calculate_eta,
+    estimate_stage_et,
+)
 
 
 def test_calculate_et0():
@@ -9,3 +13,8 @@ def test_calculate_et0():
 
 def test_calculate_eta():
     assert calculate_eta(8.54, 1.2) == 10.25
+
+
+def test_estimate_stage_et():
+    et = estimate_stage_et("tomato", "vegetative", 7)
+    assert math.isclose(et, 6.83, abs_tol=0.01)


### PR DESCRIPTION
## Summary
- extend evapotranspiration model with `estimate_stage_et`
- cover new helper in unit tests

## Testing
- `pytest -q`
- `pytest tests/test_et_model.py::test_estimate_stage_et -q`

------
https://chatgpt.com/codex/tasks/task_e_6885964b3978833091b86105ad2d523d