### PR TITLE
Refactor environment tips loader

### DIFF
--- a/plant_engine/environment_tips.py
+++ b/plant_engine/environment_tips.py
@@ -5,26 +5,39 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Dict
 
-from .utils import load_dataset, normalize_key, list_dataset_entries
+from .utils import (
+    lazy_dataset,
+    list_dataset_entries,
+    normalize_key,
+    clear_dataset_cache,
+)
 
 DATA_FILE = "environment_tips.yaml"
 
-# cached dataset
-_DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
+# Lazy loader so importing this module has minimal overhead
+_DATA = lazy_dataset(DATA_FILE)
 
 __all__ = [
     "list_supported_plants",
     "get_environment_tips",
+    "refresh_cache",
 ]
 
 
 def list_supported_plants() -> list[str]:
     """Return plant types with environment tips defined."""
-    return list_dataset_entries(_DATA)
+    return list_dataset_entries(_DATA())
 
 
 @lru_cache(maxsize=None)
 def get_environment_tips(plant_type: str) -> Dict[str, str]:
     """Return environment management tips for ``plant_type``."""
-    return _DATA.get(normalize_key(plant_type), {})
+    return _DATA().get(normalize_key(plant_type), {})
+
+
+def refresh_cache() -> None:
+    """Clear cached dataset values."""
+    clear_dataset_cache()
+    _DATA.cache_clear()
+    get_environment_tips.cache_clear()
 


### PR DESCRIPTION
## Summary
- refactor environment tips to use lazy loading
- expose a public `refresh_cache` helper

## Testing
- `pytest tests/test_environment_tips.py -q`
- `pytest -q` *(fails: test_classify_pest_severity_custom_thresholds, test_get_severity_thresholds, test_generate_pest_report, test_summarize_pest_management, test_run_daily_cycle_extended)*

------
https://chatgpt.com/codex/tasks/task_e_688601fa63888330a260fdaf1312ac62