### PR TITLE
Extend fertigation utilities with pump flow support

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -138,5 +138,7 @@
   "feature/wsda_refactored_sharded/detail/": "Detailed WSDA product info (one file per product_id)",
   "feature/wsda_refactored_sharded/index_sharded/": "Sharded index of WSDA fertilizer products",
   "propagation_guidelines.json": "Recommended environmental conditions for plant propagation methods.",
-  "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
+  "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+  "pump_flow_rates.json": "Default flow rates for injector pumps in mL/min."
 }
+

--- a/data/pump_flow_rates.json
+++ b/data/pump_flow_rates.json
@@ -1,0 +1,5 @@
+{
+  "generic_pump": 1000,
+  "dosatron_d14mz2": 1320,
+  "bluelab_peripod_m4": 400
+}

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -458,3 +458,17 @@ def test_estimate_weekly_fertigation_cost():
     )
     assert cost > 0
 
+
+def test_get_pump_flow_rate():
+    from plant_engine.fertigation import get_pump_flow_rate
+    assert get_pump_flow_rate("generic_pump") == 1000
+    assert get_pump_flow_rate("unknown") is None
+
+
+def test_estimate_injection_time():
+    from plant_engine.fertigation import estimate_injection_time
+    assert estimate_injection_time(1000, 500) == 2.0
+    with pytest.raises(ValueError):
+        estimate_injection_time(0, 500)
+    with pytest.raises(ValueError):
+        estimate_injection_time(100, 0)


### PR DESCRIPTION
## Summary
- add `pump_flow_rates.json` dataset and register it in catalog
- support injector pump flow data and injection time calculations
- test fertigation pump utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a039360083308610e31103537864