### PR TITLE
Add nutrient loss utilities

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -12,9 +12,14 @@ from .nutrient_planner import (
     NutrientManagementReport,
     generate_nutrient_management_report,
 )
+from . import nutrient_losses
 
 __all__ = sorted(
-    set(utils.__all__) | set(environment_tips.__all__) | set(media_manager.__all__) | {
+    set(utils.__all__)
+    | set(environment_tips.__all__)
+    | set(media_manager.__all__)
+    | set(nutrient_losses.__all__)
+    | {
         "NutrientManagementReport",
         "generate_nutrient_management_report",
     }

--- a/plant_engine/nutrient_losses.py
+++ b/plant_engine/nutrient_losses.py
@@ -1,0 +1,31 @@
+"""Aggregate nutrient losses from leaching and volatilization."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from . import nutrient_leaching, nutrient_volatilization
+
+__all__ = [
+    "estimate_total_loss",
+    "compensate_for_losses",
+]
+
+
+def estimate_total_loss(levels_mg: Mapping[str, float], plant_type: str | None = None) -> Dict[str, float]:
+    """Return combined nutrient losses from leaching and volatilization."""
+    leach = nutrient_leaching.estimate_leaching_loss(levels_mg, plant_type)
+    vol = nutrient_volatilization.estimate_volatilization_loss(levels_mg, plant_type)
+
+    losses: Dict[str, float] = {}
+    for nutrient in set(levels_mg) | set(leach) | set(vol):
+        losses[nutrient] = round(leach.get(nutrient, 0.0) + vol.get(nutrient, 0.0), 2)
+    return losses
+
+
+def compensate_for_losses(levels_mg: Mapping[str, float], plant_type: str | None = None) -> Dict[str, float]:
+    """Return nutrient amounts adjusted for expected losses."""
+    losses = estimate_total_loss(levels_mg, plant_type)
+    adjusted: Dict[str, float] = {}
+    for nutrient, mg in levels_mg.items():
+        adjusted[nutrient] = round(float(mg) + losses.get(nutrient, 0.0), 2)
+    return adjusted

--- a/tests/test_nutrient_losses.py
+++ b/tests/test_nutrient_losses.py
@@ -1,0 +1,14 @@
+from plant_engine import nutrient_losses
+
+
+def test_estimate_total_loss_combines_sources():
+    levels = {"N": 100, "P": 50}
+    loss = nutrient_losses.estimate_total_loss(levels, plant_type="tomato")
+    assert set(loss) == {"N", "P"}
+    assert all(v >= 0 for v in loss.values())
+
+
+def test_compensate_for_losses_adds_losses():
+    levels = {"N": 100}
+    result = nutrient_losses.compensate_for_losses(levels, plant_type="lettuce")
+    assert result["N"] >= 100


### PR DESCRIPTION
## Summary
- add `nutrient_losses` module to aggregate leaching and volatilization loss data
- export loss utilities from `plant_engine`
- test nutrient loss helpers

## Testing
- `pytest tests/test_nutrient_losses.py -q`
- `pytest tests/test_fertilizer_formulator.py::test_calculate_fertilizer_nutrients -q`

------
https://chatgpt.com/codex/tasks/task_e_688596362b648330afb95facdf220acf