### PR TITLE
Improve environment alias handling

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -10,6 +10,7 @@
   "solution_guidelines.json": "Optimal nutrient solution EC, pH, temperature and dissolved oxygen ranges.",
   "environment_score_weights.json": "Weights for environment quality metrics.",
   "environment_quality_thresholds.json": "Score boundaries for good, fair and poor classifications.",
+  "environment_aliases.json": "Canonical environment metric names mapped to accepted aliases.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",
   "pest_monitoring_intervals.json": "Recommended days between scouting events.",

--- a/data/environment_aliases.json
+++ b/data/environment_aliases.json
@@ -1,0 +1,19 @@
+{
+  "temp_c": ["temp_c", "temperature", "temp", "temperature_c", "temp_custom"],
+  "temp_f": ["temp_f", "temperature_f", "temp_fahrenheit"],
+  "temp_k": ["temp_k", "temperature_k", "temp_kelvin"],
+  "humidity_pct": ["humidity_pct", "humidity", "rh", "rh_pct"],
+  "light_ppfd": ["light_ppfd", "light", "par", "par_w_m2"],
+  "co2_ppm": ["co2_ppm", "co2"],
+  "ec": ["ec", "EC"],
+  "wind_m_s": ["wind_m_s", "wind", "wind_speed"],
+  "soil_moisture_pct": ["soil_moisture_pct", "soil_moisture", "moisture", "vwc"],
+  "soil_temp_c": ["soil_temp_c", "soil_temperature", "soil_temp", "root_temp"],
+  "soil_temp_f": ["soil_temp_f", "soil_temp_fahrenheit"],
+  "soil_temp_k": ["soil_temp_k", "soil_temperature_k", "soil_temp_kelvin"],
+  "leaf_temp_c": ["leaf_temp_c", "leaf_temp", "leaf_temperature"],
+  "leaf_temp_f": ["leaf_temp_f", "leaf_temp_fahrenheit"],
+  "leaf_temp_k": ["leaf_temp_k", "leaf_temp_kelvin"],
+  "dli": ["dli", "daily_light_integral"],
+  "photoperiod_hours": ["photoperiod_hours", "photoperiod", "day_length"]
+}

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -608,6 +608,12 @@ def test_normalize_environment_readings_leaf_temp_aliases():
     assert result["leaf_temp_c"] == pytest.approx(26.85, rel=1e-2)
 
 
+def test_normalize_environment_readings_dataset_alias():
+    data = {"temp_custom": 21}
+    result = normalize_environment_readings(data)
+    assert result == {"temp_c": 21.0}
+
+
 def test_normalize_environment_readings_light_aliases():
     data = {"daily_light_integral": 18, "photoperiod": 14}
     result = normalize_environment_readings(data)


### PR DESCRIPTION
## Summary
- load environment aliases from new `environment_aliases.json`
- expose `get_environment_aliases` helper
- test dataset-driven alias behavior
- document new dataset in catalog

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a0424e788330afc1d322836930cd