### PR TITLE
Improve fertigation mix by including synergy adjustments

### DIFF
--- a/plant_engine/nutrient_synergy.py
+++ b/plant_engine/nutrient_synergy.py
@@ -55,7 +55,9 @@ def get_synergy_factor(n1: str, n2: str) -> float | None:
 def apply_synergy_adjustments(levels: Mapping[str, float]) -> Dict[str, float]:
     """Return ``levels`` adjusted using defined synergy factors."""
     result = {k: float(v) for k, v in levels.items()}
+    lookup = {k.lower(): k for k in levels}
     for (n1, n2), info in _SYNERGY_MAP.items():
-        if n1 in levels and n2 in levels:
-            result[n2] = round(result[n2] * info.factor, 2)
+        if n1 in lookup and n2 in lookup:
+            key = lookup[n2]
+            result[key] = round(result[key] * info.factor, 2)
     return result

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -97,6 +97,12 @@ def test_recommend_nutrient_mix_deficit():
     assert mix["kcl"] == pytest.approx(0.4, rel=1e-2)
 
 
+def test_recommend_nutrient_mix_synergy():
+    base = recommend_nutrient_mix("tomato", "vegetative", 10.0)
+    synergized = recommend_nutrient_mix("tomato", "vegetative", 10.0, use_synergy=True)
+    assert synergized["map"] > base["map"]
+
+
 def test_recommend_fertigation_with_water():
     schedule, warnings = recommend_fertigation_with_water(
         "tomato",


### PR DESCRIPTION
## Summary
- allow `recommend_nutrient_mix` to optionally adjust targets using nutrient synergy factors
- make `apply_synergy_adjustments` case-insensitive
- test fertigation mix with synergy enabled

## Testing
- `pytest tests/test_fertigation.py -q`
- `pytest tests/test_nutrient_synergy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a03bcd948330b300fcf9842b6ef0