### PR TITLE
Add fertigation planner utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Risk-adjusted pest monitoring summaries and scheduling
 - Automatic pesticide rotation planning
 - Summaries of reentry and harvest restrictions for applied pesticides
+- Automated fertigation planning with cost estimates
 
 ---
 

--- a/custom_components/horticulture_assistant/utils/fertigation_planner.py
+++ b/custom_components/horticulture_assistant/utils/fertigation_planner.py
@@ -1,0 +1,91 @@
+"""Helpers for generating fertigation plans from plant profiles."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Mapping, Dict, Any
+
+try:
+    from homeassistant.core import HomeAssistant
+except Exception:  # pragma: no cover - Home Assistant not available during tests
+    HomeAssistant = None  # type: ignore
+
+from .plant_profile_loader import load_profile_by_id
+from .path_utils import plants_path
+from plant_engine.fertigation import recommend_precise_fertigation
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class FertigationPlan:
+    """Structured fertigation recommendation."""
+
+    schedule: Dict[str, float]
+    cost_total: float
+    cost_breakdown: Dict[str, float]
+    warnings: Dict[str, Dict[str, float]]
+    diagnostics: Dict[str, Dict[str, float]]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "schedule": self.schedule,
+            "cost_total": self.cost_total,
+            "cost_breakdown": self.cost_breakdown,
+            "warnings": self.warnings,
+            "diagnostics": self.diagnostics,
+        }
+
+
+def plan_fertigation_from_profile(
+    plant_id: str,
+    volume_l: float,
+    hass: HomeAssistant | None = None,
+    *,
+    water_profile: Mapping[str, float] | None = None,
+    include_micro: bool = False,
+    fertilizers: Mapping[str, str] | None = None,
+) -> FertigationPlan:
+    """Return a fertigation plan using profile data and dataset guidelines."""
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    base_dir = plants_path(hass)
+    profile = load_profile_by_id(plant_id, base_dir)
+    if not profile:
+        _LOGGER.warning("Profile for %s not found", plant_id)
+        return FertigationPlan({}, 0.0, {}, {}, {})
+
+    general = profile.get("general", {})
+    plant_type = general.get("plant_type")
+    stage = (
+        general.get("lifecycle_stage")
+        or general.get("stage")
+        or profile.get("stage")
+    )
+    if not plant_type or not stage:
+        _LOGGER.warning("Incomplete profile for %s", plant_id)
+        return FertigationPlan({}, 0.0, {}, {}, {})
+
+    if fertilizers is None:
+        fertilizers = {
+            "N": "foxfarm_grow_big",
+            "P": "foxfarm_grow_big",
+            "K": "intrepid_granular_potash_0_0_60",
+        }
+
+    schedule, total, breakdown, warnings, diagnostics = recommend_precise_fertigation(
+        plant_type,
+        stage,
+        volume_l,
+        water_profile,
+        fertilizers=fertilizers,
+        include_micro=include_micro,
+    )
+
+    return FertigationPlan(schedule, total, breakdown, warnings, diagnostics)
+
+
+__all__ = ["plan_fertigation_from_profile", "FertigationPlan"]

--- a/tests/test_fertigation_planner.py
+++ b/tests/test_fertigation_planner.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+PACKAGE = "custom_components.horticulture_assistant.utils"
+MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/utils/fertigation_planner.py"
+spec = importlib.util.spec_from_file_location(f"{PACKAGE}.fertigation_planner", MODULE_PATH)
+fertigation_planner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = fertigation_planner
+spec.loader.exec_module(fertigation_planner)
+
+FertigationPlan = fertigation_planner.FertigationPlan
+plan_fertigation_from_profile = fertigation_planner.plan_fertigation_from_profile
+
+
+def _hass_for(base: Path):
+    class DummyConfig:
+        def __init__(self, base):
+            self._base = Path(base)
+        def path(self, name: str) -> str:
+            return str(Path(base) / name)
+    class DummyHass:
+        def __init__(self, base):
+            self.config = DummyConfig(base)
+    return DummyHass(base)
+
+
+def test_plan_fertigation_from_profile(tmp_path):
+    (tmp_path / "plants").mkdir()
+    (tmp_path / "plants/test.json").write_text(
+        '{"general": {"plant_type": "citrus", "stage": "vegetative"}}'
+    )
+    hass = _hass_for(tmp_path)
+    plan = plan_fertigation_from_profile("test", 5.0, hass)
+    assert isinstance(plan, FertigationPlan)
+    assert plan.schedule
+    assert plan.cost_total >= 0
+
+
+def test_plan_fertigation_missing_profile(tmp_path):
+    hass = _hass_for(tmp_path)
+    plan = plan_fertigation_from_profile("missing", 5.0, hass)
+    assert plan.schedule == {}
+    assert plan.cost_total == 0.0


### PR DESCRIPTION
## Summary
- implement `fertigation_planner` utility to generate fertigation plans from plant profiles
- add unit tests for the planner
- document fertigation planning feature in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a01193cc8330bbfa55d83c46eabf