### PR TITLE
Add pest threshold checking helper

### DIFF
--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -132,3 +132,12 @@ def test_build_pest_management_plan_includes_organic():
     plan = build_pest_management_plan("citrus", ["aphids"])
     assert "organic" in plan["aphids"]
     assert "neem oil" in plan["aphids"]["organic"]
+
+
+def test_check_pest_thresholds():
+    from plant_engine.pest_manager import check_pest_thresholds
+
+    counts = {"aphids": 6, "scale": 1}
+    exceeded = check_pest_thresholds("citrus", counts)
+    assert exceeded["aphids"] is True
+    assert exceeded.get("scale") is False


### PR DESCRIPTION
## Summary
- expand pest manager with `check_pest_thresholds` for economic threshold alerts
- include dataset for pest thresholds in module
- test threshold helper

## Testing
- `pytest tests/test_pest_manager.py::test_check_pest_thresholds -q`
- `pytest tests/test_dataset_catalog.py::test_list_datasets_includes_subdirectory -q`


------
https://chatgpt.com/codex/tasks/task_e_6885f6cb56788330b4b7de8022b6b342