### PR TITLE
Add nutrient synergy utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -6,6 +6,7 @@
   "nutrient_weights.json": "Relative importance weighting for nutrient scoring.",
   "nutrient_tag_modifiers.json": "Tag-based multipliers for nutrient targets.",
   "nutrient_efficiency_targets.json": "Typical nutrient use efficiency (g yield per mg applied) for each crop.",
+  "nutrient_synergies.json": "Synergy factors for nutrient pairs to adjust recommendations.",
   "solution_guidelines.json": "Optimal nutrient solution EC, pH, temperature and dissolved oxygen ranges.",
   "environment_score_weights.json": "Weights for environment quality metrics.",
   "environment_quality_thresholds.json": "Score boundaries for good, fair and poor classifications.",

--- a/data/nutrient_synergies.json
+++ b/data/nutrient_synergies.json
@@ -1,0 +1,4 @@
+{
+  "n_p": {"factor": 1.1, "message": "Nitrogen improves phosphorus uptake"},
+  "ca_b": {"factor": 1.05, "message": "Calcium transport aided by boron"}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -12,11 +12,22 @@ from .nutrient_planner import (
     NutrientManagementReport,
     generate_nutrient_management_report,
 )
+from .nutrient_synergy import (
+    list_synergy_pairs,
+    get_synergy_factor,
+    apply_synergy_adjustments,
+)
 
 __all__ = sorted(
-    set(utils.__all__) | set(environment_tips.__all__) | set(media_manager.__all__) | {
+    set(utils.__all__)
+    | set(environment_tips.__all__)
+    | set(media_manager.__all__)
+    | {
         "NutrientManagementReport",
         "generate_nutrient_management_report",
+        "list_synergy_pairs",
+        "get_synergy_factor",
+        "apply_synergy_adjustments",
     }
 )
 

--- a/plant_engine/nutrient_synergy.py
+++ b/plant_engine/nutrient_synergy.py
@@ -1,0 +1,61 @@
+"""Nutrient synergy adjustments for fertilizer recommendations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Tuple
+
+from .utils import load_dataset, list_dataset_entries
+
+DATA_FILE = "nutrient_synergies.json"
+
+@dataclass(frozen=True)
+class SynergyInfo:
+    factor: float
+    message: str = ""
+
+_DATA: Dict[str, Dict[str, object]] = load_dataset(DATA_FILE)
+_SYNERGY_MAP: Dict[Tuple[str, str], SynergyInfo] = {}
+for key, info in _DATA.items():
+    if not isinstance(info, Mapping):
+        continue
+    try:
+        n1, n2 = key.split("_")
+        factor = float(info.get("factor", 1.0))
+        msg = str(info.get("message", ""))
+        _SYNERGY_MAP[(n1, n2)] = SynergyInfo(factor=factor, message=msg)
+    except Exception:
+        continue
+
+__all__ = [
+    "list_synergy_pairs",
+    "get_synergy_info",
+    "get_synergy_factor",
+    "apply_synergy_adjustments",
+]
+
+
+def list_synergy_pairs() -> list[str]:
+    """Return all nutrient pairs with synergy data."""
+    return list_dataset_entries(_DATA)
+
+
+def get_synergy_info(pair: str) -> Dict[str, object]:
+    """Return raw synergy entry for ``pair`` if defined."""
+    return _DATA.get(pair.lower(), {})
+
+
+def get_synergy_factor(n1: str, n2: str) -> float | None:
+    """Return synergy factor for nutrients ``n1`` and ``n2`` if available."""
+    info = _SYNERGY_MAP.get((n1.lower(), n2.lower())) or _SYNERGY_MAP.get(
+        (n2.lower(), n1.lower())
+    )
+    return info.factor if info else None
+
+
+def apply_synergy_adjustments(levels: Mapping[str, float]) -> Dict[str, float]:
+    """Return ``levels`` adjusted using defined synergy factors."""
+    result = {k: float(v) for k, v in levels.items()}
+    for (n1, n2), info in _SYNERGY_MAP.items():
+        if n1 in levels and n2 in levels:
+            result[n2] = round(result[n2] * info.factor, 2)
+    return result

--- a/tests/test_nutrient_synergy.py
+++ b/tests/test_nutrient_synergy.py
@@ -1,0 +1,26 @@
+from plant_engine.nutrient_synergy import (
+    list_synergy_pairs,
+    get_synergy_factor,
+    apply_synergy_adjustments,
+)
+
+
+def test_list_synergy_pairs():
+    pairs = list_synergy_pairs()
+    assert "n_p" in pairs
+    assert "ca_b" in pairs
+
+
+def test_get_synergy_factor_case_insensitive():
+    factor = get_synergy_factor("N", "p")
+    assert factor == 1.1
+
+
+def test_apply_synergy_adjustments():
+    levels = {"n": 100, "p": 50, "ca": 60, "b": 2}
+    adjusted = apply_synergy_adjustments(levels)
+    # N/P pair should increase P by 10%
+    assert adjusted["p"] == 55.0
+    # Ca/B pair increases B by 5%
+    assert adjusted["b"] == 2 * 1.05
+


### PR DESCRIPTION
## Summary
- add dataset describing nutrient synergies
- expose synergy helpers in `plant_engine`
- implement `nutrient_synergy` module
- document dataset in catalog
- test synergy utilities

## Testing
- `pytest -q tests/test_nutrient_synergy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885962fa7188330b895bc8d9a75ac8c