### PR TITLE
Extend nutrient data and uptake utilities

### DIFF
--- a/data/growth_stages.json
+++ b/data/growth_stages.json
@@ -120,5 +120,10 @@
     "vegetative": {"duration_days": 60, "notes": "Focus on cane development."},
     "flowering": {"duration_days": 20, "notes": "Monitor for frost damage."},
     "fruiting": {"duration_days": 40, "notes": "Maintain soil acidity."}
+  },
+  "kale": {
+    "seedling": {"duration_days": 20, "notes": "Keep evenly moist."},
+    "vegetative": {"duration_days": 40, "notes": "Provide regular nitrogen."},
+    "harvest": {"duration_days": 30, "notes": "Harvest outer leaves first."}
   }
 }

--- a/data/nutrient_guidelines.json
+++ b/data/nutrient_guidelines.json
@@ -134,5 +134,9 @@
   "blueberry": {
     "vegetative": {"N": 60, "P": 20, "K": 50, "Ca": 30, "Mg": 15},
     "fruiting": {"N": 40, "P": 30, "K": 80, "Ca": 40, "Mg": 20}
+  },
+  "kale": {
+    "vegetative": {"N": 90, "P": 40, "K": 80, "Ca": 40, "Mg": 20},
+    "harvest": {"N": 70, "P": 30, "K": 100, "Ca": 40, "Mg": 20}
   }
 }

--- a/data/nutrient_uptake.json
+++ b/data/nutrient_uptake.json
@@ -27,5 +27,9 @@
   "blueberry": {
     "vegetative": {"N": 30, "P": 10, "K": 40},
     "fruiting": {"N": 20, "P": 15, "K": 60}
+  },
+  "kale": {
+    "vegetative": {"N": 55, "P": 25, "K": 75},
+    "harvest": {"N": 50, "P": 20, "K": 70}
   }
 }

--- a/plant_engine/nutrient_uptake.py
+++ b/plant_engine/nutrient_uptake.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Dict
 
+from .growth_stage import list_growth_stages
+
 from .utils import load_dataset, list_dataset_entries
 
 DATA_FILE = "nutrient_uptake.json"
@@ -14,6 +16,7 @@ __all__ = [
     "get_daily_uptake",
     "estimate_stage_totals",
     "estimate_total_uptake",
+    "estimate_cumulative_uptake",
     "estimate_average_daily_uptake",
     "get_uptake_ratio",
 ]
@@ -92,4 +95,22 @@ def estimate_average_daily_uptake(plant_type: str) -> Dict[str, float]:
         return {}
 
     return {nutrient: round(mg / days, 2) for nutrient, mg in totals.items()}
+
+
+def estimate_cumulative_uptake(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return total nutrient demand from the start through ``stage``."""
+
+    stages = list_growth_stages(plant_type)
+    if not stages or stage not in stages:
+        return {}
+
+    totals: Dict[str, float] = {}
+    for st in stages:
+        stage_totals = estimate_stage_totals(plant_type, st)
+        for nutrient, amount in stage_totals.items():
+            totals[nutrient] = round(totals.get(nutrient, 0.0) + amount, 2)
+        if st == stage:
+            break
+
+    return totals
 

--- a/tests/test_nutrient_uptake.py
+++ b/tests/test_nutrient_uptake.py
@@ -5,6 +5,7 @@ from plant_engine.nutrient_uptake import (
     get_daily_uptake,
     get_uptake_ratio,
     estimate_average_daily_uptake,
+    estimate_cumulative_uptake,
 )
 from plant_engine.fertigation import recommend_uptake_fertigation
 
@@ -20,6 +21,7 @@ def test_list_supported_plants():
     assert "lettuce" in plants
     assert "citrus" in plants
     assert "pepper" in plants
+    assert "kale" in plants
 
 
 def test_recommend_uptake_fertigation():
@@ -37,3 +39,9 @@ def test_get_uptake_ratio():
 def test_estimate_average_daily_uptake():
     avg = estimate_average_daily_uptake("tomato")
     assert avg == {"N": 51.67, "P": 15.83, "K": 60.0}
+
+
+def test_estimate_cumulative_uptake():
+    totals = estimate_cumulative_uptake("lettuce", "vegetative")
+    assert totals["N"] == 60 * 35
+    assert totals["K"] == 80 * 35


### PR DESCRIPTION
## Summary
- add kale to growth stage, nutrient guidelines and uptake datasets
- implement `estimate_cumulative_uptake` for running totals
- document new function in `nutrient_uptake`
- cover new logic with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a006225883309819524b77930e98