### PR TITLE
Improve environment defaults and pest threshold handling

### DIFF
--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -162,7 +162,9 @@ def get_scouting_method(pest: str) -> str:
 def get_severity_thresholds(pest: str) -> Dict[str, float]:
     """Return population thresholds for severity levels of ``pest``."""
 
-    thresholds = _SEVERITY_THRESHOLDS()
+    thresholds = _SEVERITY_THRESHOLDS
+    if callable(thresholds):
+        thresholds = thresholds()
     return thresholds.get(normalize_key(pest), {})
 
 

--- a/tests/test_default_environment.py
+++ b/tests/test_default_environment.py
@@ -37,3 +37,21 @@ def test_default_environment_overlay(tmp_path, monkeypatch):
     importlib.reload(const)
 
     assert const.DEFAULT_ENV["temp_c"] == 24
+
+
+def test_default_environment_dataclass(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "default_environment.json").write_text(
+        json.dumps({"temp_c": 18, "rh_pct": 50})
+    )
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+
+    importlib.reload(utils)
+    importlib.reload(const)
+
+    env = const.load_default_environment()
+    assert env.temp_c == 18
+    assert env.rh_pct == 50
+    assert env.as_dict() == const.DEFAULT_ENV


### PR DESCRIPTION
## Summary
- introduce `EnvironmentDefaults` dataclass and loader
- expose `DEFAULT_ENV_OBJ` with typed defaults
- allow `pest_monitor.get_severity_thresholds` to accept lazy loader or dict
- test dataclass functionality

## Testing
- `pytest tests/test_default_environment.py tests/test_compute_transpiration.py -q`
- `pytest tests/test_pest_monitor.py tests/test_run_daily_cycle_extended.py::test_run_daily_cycle_extended -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886022954e08330a127c9e4b62405c3