### PR TITLE
Add dataset-driven default environment

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -11,6 +11,7 @@
   "environment_score_weights.json": "Weights for environment quality metrics.",
   "environment_quality_thresholds.json": "Score boundaries for good, fair and poor classifications.",
   "environment_aliases.json": "Canonical environment metric names mapped to accepted aliases.",
+  "default_environment.json": "Fallback environment readings used when sensor data is missing.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",
   "pest_thresholds.json": "Economic threshold counts for triggering actions.",
   "pest_monitoring_intervals.json": "Recommended days between scouting events.",

--- a/data/default_environment.json
+++ b/data/default_environment.json
@@ -1,0 +1,8 @@
+{
+  "temp_c": 26,
+  "temp_c_max": 30,
+  "temp_c_min": 22,
+  "rh_pct": 65,
+  "par_w_m2": 350,
+  "wind_speed_m_s": 1.2
+}

--- a/plant_engine/constants.py
+++ b/plant_engine/constants.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from .utils import lazy_dataset, normalize_key
+from typing import Mapping
+
+from .utils import load_dataset, lazy_dataset, normalize_key
 
 _MULTIPLIER_FILE = "stage_multipliers.json"
 _DEFAULT_MULTIPLIERS: dict[str, float] = {
@@ -13,6 +15,36 @@ _DEFAULT_MULTIPLIERS: dict[str, float] = {
 }
 
 _multipliers = lazy_dataset(_MULTIPLIER_FILE)
+
+# Path of the dataset providing baseline environment readings
+DEFAULT_ENV_FILE = "default_environment.json"
+_DEFAULT_ENV_FALLBACK: dict[str, float] = {
+    "temp_c": 26,
+    "temp_c_max": 30,
+    "temp_c_min": 22,
+    "rh_pct": 65,
+    "par_w_m2": 350,
+    "wind_speed_m_s": 1.2,
+}
+
+
+def _load_default_env() -> dict[str, float]:
+    """Return default environment values from dataset with fallback.
+
+    The dataset may be overridden via ``HORTICULTURE_OVERLAY_DIR``. Invalid
+    or missing values gracefully fall back to :data:`_DEFAULT_ENV_FALLBACK`.
+    """
+
+    data = load_dataset(DEFAULT_ENV_FILE)
+    if not isinstance(data, Mapping):
+        return dict(_DEFAULT_ENV_FALLBACK)
+    result: dict[str, float] = {}
+    for k, v in data.items():
+        try:
+            result[str(k)] = float(v)
+        except (TypeError, ValueError):
+            continue
+    return {**_DEFAULT_ENV_FALLBACK, **result}
 
 
 def stage_multipliers() -> dict[str, float]:
@@ -27,13 +59,11 @@ def get_stage_multiplier(stage: str) -> float:
     return float(stage_multipliers().get(normalize_key(stage), 1.0))
 
 # Default environment readings applied when a plant profile lacks recent data.
-DEFAULT_ENV: dict[str, float] = {
-    "temp_c": 26,
-    "temp_c_max": 30,
-    "temp_c_min": 22,
-    "rh_pct": 65,
-    "par_w_m2": 350,
-    "wind_speed_m_s": 1.2,
-}
+DEFAULT_ENV: dict[str, float] = _load_default_env()
 
-__all__ = ["stage_multipliers", "get_stage_multiplier", "DEFAULT_ENV"]
+__all__ = [
+    "stage_multipliers",
+    "get_stage_multiplier",
+    "DEFAULT_ENV",
+    "DEFAULT_ENV_FILE",
+]

--- a/tests/test_default_environment.py
+++ b/tests/test_default_environment.py
@@ -1,0 +1,39 @@
+import importlib
+import json
+
+import plant_engine.utils as utils
+import plant_engine.constants as const
+
+
+def test_default_environment_loaded(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "default_environment.json").write_text(
+        json.dumps({"temp_c": 20, "rh_pct": 55})
+    )
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(utils)
+    importlib.reload(const)
+
+    assert const.DEFAULT_ENV["temp_c"] == 20
+    assert const.DEFAULT_ENV["rh_pct"] == 55
+    # ensure fallback values still present
+    assert const.DEFAULT_ENV["par_w_m2"] == 350
+
+
+def test_default_environment_overlay(tmp_path, monkeypatch):
+    base = tmp_path / "data"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    overlay.mkdir()
+    (base / "default_environment.json").write_text(json.dumps({"temp_c": 20}))
+    (overlay / "default_environment.json").write_text(json.dumps({"temp_c": 24}))
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    monkeypatch.setenv("HORTICULTURE_OVERLAY_DIR", str(overlay))
+
+    importlib.reload(utils)
+    importlib.reload(const)
+
+    assert const.DEFAULT_ENV["temp_c"] == 24


### PR DESCRIPTION
## Summary
- move default environment settings to a data file
- load defaults from `default_environment.json`
- expose `DEFAULT_ENV_FILE` constant
- document dataset in the catalog
- test dataset overrides

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f6c4e77c8330a88fadc112a2cf86