### PR TITLE
Add training guidelines dataset and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ python -m custom_components.horticulture_assistant.analytics.export_all_growth_y
 - Tag plants (e.g. `"blueberry"`, `"fruiting"`) to generate grouped dashboards and reports.
 - `recommend_nutrient_mix` computes fertilizer grams needed to hit N/P/K targets and can include micronutrients. `recommend_nutrient_mix_with_cost` returns the same schedule with estimated cost. `generate_nutrient_management_report` consolidates analysis and correction grams for a solution volume.
 - `get_pruning_instructions` provides stage-specific pruning tips from `pruning_guidelines.json`.
+- `get_training_guideline` gives training advice for each stage from `training_guidelines.json`.
 - `generate_cycle_irrigation_plan` returns stage irrigation volumes using guideline intervals and durations.
 - `calculate_environment_stddev` computes standard deviation of environment sensor series for tighter control.
 - `estimate_hvac_energy_series` and `estimate_hvac_cost_series` evaluate energy

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -83,6 +83,7 @@
   "planting_depth_guidelines.json": "Recommended seeding or transplant depths.",
   "pruning_guidelines.json": "Stage-specific pruning recommendations.",
   "pruning_intervals.json": "Days between pruning events for each plant stage.",
+  "training_guidelines.json": "Guidelines for plant training techniques by stage.",
   "soil_nutrient_guidelines.json": "Target soil nutrient levels by crop.",
   "soil_texture_parameters.json": "Typical sand, silt and clay percentages.",
   "soil_infiltration_rates.json": "Infiltration rates (mm/hr) by soil texture.",

--- a/data/training_guidelines.json
+++ b/data/training_guidelines.json
@@ -1,0 +1,9 @@
+{
+  "tomato": {
+    "seedling": "Gently bend stems daily to encourage strength.",
+    "vegetative": "Train main stem vertically and prune side shoots."
+  },
+  "citrus": {
+    "vegetative": "Stake young trees for upright growth and remove suckers."
+  }
+}

--- a/plant_engine/training_manager.py
+++ b/plant_engine/training_manager.py
@@ -1,0 +1,37 @@
+"""Access plant training guidelines by stage."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "training_guidelines.json"
+
+# Loaded once via :func:`load_dataset` which caches results
+_DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "list_training_stages",
+    "get_training_guideline",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with training guidelines."""
+    return list_dataset_entries(_DATA)
+
+
+def list_training_stages(plant_type: str) -> list[str]:
+    """Return stages with training tips for ``plant_type``."""
+    plant = _DATA.get(normalize_key(plant_type), {})
+    return sorted(plant.keys()) if isinstance(plant, dict) else []
+
+
+def get_training_guideline(plant_type: str, stage: str) -> str | None:
+    """Return training advice for ``plant_type`` at ``stage`` if available."""
+    plant = _DATA.get(normalize_key(plant_type), {})
+    if not isinstance(plant, dict):
+        return None
+    guideline = plant.get(normalize_key(stage))
+    return str(guideline) if isinstance(guideline, str) else None

--- a/tests/test_training_manager.py
+++ b/tests/test_training_manager.py
@@ -1,0 +1,26 @@
+from plant_engine.training_manager import (
+    get_training_guideline,
+    list_supported_plants,
+    list_training_stages,
+)
+
+
+def test_list_supported_plants_contains_known():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+    assert "citrus" in plants
+
+
+def test_list_training_stages():
+    stages = list_training_stages("tomato")
+    assert "seedling" in stages
+    assert "vegetative" in stages
+
+
+def test_get_training_guideline_case_insensitive():
+    guid = get_training_guideline("ToMaTo", "VeGeTaTiVe")
+    assert "prune" in guid.lower()
+
+
+def test_get_training_guideline_unknown():
+    assert get_training_guideline("unknown", "stage") is None


### PR DESCRIPTION
## Summary
- create `training_guidelines.json` dataset and register it in `dataset_catalog.json`
- add `training_manager` module to fetch stage-specific training advice
- document `get_training_guideline` helper in README
- test new training manager utilities

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a01e38e48330b90ed6cdc64ea62b