### PR TITLE
Enhance fertigation planning and trigger helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Important categories include:
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions
+- **Stock solution recipes** – injection ratios for automated fertigation
 - **Fertilizer compatibility** – warnings for mixing products that react poorly
 - **Soil pH guidelines** – optimal soil pH ranges for supported crops
 - **Root temperature uptake factors** – relative nutrient uptake efficiency by root zone temperature
@@ -310,6 +311,7 @@ python scripts/train_ec_model.py samples.csv --plant-id myplant
 python scripts/profile_manager.py load-default tomato my_plant
 python scripts/profile_manager.py list-sensors my_plant
 python scripts/precision_fertigation.py tomato vegetative 10
+python scripts/precision_fertigation.py tomato vegetative 10 --use-stock-recipe
 python -m custom_components.horticulture_assistant.analytics.export_all_growth_yield
 ```
 

--- a/custom_components/horticulture_assistant/automation/irrigation_trigger.py
+++ b/custom_components/horticulture_assistant/automation/irrigation_trigger.py
@@ -1,8 +1,12 @@
-import json
+"""Simplified irrigation trigger helper."""
+
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 
 from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from plant_engine.utils import load_json
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,10 +33,9 @@ def irrigation_trigger(
         _LOGGER.error("Plant profile file not found for plant_id: %s", plant_id)
         return False
     try:
-        with open(profile_path, "r", encoding="utf-8") as f:
-            profile_data = json.load(f)
-    except Exception as e:
-        _LOGGER.error("Failed to load profile for plant_id %s: %s", plant_id, e)
+        profile_data = load_json(str(profile_path))
+    except Exception as exc:  # pragma: no cover - log and fail gracefully
+        _LOGGER.error("Failed to load profile for plant_id %s: %s", plant_id, exc)
         return False
 
     # Check if irrigation is globally enabled for this plant
@@ -96,8 +99,18 @@ def irrigation_trigger(
 
     # Compare the current moisture against the threshold
     if current_val < threshold_val:
-        _LOGGER.info("Soil moisture below threshold for plant_id %s (%.2f < %.2f). Triggering irrigation.", plant_id, current_val, threshold_val)
+        _LOGGER.info(
+            "Soil moisture below threshold for plant_id %s (%.2f < %.2f). Triggering irrigation.",
+            plant_id,
+            current_val,
+            threshold_val,
+        )
         return True
-    else:
-        _LOGGER.info("Soil moisture sufficient for plant_id %s (%.2f >= %.2f). No irrigation needed.", plant_id, current_val, threshold_val)
-        return False
+
+    _LOGGER.info(
+        "Soil moisture sufficient for plant_id %s (%.2f >= %.2f). No irrigation needed.",
+        plant_id,
+        current_val,
+        threshold_val,
+    )
+    return False

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -123,6 +123,7 @@
   "risk_score_map.json": "Numeric weights for risk level scoring.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",
+  "stock_solution_recipes.json": "Recommended stock solution injection ratios by plant stage.",
   "cold_stress_thresholds.json": "Temperature levels causing cold stress.",
   "disease_monitoring_intervals.json": "Recommended days between disease scouting events.",
   "disease_severity_actions.json": "Actions to take based on disease severity level.",

--- a/data/stock_solution_recipes.json
+++ b/data/stock_solution_recipes.json
@@ -1,0 +1,8 @@
+{
+  "tomato": {
+    "vegetative": {"stock_a": 2.0, "stock_b": 1.0}
+  },
+  "lettuce": {
+    "seedling": {"stock_a": 1.0, "stock_b": 0.5}
+  }
+}

--- a/scripts/precision_fertigation.py
+++ b/scripts/precision_fertigation.py
@@ -29,6 +29,7 @@ def main(argv=None):
     parser.add_argument("volume_l", type=float)
     parser.add_argument("--water-profile")
     parser.add_argument("--include-micro", action="store_true")
+    parser.add_argument("--use-stock-recipe", action="store_true", help="Include preset stock solution ratios")
     parser.add_argument("--yaml", action="store_true", dest="as_yaml")
     args = parser.parse_args(argv)
 
@@ -49,6 +50,16 @@ def main(argv=None):
         include_micro=args.include_micro,
     )
 
+    recipe_injection = None
+    if args.use_stock_recipe:
+        from plant_engine.fertigation import apply_stock_solution_recipe
+
+        recipe_injection = apply_stock_solution_recipe(
+            args.plant_type,
+            args.stage,
+            args.volume_l,
+        )
+
     result = {
         "schedule": schedule,
         "cost_total": total,
@@ -56,6 +67,7 @@ def main(argv=None):
         "warnings": warnings,
         "diagnostics": diag,
         "injection_volumes": injection,
+        "recipe_injection": recipe_injection,
     }
 
     if args.as_yaml:

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -359,6 +359,19 @@ def test_recommend_stock_solution_injection():
     assert result["stock_b"] == pytest.approx(10.0, rel=1e-3)
 
 
+def test_stock_solution_recipes():
+    from plant_engine.fertigation import (
+        get_stock_solution_recipe,
+        apply_stock_solution_recipe,
+    )
+
+    recipe = get_stock_solution_recipe("tomato", "vegetative")
+    assert recipe == {"stock_a": 2.0, "stock_b": 1.0}
+
+    scaled = apply_stock_solution_recipe("tomato", "vegetative", 5.0)
+    assert scaled == {"stock_a": 10.0, "stock_b": 5.0}
+
+
 def test_check_solubility_limits():
     from plant_engine.fertigation import check_solubility_limits
 


### PR DESCRIPTION
## Summary
- add stock solution recipe dataset and hook it up in fertigation module
- provide helpers to load/scale stock solution recipes
- expose optional use of the recipe in `precision_fertigation.py`
- clean up `irrigation_trigger` and fix newline
- document new recipe dataset and CLI usage
- test the recipe helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a00ced948330a13f239c0219cb5c