### PR TITLE
Improve irrigation modeling with climate zone modifiers

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -27,6 +27,7 @@
   "irrigation_guidelines.json": "Daily irrigation volume guidelines by stage.",
   "irrigation_intervals.json": "Recommended days between irrigation events for each plant stage.",
   "irrigation_efficiency.json": "Efficiency factors for irrigation methods.",
+  "irrigation_zone_modifiers.json": "Climate zone multipliers for irrigation demand.",
   "rain_capture_efficiency.json": "Fraction of rainfall captured by different ground covers.",
   "water_quality_thresholds.json": "Maximum safe levels of common water analytes.",
   "water_quality_actions.json": "Recommended remediation steps for poor water quality.",

--- a/data/irrigation_zone_modifiers.json
+++ b/data/irrigation_zone_modifiers.json
@@ -1,0 +1,5 @@
+{
+  "arid": 1.2,
+  "temperate": 1.0,
+  "humid": 0.8
+}

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -19,6 +19,8 @@ from plant_engine.irrigation_manager import (
     generate_precipitation_schedule,
     generate_env_precipitation_schedule,
     get_rain_capture_efficiency,
+    get_irrigation_zone_modifier,
+    adjust_irrigation_for_zone,
     get_recommended_interval,
     IrrigationRecommendation,
 )
@@ -338,4 +340,16 @@ def test_generate_env_precipitation_schedule():
     assert schedule[1]["volume_ml"] == vol1
     assert schedule[1]["metrics"] == metrics
     assert schedule[2]["volume_ml"] == vol2
+
+
+def test_irrigation_zone_modifier():
+    assert get_irrigation_zone_modifier("arid") == 1.2
+    assert get_irrigation_zone_modifier("unknown") == 1.0
+
+
+def test_adjust_irrigation_for_zone():
+    assert adjust_irrigation_for_zone(100.0, "arid") == 120.0
+    assert adjust_irrigation_for_zone(50.0, "humid") == 40.0
+    with pytest.raises(ValueError):
+        adjust_irrigation_for_zone(-1.0, "arid")
 


### PR DESCRIPTION
## Summary
- add `irrigation_zone_modifiers.json` dataset for climate based irrigation adjustments
- document new dataset in `dataset_catalog.json`
- extend `irrigation_manager` with helper functions to scale irrigation by zone
- test zone modifier helpers

## Testing
- `pytest tests/test_irrigation_manager.py -q`
- `pytest tests/test_dose_calculator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688596455ec48330b35efba1377d6c33