### PR TITLE
Add fertigation mix recommendation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Stage-adjusted nutrient targets and leaf tissue analysis
 - Nutrient deficiency severity and treatment recommendations
 - Combined nutrient management reports with correction schedules
+- Automatic fertigation mix recommendations using priced fertilizer data
 - Daily report files summarizing environment and nutrient targets
 - Environment score and quality rating for sensor data
 - Infiltration-aware irrigation burst scheduling

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -304,3 +304,10 @@ def test_estimate_deficiency_correction_cost():
     with pytest.raises(ValueError):
         estimate_deficiency_correction_cost(current, "citrus", "vegetative", 0)
 
+
+def test_recommend_fertigation_mix():
+    mix = fert_mod.recommend_fertigation_mix("citrus", "vegetative", 1)
+    assert mix
+    ppm = fert_mod.calculate_mix_ppm(mix, 1)
+    assert ppm.get("N", 0) >= 80
+


### PR DESCRIPTION
## Summary
- document new fertigation mix capability
- support generating cheapest fertigation mix from nutrient guidelines
- test fertigation mix helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a046c2f88330847707819e06552f