### PR TITLE
Add comprehensive plan generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Helper scripts live in the `scripts/` directory.
   solution injection volumes.
 - `monitor_schedule.py` outputs an integrated pest and disease monitoring
   schedule for a plant stage.
+- `comprehensive_plan.py` creates a single JSON file with environment setpoints,
+  fertigation schedules and monitoring dates.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
 - `profile_manager.py` manages sensors, preferences, templates and history files. `attach-sensor` appends new sensors, while `detach-sensor` removes them. Other subcommands include `list-sensors`, `show-prefs`, `list-logs`, `set-pref`, `load-default`, `show-history`, `show-global`, and `list-globals`. `--plants-dir` and `--global-dir` operate on alternate directories.
 
@@ -310,6 +312,7 @@ python scripts/train_ec_model.py samples.csv --plant-id myplant
 python scripts/profile_manager.py load-default tomato my_plant
 python scripts/profile_manager.py list-sensors my_plant
 python scripts/precision_fertigation.py tomato vegetative 10
+python scripts/comprehensive_plan.py tomato vegetative 7 2025-01-01 4
 python -m custom_components.horticulture_assistant.analytics.export_all_growth_yield
 ```
 

--- a/scripts/comprehensive_plan.py
+++ b/scripts/comprehensive_plan.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate a comprehensive cultivation plan for a crop stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+import sys
+
+# Ensure project root on the Python path when executed directly
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.environment_manager import generate_stage_environment_plan
+from plant_engine.fertigation import generate_fertigation_plan
+from plant_engine.integrated_monitor import generate_integrated_monitoring_schedule
+
+
+def generate_plan(
+    plant_type: str,
+    stage: str,
+    days: int,
+    start: date,
+    events: int,
+) -> dict:
+    """Return combined environment, fertigation and monitoring plans."""
+
+    env = generate_stage_environment_plan(plant_type).get(stage, {})
+    fertigation = generate_fertigation_plan(plant_type, stage, days)
+    monitoring = [
+        d.isoformat()
+        for d in generate_integrated_monitoring_schedule(
+            plant_type, stage, start, events
+        )
+    ]
+
+    return {
+        "environment": env,
+        "fertigation_schedule": fertigation,
+        "monitoring_schedule": monitoring,
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate environment, fertigation and monitoring plan"
+    )
+    parser.add_argument("plant_type", help="Crop identifier")
+    parser.add_argument("stage", help="Growth stage")
+    parser.add_argument("days", type=int, help="Fertigation schedule days")
+    parser.add_argument("start", help="Monitoring start date YYYY-MM-DD")
+    parser.add_argument("events", type=int, help="Number of monitoring events")
+    parser.add_argument("--output", type=Path, help="Optional output path")
+    args = parser.parse_args(argv)
+
+    plan = generate_plan(
+        args.plant_type,
+        args.stage,
+        args.days,
+        date.fromisoformat(args.start),
+        args.events,
+    )
+
+    text = json.dumps(plan, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_comprehensive_plan.py
+++ b/tests/test_comprehensive_plan.py
@@ -1,0 +1,18 @@
+from datetime import date
+
+from scripts import comprehensive_plan
+
+
+def test_generate_plan():
+    plan = comprehensive_plan.generate_plan(
+        "lettuce",
+        "vegetative",
+        3,
+        date(2025, 1, 1),
+        2,
+    )
+    assert "environment" in plan
+    assert "fertigation_schedule" in plan
+    assert "monitoring_schedule" in plan
+    assert len(plan["fertigation_schedule"]) == 3
+    assert len(plan["monitoring_schedule"]) == 2


### PR DESCRIPTION
## Summary
- add `comprehensive_plan.py` script to generate a combined environment, fertigation and monitoring plan
- document the new tool in README
- test plan generation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a01a427083309a6825e6377e5c57