### PR TITLE
Enhance deficiency tools with severity scoring

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -64,6 +64,7 @@
   "nutrient_deficiency_symptoms.json": "Visual cues for nutrient deficiencies.",
   "nutrient_deficiency_treatments.json": "Corrective actions for deficiencies.",
   "nutrient_deficiency_thresholds.json": "Deficiency ppm thresholds for severity classification.",
+  "deficiency_severity_scores.json": "Numeric scores for deficiency severity levels.",
   "nutrient_interactions.json": "Synergies and antagonisms between nutrients.",
   "nutrient_interaction_actions.json": "Corrective actions for nutrient ratio imbalances.",
   "nutrient_mobility.json": "Classification of mobile versus immobile nutrients.",

--- a/data/deficiency_severity_scores.json
+++ b/data/deficiency_severity_scores.json
@@ -1,0 +1,5 @@
+{
+  "mild": 1,
+  "moderate": 2,
+  "severe": 3
+}

--- a/tests/test_deficiency_manager.py
+++ b/tests/test_deficiency_manager.py
@@ -8,6 +8,8 @@ from plant_engine.deficiency_manager import (
     assess_deficiency_severity,
     recommend_deficiency_treatments,
     diagnose_deficiency_actions,
+    calculate_deficiency_index,
+    summarize_deficiencies,
 )
 from plant_engine.nutrient_manager import get_recommended_levels
 
@@ -80,4 +82,20 @@ def test_diagnose_deficiency_actions():
     actions = diagnose_deficiency_actions(current, "lettuce", "seedling")
     assert actions["N"]["severity"] == "severe"
     assert "nitrogen" in actions["N"]["treatment"].lower()
+
+
+def test_calculate_deficiency_index():
+    guidelines = get_recommended_levels("lettuce", "seedling")
+    current = {n: 0 for n in guidelines}
+    severity = assess_deficiency_severity(current, "lettuce", "seedling")
+    index = calculate_deficiency_index(severity)
+    assert index == 3.0
+
+
+def test_summarize_deficiencies():
+    guidelines = get_recommended_levels("lettuce", "seedling")
+    current = {n: 0 for n in guidelines}
+    summary = summarize_deficiencies(current, "lettuce", "seedling")
+    assert summary["severity_index"] == 3.0
+    assert "N" in summary["treatments"]
 


### PR DESCRIPTION
## Summary
- add deficiency severity scoring dataset
- expose scoring helpers in `deficiency_manager`
- include dataset in catalog
- test summary and scoring helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f6ce0e3c83309ff8177e716bee8e