### PR TITLE
Improve profile management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,20 @@ directory and accepts several subcommands:
 python scripts/profile_manager.py attach-sensor <plant_id> <sensor_type> sensor.a sensor.b
 python scripts/profile_manager.py detach-sensor <plant_id> <sensor_type> sensor.a
 python scripts/profile_manager.py list-sensors <plant_id>
+python scripts/profile_manager.py show-prefs <plant_id>
+python scripts/profile_manager.py list-logs <plant_id>
 
 # read the last entries from a log
 python scripts/profile_manager.py show-history <plant_id> events --lines 10
+
+# inspect global templates
+python scripts/profile_manager.py list-globals
+python scripts/profile_manager.py show-global tomato
 
 # change preferences like automation flags
 python scripts/profile_manager.py set-pref <plant_id> auto_approve_all true
 
 # load a new local profile from a global template
-python scripts/profile_manager.py list-globals
 python scripts/profile_manager.py load-default tomato my_tomato
 
 # override default paths
@@ -293,7 +298,7 @@ Helper scripts live in the `scripts/` directory.
 - `monitor_schedule.py` outputs an integrated pest and disease monitoring
   schedule for a plant stage.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
-- `profile_manager.py` manages sensors, preferences, and templates.  `attach-sensor` appends new sensors, while `detach-sensor` removes them.  Other subcommands include `list-sensors`, `set-pref`, `load-default`, `show-history`, and `list-globals`.  `--plants-dir` and `--global-dir` operate on alternate directories.
+- `profile_manager.py` manages sensors, preferences, templates and history files. `attach-sensor` appends new sensors, while `detach-sensor` removes them. Other subcommands include `list-sensors`, `show-prefs`, `list-logs`, `set-pref`, `load-default`, `show-history`, `show-global`, and `list-globals`. `--plants-dir` and `--global-dir` operate on alternate directories.
 
 Example usage:
 ```bash

--- a/tests/test_profile_manager_script.py
+++ b/tests/test_profile_manager_script.py
@@ -57,6 +57,33 @@ def test_list_global_profiles(tmp_path: Path):
     assert profiles == ["a", "b"]
 
 
+def test_show_global_profile(tmp_path: Path):
+    global_dir = tmp_path / "data/global_profiles"
+    global_dir.mkdir(parents=True)
+    data = {"general": {"plant_type": "demo"}}
+    (global_dir / "demo.json").write_text(json.dumps(data))
+
+    result = pm.show_global_profile("demo", global_dir)
+    assert result["general"]["plant_type"] == "demo"
+
+
+def test_show_preferences_and_logs(tmp_path: Path):
+    plants_dir = tmp_path / "plants"
+    plant_home = plants_dir / "p1"
+    plant_home.mkdir(parents=True)
+    profile = {"general": {"auto_approve_all": True, "sensor_entities": {"m": ["a"]}}}
+    (plants_dir / "p1.json").write_text(json.dumps(profile))
+    (plant_home / "events.json").write_text("[]")
+    (plant_home / "metrics.json").write_text("[]")
+
+    prefs = pm.show_preferences("p1", plants_dir)
+    assert prefs["auto_approve_all"] is True
+    assert "sensor_entities" not in prefs
+
+    logs = pm.list_log_files("p1", plants_dir)
+    assert logs == ["events", "metrics"]
+
+
 def test_attach_and_detach_sensor(tmp_path: Path):
     plants_dir = tmp_path / "plants"
     plants_dir.mkdir()


### PR DESCRIPTION
## Summary
- expand profile manager with utilities to show preferences and logs
- support showing global templates
- update documentation with new commands
- add tests for new helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885962c1e9c8330a26f30c7c28559fe