### PR TITLE
Enhance dose calculator with purity data

### DIFF
--- a/tests/test_dose_calculator.py
+++ b/tests/test_dose_calculator.py
@@ -59,3 +59,12 @@ def test_blend_solutions():
     with pytest.raises(ValueError):
         DoseCalculator.blend_solutions(100, -1, 100, 1)
 
+
+def test_calculate_nutrient_dose():
+    grams = DoseCalculator.calculate_nutrient_dose("N", 150, 10, "urea")
+    assert grams == pytest.approx(3.261, rel=1e-3)
+    with pytest.raises(ValueError):
+        DoseCalculator.calculate_nutrient_dose("N", 100, 0, "urea")
+    with pytest.raises(ValueError):
+        DoseCalculator.calculate_nutrient_dose("X", 100, 10, "urea")
+


### PR DESCRIPTION
## Summary
- extend dose calculator with `calculate_nutrient_dose` helper
- cover new logic with tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a02441dc8330bbe499eb130889e0