### PR TITLE
Refactor dataset loading with lazy loaders

### DIFF
--- a/plant_engine/environment_tips.py
+++ b/plant_engine/environment_tips.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Dict
 
-from .utils import load_dataset, normalize_key, list_dataset_entries
+from .utils import lazy_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "environment_tips.yaml"
 
-# cached dataset
-_DATA: Dict[str, Dict[str, str]] = load_dataset(DATA_FILE)
+# lazily loaded dataset
+_DATA = lazy_dataset(DATA_FILE)
 
 __all__ = [
     "list_supported_plants",
@@ -20,11 +20,11 @@ __all__ = [
 
 def list_supported_plants() -> list[str]:
     """Return plant types with environment tips defined."""
-    return list_dataset_entries(_DATA)
+    return list_dataset_entries(_DATA())
 
 
 @lru_cache(maxsize=None)
 def get_environment_tips(plant_type: str) -> Dict[str, str]:
     """Return environment management tips for ``plant_type``."""
-    return _DATA.get(normalize_key(plant_type), {})
+    return _DATA().get(normalize_key(plant_type), {})
 

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -161,8 +161,11 @@ def get_scouting_method(pest: str) -> str:
 
 def get_severity_thresholds(pest: str) -> Dict[str, float]:
     """Return population thresholds for severity levels of ``pest``."""
-
-    thresholds = _SEVERITY_THRESHOLDS()
+    thresholds = (
+        _SEVERITY_THRESHOLDS()
+        if callable(_SEVERITY_THRESHOLDS)
+        else _SEVERITY_THRESHOLDS
+    )
     return thresholds.get(normalize_key(pest), {})
 
 


### PR DESCRIPTION
## Summary
- use `lazy_dataset` for environment manager data to reduce import cost
- load environment tips lazily
- make pest monitor `get_severity_thresholds` accept dict overrides

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886021f0ee483309e933224a9fdf586