### PR TITLE
Fix pest severity dataset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ for prod in stream_index():
         print(detail["metadata"]["label_name"])
 ```
 
-Datasets can be overridden by setting environment variables:
+Datasets can be customized or extended at runtime using environment variables:
 - `HORTICULTURE_DATA_DIR` to change the base data directory
 - `HORTICULTURE_OVERLAY_DIR` to merge in custom files
 - `HORTICULTURE_EXTRA_DATA_DIRS` to load additional datasets
-Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately.
+Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately. Dataset loader functions now accept raw dictionaries for easier testing and overrides.
 
 ---
 


### PR DESCRIPTION
## Summary
- allow lazy loaders in pest_monitor to accept dictionaries
- update README with dataset loader notes
- fix failing tests

## Testing
- `pytest tests/test_pest_monitor.py tests/test_run_daily_cycle_extended.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860200b3dc83308a9fc5094a55065b