### PR TITLE
Improve nutrient budget calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Stage-adjusted nutrient targets and leaf tissue analysis
 - Nutrient deficiency severity and treatment recommendations
 - Combined nutrient management reports with correction schedules
+- Recovery-aware fertilizer estimates using nutrient recovery factors
 - Daily report files summarizing environment and nutrient targets
 - Environment score and quality rating for sensor data
 - Infiltration-aware irrigation burst scheduling

--- a/tests/test_nutrient_budget.py
+++ b/tests/test_nutrient_budget.py
@@ -40,3 +40,13 @@ def test_estimate_solution_volume():
     assert volumes["foxfarm_grow_big"] == 0.5  # 150g / 300 g/L
     assert volumes["magriculture"] == 1.0      # 800g / 800 g/L
 
+
+def test_estimate_recovery_adjusted_requirements():
+    ferts = {"N": "urea", "P": "map", "K": "kcl"}
+    masses = nutrient_budget.estimate_recovery_adjusted_requirements(
+        "lettuce", 1.0, ferts, efficiency=1.0
+    )
+    assert round(masses["urea"], 2) == 4.74
+    assert round(masses["map"], 2) == 3.03
+    assert round(masses["kcl"], 2) == 5.0
+


### PR DESCRIPTION
## Summary
- expose a new helper `estimate_recovery_adjusted_requirements`
- test the helper in nutrient budget tests
- document recovery-aware fertilizer estimation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a03319b08330aa93777c8753ce95