### PR TITLE
Add seasonal environment adjustments

### DIFF
--- a/data/seasonal_environment_modifiers.json
+++ b/data/seasonal_environment_modifiers.json
@@ -1,0 +1,4 @@
+{
+  "winter": {"temp_c": -2, "humidity_pct": 5},
+  "summer": {"temp_c": 2, "humidity_pct": -5}
+}

--- a/tests/test_environment_guidelines.py
+++ b/tests/test_environment_guidelines.py
@@ -1,4 +1,9 @@
-from plant_engine.environment_manager import get_environment_guidelines, get_environmental_targets
+from plant_engine.environment_manager import (
+    get_environment_guidelines,
+    get_environmental_targets,
+    get_seasonal_environment_guidelines,
+    get_seasonal_environmental_targets,
+)
 
 
 def test_get_environment_guidelines_dataclass():
@@ -13,3 +18,15 @@ def test_get_environmental_targets_matches_dataclass():
     guide_dict = get_environmental_targets("citrus", "seedling")
     guide = get_environment_guidelines("citrus", "seedling")
     assert guide_dict == guide.as_dict()
+
+
+def test_get_seasonal_environment_guidelines_winter():
+    guide = get_seasonal_environment_guidelines("citrus", "seedling", season="winter")
+    assert guide.temp_c == (20.0, 24.0)
+    assert guide.humidity_pct == (65.0, 85.0)
+
+
+def test_get_seasonal_environmental_targets_matches_dataclass():
+    guide = get_seasonal_environment_guidelines("citrus", "seedling", season="summer")
+    targets = get_seasonal_environmental_targets("citrus", "seedling", season="summer")
+    assert targets == guide.as_dict()


### PR DESCRIPTION
## Summary
- add seasonal environment modifiers dataset
- extend environment manager with seasonal guideline helpers
- include dataset loader and new API exports
- update tests for seasonal guidelines

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a0361f608330b7adea96c8323747