### PR TITLE
Enhance profile loader and env config

### DIFF
--- a/custom_components/horticulture_assistant/utils/load_plant_profile.py
+++ b/custom_components/horticulture_assistant/utils/load_plant_profile.py
@@ -33,6 +33,13 @@ class PlantProfile:
     def __getitem__(self, item: str) -> Any:
         return self.as_dict()[item]
 
+    def get_stage_data(self, stage: str) -> Dict[str, Any] | None:
+        """Return data for a specific growth ``stage`` if available."""
+
+        stages = self.profile_data.get("stages", {})
+        section = stages.get(stage)
+        return dict(section) if isinstance(section, dict) else None
+
 
 @lru_cache(maxsize=None)
 def load_plant_profile(

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from plant_engine.utils import save_json
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_profile_by_id,
+    default_base_dir,
 )
 from plant_engine.ai_model import analyze
 from plant_engine.compute_transpiration import compute_transpiration
@@ -34,7 +35,7 @@ from plant_engine.growth_stage import get_stage_info
 from plant_engine.report import DailyReport
 from plant_engine.constants import get_stage_multiplier, DEFAULT_ENV
 
-PLANTS_DIR = "plants"
+PLANTS_DIR = str(default_base_dir())
 OUTPUT_DIR = "data/reports"
 
 _LOGGER = logging.getLogger(__name__)

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -7,7 +7,7 @@ from datetime import date, timedelta
 from typing import Dict, Mapping
 
 
-from .utils import lazy_dataset, normalize_key, list_dataset_entries
+from .utils import lazy_dataset, normalize_key, list_dataset_entries, load_dataset
 from .monitor_utils import (
     get_interval as _get_interval,
     next_date as _next_date,
@@ -35,7 +35,7 @@ SEVERITY_THRESHOLD_FILE = "pest_severity_thresholds.json"
 _THRESHOLDS = lazy_dataset(DATA_FILE)
 _RISK_FACTORS = lazy_dataset(RISK_DATA_FILE)
 _SEVERITY_ACTIONS = lazy_dataset(SEVERITY_ACTIONS_FILE)
-_SEVERITY_THRESHOLDS = lazy_dataset(SEVERITY_THRESHOLD_FILE)
+_SEVERITY_THRESHOLDS = load_dataset(SEVERITY_THRESHOLD_FILE)
 _MONITOR_INTERVALS = lazy_dataset(MONITOR_INTERVAL_FILE)
 _RISK_MODIFIERS = lazy_dataset(RISK_INTERVAL_MOD_FILE)
 _SCOUTING_METHODS = lazy_dataset(SCOUTING_METHOD_FILE)
@@ -162,7 +162,7 @@ def get_scouting_method(pest: str) -> str:
 def get_severity_thresholds(pest: str) -> Dict[str, float]:
     """Return population thresholds for severity levels of ``pest``."""
 
-    thresholds = _SEVERITY_THRESHOLDS()
+    thresholds = _SEVERITY_THRESHOLDS
     return thresholds.get(normalize_key(pest), {})
 
 

--- a/scripts/backup_profiles.py
+++ b/scripts/backup_profiles.py
@@ -7,6 +7,7 @@ import argparse
 from datetime import datetime
 from pathlib import Path
 import zipfile
+import os
 
 import sys
 
@@ -17,7 +18,7 @@ sys.path.insert(0, str(ROOT))
 from scripts import ensure_repo_root_on_path
 
 ROOT = ensure_repo_root_on_path()
-PLANTS_DIR = ROOT / "plants"
+PLANTS_DIR = Path(os.getenv("HORTICULTURE_PLANT_DIR", ROOT / "plants"))
 REGISTRY_PATH = ROOT / "plant_registry.json"
 DEFAULT_BACKUP_DIR = ROOT / "backups"
 
@@ -27,7 +28,7 @@ def configure_root(path: Path) -> Path:
 
     global ROOT, PLANTS_DIR, REGISTRY_PATH, DEFAULT_BACKUP_DIR
     ROOT = path.resolve()
-    PLANTS_DIR = ROOT / "plants"
+    PLANTS_DIR = Path(os.getenv("HORTICULTURE_PLANT_DIR", ROOT / "plants"))
     REGISTRY_PATH = ROOT / "plant_registry.json"
     DEFAULT_BACKUP_DIR = ROOT / "backups"
     return ROOT

--- a/scripts/profile_manager.py
+++ b/scripts/profile_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import json
+import os
 
 from scripts import ensure_repo_root_on_path
 
@@ -15,7 +16,7 @@ from custom_components.horticulture_assistant.utils import (
 )
 from custom_components.horticulture_assistant.utils.json_io import load_json
 
-DEFAULT_PLANTS_DIR = ROOT / "plants"
+DEFAULT_PLANTS_DIR = Path(os.getenv("HORTICULTURE_PLANT_DIR", ROOT / "plants"))
 DEFAULT_GLOBAL_DIR = ROOT / "data" / "global_profiles"
 
 

--- a/scripts/review_thresholds.py
+++ b/scripts/review_thresholds.py
@@ -3,7 +3,7 @@ from approval_queue import apply_approved_thresholds
 from plant_engine.utils import load_json, save_json, get_pending_dir
 
 PENDING_DIR = str(get_pending_dir())
-PLANT_DIR = "plants"
+PLANT_DIR = os.getenv("HORTICULTURE_PLANT_DIR", "plants")
 
 def review_pending_thresholds():
     print("🔍 Scanning for pending threshold files...\n")

--- a/scripts/run_all_plants.py
+++ b/scripts/run_all_plants.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from plant_engine import run_daily_cycle
 from plant_engine.utils import save_json
 
-PLANT_DIR = "plants"
+PLANT_DIR = os.getenv("HORTICULTURE_PLANT_DIR", "plants")
 SUMMARY_PATH = "data/reports/summary.json"
 
 def get_plant_ids():

--- a/tests/test_load_plant_profile.py
+++ b/tests/test_load_plant_profile.py
@@ -54,3 +54,12 @@ def test_profile_caching(tmp_path):
     clear_profile_cache()
     third = load_plant_profile("demo", base_path=tmp_path / "plants")
     assert third.profile_data["general"]["name"] == "second"
+
+
+def test_get_stage_data(tmp_path):
+    plant_dir = tmp_path / "plants" / "demo"
+    plant_dir.mkdir(parents=True)
+    (plant_dir / "stages.json").write_text(json.dumps({"veg": {"light": 100}}))
+    profile = load_plant_profile("demo", base_path=tmp_path / "plants")
+    assert profile.get_stage_data("veg") == {"light": 100}
+    assert profile.get_stage_data("bloom") is None

--- a/tests/test_profile_loader.py
+++ b/tests/test_profile_loader.py
@@ -157,3 +157,12 @@ def test_profile_exists_and_delete(tmp_path):
     assert loader.profile_exists("p1", plants)
     assert loader.delete_profile_by_id("p1", plants)
     assert not loader.profile_exists("p1", plants)
+
+
+def test_default_base_dir_env(monkeypatch, tmp_path):
+    env_dir = tmp_path / "envplants"
+    env_dir.mkdir()
+    monkeypatch.setenv("HORTICULTURE_PLANT_DIR", str(env_dir))
+    assert loader.default_base_dir() == env_dir
+    (env_dir / "x.json").write_text("{}")
+    assert loader.get_profile_path("x") == env_dir / "x.json"


### PR DESCRIPTION
## Summary
- support environment-defined plant profile directory
- expose helper to retrieve the default plant directory
- expose stage specific data from `PlantProfile`
- update engine and scripts to honor `HORTICULTURE_PLANT_DIR`
- fix pest monitor dataset handling
- test `get_stage_data` and environment variable logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886021cb93c833096efadbb99ada03f