### PR TITLE
Add cost optimized fertigation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Daily report files summarizing environment and nutrient targets
 - Environment score and quality rating for sensor data
 - Infiltration-aware irrigation burst scheduling
+- Cost-optimized fertigation plans with injection volumes
 - Risk-adjusted pest monitoring summaries and scheduling
 - Automatic pesticide rotation planning
 - Summaries of reentry and harvest restrictions for applied pesticides

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -236,6 +236,7 @@ __all__ = [
     "optimize_fertigation_schedule",
     "recommend_precise_fertigation",
     "recommend_precise_fertigation_with_injection",
+    "recommend_cost_optimized_fertigation_with_injection",
     "recommend_rootzone_fertigation",
     "grams_to_ppm",
     "check_solubility_limits",
@@ -1127,6 +1128,37 @@ def optimize_fertigation_schedule(
 
     cost = estimate_mix_cost(schedule) if schedule else 0.0
     return schedule, cost
+
+
+def recommend_cost_optimized_fertigation_with_injection(
+    plant_type: str,
+    stage: str,
+    volume_l: float,
+    *,
+    include_micro: bool = False,
+) -> tuple[Dict[str, float], float, Dict[str, float]]:
+    """Return lowest cost fertigation mix and injection volumes.
+
+    This helper combines :func:`optimize_fertigation_schedule` with
+    stock solution injection calculations so the resulting schedule can
+    be applied directly by nutrient injectors.
+    """
+
+    schedule, cost = optimize_fertigation_schedule(
+        plant_type, stage, volume_l, include_micro=include_micro
+    )
+
+    if not schedule:
+        return {}, 0.0, {}
+
+    from custom_components.horticulture_assistant.fertilizer_formulator import (
+        calculate_mix_ppm,
+    )
+
+    ppm_levels = calculate_mix_ppm(schedule, volume_l)
+    injection = recommend_stock_solution_injection(ppm_levels, volume_l)
+
+    return schedule, cost, injection
 
 
 def generate_cycle_fertigation_plan(

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -458,3 +458,19 @@ def test_estimate_weekly_fertigation_cost():
     )
     assert cost > 0
 
+
+def test_cost_optimized_fertigation_injection():
+    from plant_engine.fertigation import (
+        recommend_cost_optimized_fertigation_with_injection,
+    )
+
+    schedule, cost, injection = recommend_cost_optimized_fertigation_with_injection(
+        "tomato",
+        "vegetative",
+        5.0,
+    )
+
+    assert schedule
+    assert cost >= 0
+    assert injection
+


### PR DESCRIPTION
## Summary
- implement `recommend_cost_optimized_fertigation_with_injection` helper
- test cost-optimized fertigation with injection volumes
- document new capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a00ec7408330a92a344d29f2038a