### PR TITLE
Refactor dataset search paths

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -18,7 +18,7 @@ __all__ = [
     "lazy_dataset",
     "clear_dataset_cache",
     "dataset_paths",
-    "dataset_file",
+    "dataset_search_paths",
     "get_data_dir",
     "get_pending_dir",
     "get_extra_dirs",
@@ -179,16 +179,22 @@ def dataset_paths() -> tuple[Path, ...]:
     return _PATH_CACHE
 
 
+def dataset_search_paths(include_overlay: bool = False) -> tuple[Path, ...]:
+    """Return dataset search paths optionally including overlay first."""
+
+    paths = []
+    if include_overlay:
+        ov = overlay_dir()
+        if ov:
+            paths.append(ov)
+    paths.extend(dataset_paths())
+    return tuple(paths)
+
+
 def dataset_file(filename: str) -> Path | None:
     """Return absolute path to ``filename`` if found in search paths."""
 
-    overlay = overlay_dir()
-    if overlay:
-        path = overlay / filename
-        if path.exists():
-            return path
-
-    for base in dataset_paths():
+    for base in dataset_search_paths(include_overlay=True):
         path = base / filename
         if path.exists():
             return path

--- a/tests/test_dataset_paths.py
+++ b/tests/test_dataset_paths.py
@@ -38,6 +38,17 @@ def test_overlay_dir_cache(monkeypatch, tmp_path):
     assert utils.overlay_dir() == overlay
     monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(tmp_path / "other"))
     utils.clear_dataset_cache()
+
+
+def test_dataset_search_paths_includes_overlay(monkeypatch, tmp_path):
+    base = tmp_path / "data"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    overlay.mkdir()
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
     importlib.reload(utils)
-    assert utils.overlay_dir() != overlay
+    paths = utils.dataset_search_paths(include_overlay=True)
+    assert paths[0] == overlay
+    assert base in paths
     utils.clear_dataset_cache()


### PR DESCRIPTION
## Summary
- add `dataset_search_paths` helper to centralize dataset discovery logic
- update `dataset_file` to use the new helper
- add regression test for overlay-aware search paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a02a85b08330a55d795afbeae4a9