### PR TITLE
Add integrated health management helper

### DIFF
--- a/plant_engine/health_management.py
+++ b/plant_engine/health_management.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Utilities for integrated pest and disease management."""
+
+from typing import Iterable, Mapping, Any, Dict
+
+from . import (
+    pest_manager,
+    pest_monitor,
+    disease_manager,
+    disease_monitor,
+)
+
+__all__ = ["generate_management_plan"]
+
+
+def generate_management_plan(
+    plant_type: str,
+    pests: Iterable[str] | None = None,
+    diseases: Iterable[str] | None = None,
+    *,
+    pest_severity: Mapping[str, str] | None = None,
+    disease_severity: Mapping[str, str] | None = None,
+) -> Dict[str, Any]:
+    """Return consolidated management actions for pests and diseases.
+
+    Parameters
+    ----------
+    plant_type:
+        Crop identifier used for guideline lookups.
+    pests:
+        Iterable of observed pest names.
+    diseases:
+        Iterable of observed disease names.
+    pest_severity:
+        Optional mapping of pest names to severity levels.
+    disease_severity:
+        Optional mapping of disease names to severity levels.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Mapping with ``"pest_management"`` and ``"disease_management"`` entries.
+    """
+
+    pests = list(pests or [])
+    diseases = list(diseases or [])
+
+    pest_plan = pest_manager.build_pest_management_plan(plant_type, pests)
+    if pest_severity:
+        for pest, level in pest_severity.items():
+            action = pest_monitor.get_severity_action(level)
+            if action:
+                pest_plan.setdefault(pest, {})["severity_action"] = action
+
+    disease_actions = disease_manager.recommend_treatments(plant_type, diseases)
+    disease_prev = disease_manager.recommend_prevention(plant_type, diseases)
+    disease_plan: Dict[str, Dict[str, Any]] = {}
+    for disease in diseases:
+        disease_plan[disease] = {
+            "treatment": disease_actions.get(disease, "No guideline available"),
+            "prevention": disease_prev.get(disease, "No guideline available"),
+        }
+    if disease_severity:
+        for dis, level in disease_severity.items():
+            action = disease_monitor.get_severity_action(level)
+            if action:
+                disease_plan.setdefault(dis, {})["severity_action"] = action
+
+    return {"pest_management": pest_plan, "disease_management": disease_plan}

--- a/tests/test_health_management.py
+++ b/tests/test_health_management.py
@@ -1,0 +1,15 @@
+from plant_engine.health_management import generate_management_plan
+
+
+def test_generate_management_plan():
+    plan = generate_management_plan(
+        "citrus",
+        pests=["aphids"],
+        diseases=["root rot"],
+        pest_severity={"aphids": "moderate"},
+        disease_severity={"root rot": "severe"},
+    )
+    assert "pest_management" in plan
+    assert "disease_management" in plan
+    assert plan["pest_management"]["aphids"]["severity_action"].startswith("Deploy")
+    assert plan["disease_management"]["root rot"]["severity_action"].startswith("Implement")


### PR DESCRIPTION
## Summary
- provide `health_management.generate_management_plan` for unified pest and disease actions
- test `generate_management_plan`

## Testing
- `pytest tests/test_health_management.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6885f6ac61a88330bc14b9d8d5f12a08