### PR TITLE
Improve pesticide cost tracking

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -125,6 +125,7 @@
   "pesticide_rotation_intervals.json": "Recommended days to wait before reusing the same pesticide mode of action.",
   "pesticide_phytotoxicity.json": "Crop-specific phytotoxicity risk levels for pesticide products.",
   "pesticide_application_rates.json": "Recommended pesticide application rates in ml or g per liter.",
+  "pesticide_prices.json": "Cost per unit of pesticide product.",
   "risk_score_map.json": "Numeric weights for risk level scoring.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/pesticide_prices.json
+++ b/data/pesticide_prices.json
@@ -1,0 +1,5 @@
+{
+  "neem_oil": 15.0,
+  "copper_sulfate": 8.0,
+  "spinosad": 25.0
+}

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -15,6 +15,8 @@ from plant_engine.pesticide_manager import (
     suggest_rotation_schedule,
     next_rotation_date,
     suggest_rotation_plan,
+    get_pesticide_price,
+    estimate_application_cost,
 )
 
 
@@ -169,5 +171,12 @@ def test_summarize_pesticide_restrictions():
     summary = summarize_pesticide_restrictions(apps)
     assert summary["reentry_time"] == earliest_reentry_time("imidacloprid", apps[1][1])
     assert summary["harvest_date"] == earliest_harvest_date("imidacloprid", apps[1][1].date())
+
+
+def test_get_pesticide_price_and_cost():
+    assert get_pesticide_price("neem_oil") == 15.0
+    cost = estimate_application_cost("neem_oil", 2.0)
+    assert cost == 0.15
+
 
 


### PR DESCRIPTION
## Summary
- add new pesticide price dataset and record to catalog
- extend `pesticide_manager` with cost lookup helpers
- add unit test for cost calculation

## Testing
- `pytest tests/test_pesticide_manager.py -k pesticide_price -vv`

------
https://chatgpt.com/codex/tasks/task_e_6886022500708330b833f57737704c0d