### PR TITLE
Add pest severity thresholds

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -77,6 +77,7 @@
   "pest_risk_factors.json": "Environmental factors increasing pest risk.",
   "disease_risk_factors.json": "Environmental factors increasing disease risk.",
   "pest_severity_actions.json": "Actions to take based on pest severity level.",
+  "pest_severity_thresholds.json": "Population levels defining pest severity categories.",
   "ph_adjustment_factors.json": "Acid/base amounts for pH corrections.",
   "ph_guidelines.json": "Optimal pH ranges for nutrient uptake.",
   "growth_medium_ph_ranges.json": "Recommended pH ranges for common growing media.",

--- a/data/pest_severity_thresholds.json
+++ b/data/pest_severity_thresholds.json
@@ -1,0 +1,4 @@
+{
+  "scale": {"moderate": 2, "severe": 4},
+  "spider mites": {"moderate": 3, "severe": 6}
+}


### PR DESCRIPTION
## Summary
- integrate optional pest severity thresholds
- support custom severity cutoffs in pest monitor
- document new dataset
- test pest monitor severity overrides

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a02d24188330ad1f292c8f8a0fd4