### PR TITLE
Add drought tolerance dataset and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Important categories include:
 - **Soil pH guidelines** – optimal soil pH ranges for supported crops
 - **Root temperature uptake factors** – relative nutrient uptake efficiency by root zone temperature
 - **Media properties** – recommended pH range and water retention for common substrates
+- **Drought tolerance** – maximum days plants can remain dry before watering
 
 The WSDA fertilizer dataset resides under `feature/wsda_refactored_sharded/` which contains an
 `index_sharded/` directory of `.jsonl` shards and a `detail/` directory of per-product records.

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -138,5 +138,6 @@
   "feature/wsda_refactored_sharded/detail/": "Detailed WSDA product info (one file per product_id)",
   "feature/wsda_refactored_sharded/index_sharded/": "Sharded index of WSDA fertilizer products",
   "propagation_guidelines.json": "Recommended environmental conditions for plant propagation methods.",
+  "drought_tolerance.json": "Relative drought tolerance and max dry days for each crop.",
   "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/drought_tolerance.json
+++ b/data/drought_tolerance.json
@@ -1,0 +1,9 @@
+{
+  "lettuce": {"tolerance": "low", "max_dry_days": 1},
+  "citrus": {"tolerance": "moderate", "max_dry_days": 3},
+  "basil": {"tolerance": "low", "max_dry_days": 1},
+  "cucumber": {"tolerance": "moderate", "max_dry_days": 2},
+  "pepper": {"tolerance": "high", "max_dry_days": 4},
+  "strawberry": {"tolerance": "low", "max_dry_days": 2},
+  "blueberry": {"tolerance": "moderate", "max_dry_days": 3}
+}

--- a/plant_engine/drought_manager.py
+++ b/plant_engine/drought_manager.py
@@ -1,0 +1,41 @@
+"""Access drought tolerance guidelines for scheduling irrigation."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "drought_tolerance.json"
+
+_DATA: Dict[str, Dict[str, object]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_drought_tolerance",
+    "recommend_watering_interval",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with drought tolerance data."""
+    return list_dataset_entries(_DATA)
+
+
+@lru_cache(maxsize=None)
+def get_drought_tolerance(plant_type: str) -> Dict[str, object] | None:
+    """Return drought tolerance info for ``plant_type`` if available."""
+    return _DATA.get(normalize_key(plant_type))
+
+
+def recommend_watering_interval(plant_type: str, default_days: int = 1) -> int:
+    """Return maximum days between watering based on drought tolerance."""
+    info = get_drought_tolerance(plant_type)
+    if not info:
+        return default_days
+    try:
+        days = int(info.get("max_dry_days", default_days))
+        return days if days > 0 else default_days
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return default_days

--- a/tests/test_deep_update.py
+++ b/tests/test_deep_update.py
@@ -1,0 +1,15 @@
+from plant_engine.utils import deep_update
+
+
+def test_deep_update_nested_dict():
+    base = {"a": {"b": 1, "c": 2}, "d": 3}
+    other = {"a": {"b": 4}, "e": 5}
+    result = deep_update(base, other)
+    assert result == {"a": {"b": 4, "c": 2}, "d": 3, "e": 5}
+
+
+def test_deep_update_overwrite_non_mapping():
+    base = {"a": {"b": 1}, "d": 2}
+    other = {"a": 3}
+    result = deep_update(base, other)
+    assert result == {"a": 3, "d": 2}

--- a/tests/test_drought_manager.py
+++ b/tests/test_drought_manager.py
@@ -1,0 +1,18 @@
+from plant_engine import drought_manager
+
+
+def test_list_supported_plants():
+    plants = drought_manager.list_supported_plants()
+    assert "lettuce" in plants
+    assert "pepper" in plants
+
+
+def test_get_drought_tolerance():
+    info = drought_manager.get_drought_tolerance("citrus")
+    assert info["tolerance"] == "moderate"
+    assert info["max_dry_days"] == 3
+
+
+def test_recommend_watering_interval():
+    assert drought_manager.recommend_watering_interval("pepper") == 4
+    assert drought_manager.recommend_watering_interval("unknown", default_days=2) == 2


### PR DESCRIPTION
## Summary
- include drought tolerance dataset and catalog entry
- support drought tolerance lookups via new `drought_manager`
- extend docs with new dataset description
- cover `deep_update` utility
- test drought tolerance utilities

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a030657483308a7e303bab55231b