### PR TITLE
Improve environment cache handling

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -6,7 +6,6 @@ import math
 import datetime
 from dataclasses import dataclass, asdict
 from functools import lru_cache
-import math
 from typing import Any, Dict, Mapping, Tuple, Iterable
 
 RangeTuple = Tuple[float, float]
@@ -693,9 +692,21 @@ def get_environmental_targets(
 
 
 def clear_environment_cache() -> None:
-    """Clear cached environment targets and guidelines."""
-    get_environmental_targets.cache_clear()
-    get_environment_guidelines.cache_clear()
+    """Clear cached guideline lookups."""
+
+    caches = [
+        get_environmental_targets,
+        get_environment_guidelines,
+        get_climate_guidelines,
+        get_frost_dates,
+        get_combined_environment_guidelines,
+        get_combined_environmental_targets,
+        get_co2_price,
+        get_co2_efficiency,
+    ]
+
+    for func in caches:
+        func.cache_clear()
 
 
 def classify_value_range(value: float, bounds: RangeTuple) -> str:

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -942,9 +942,12 @@ def test_score_overall_environment():
 
 def test_clear_environment_cache():
     data1 = get_environmental_targets("citrus", "seedling")
+    price1 = get_co2_price("bulk_tank")
     clear_environment_cache()
     data2 = get_environmental_targets("citrus", "seedling")
+    price2 = get_co2_price("bulk_tank")
     assert data1 == data2
+    assert price1 == price2
 
 
 def test_co2_price_and_cost():


### PR DESCRIPTION
## Summary
- deduplicate imports in `environment_manager`
- clear all cached environment lookups
- test cache clearing for additional functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885f6babb4c8330bb783b26c1a3f384