### PR TITLE
Improve environment reading normalization

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, asdict
 from functools import lru_cache
+import math
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
 RangeTuple = Tuple[float, float]
@@ -201,7 +202,11 @@ def recommend_climate_adjustments(
 
 
 def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, float]:
-    """Return ``readings`` with keys mapped to canonical environment names."""
+    """Return ``readings`` with keys mapped to canonical environment names.
+
+    Values that cannot be converted to a finite float are ignored to avoid
+    propagating ``NaN`` or infinite measurements into calculations.
+    """
 
     normalized: Dict[str, float] = {}
     for key, value in readings.items():
@@ -209,6 +214,8 @@ def normalize_environment_readings(readings: Mapping[str, float]) -> Dict[str, f
         try:
             val = float(value)
         except (TypeError, ValueError):
+            continue
+        if not math.isfinite(val):
             continue
         if canonical in {"temp_f", "soil_temp_f", "leaf_temp_f"}:
             val = (val - 32) * 5 / 9

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -619,6 +619,12 @@ def test_normalize_environment_readings_unknown_key():
     assert result == {"foo": 1.0}
 
 
+def test_normalize_environment_readings_skip_invalid_values():
+    data = {"temperature": float("nan"), "humidity": float("inf"), "co2": 700}
+    result = normalize_environment_readings(data)
+    assert result == {"co2_ppm": 700.0}
+
+
 def test_average_environment_readings():
     series = [
         {"temp_c": 20, "humidity_pct": 60},


### PR DESCRIPTION
## Summary
- ignore NaN and infinite values when normalizing environment readings
- document this behavior in `normalize_environment_readings`
- test skipping invalid readings

## Testing
- `pip install pyyaml >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pytest tests/test_environment_manager.py -k skip_invalid_values -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688596476e4c83308325b3edd3d6b7ca