### PR TITLE
Add fungicide rate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 ### Data & Analytics
 - Disease and pest treatment recommendations
 - Organic fungicide suggestions for common diseases
+- Fungicide application rate calculations for spray mixes
 - Environment optimization suggestions with pH guidance
 - Precise pH adjustment volume calculations
 - Heat, humidity and light stress warnings

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -56,6 +56,7 @@
   "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",
   "foliar_spray_volume.json": "Recommended foliar spray volume per plant in mL.",
   "fungicide_recommendations.json": "Organic fungicide options for common diseases.",
+  "fungicide_application_rates.json": "Recommended fungicide application rates (g/L or mL/L).",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",

--- a/data/fungicide_application_rates.json
+++ b/data/fungicide_application_rates.json
@@ -1,0 +1,7 @@
+{
+  "copper fungicide": 2.0,
+  "bacillus subtilis": 1.0,
+  "potassium bicarbonate": 3.0,
+  "sulfur spray": 3.0,
+  "phosphorous acid": 2.5
+}

--- a/tests/test_disease_manager.py
+++ b/tests/test_disease_manager.py
@@ -48,3 +48,17 @@ def test_recommend_fungicides():
         "potassium bicarbonate",
     ]
     assert recs["unknown"] == []
+
+
+def test_get_fungicide_application_rate():
+    from plant_engine.disease_manager import get_fungicide_application_rate
+
+    assert get_fungicide_application_rate("copper fungicide") == 2.0
+    assert get_fungicide_application_rate("unknown") is None
+
+
+def test_calculate_fungicide_mix():
+    from plant_engine.disease_manager import calculate_fungicide_mix
+
+    mix = calculate_fungicide_mix("blight", 10)
+    assert mix == {"copper fungicide": 20.0, "bacillus subtilis": 10.0}


### PR DESCRIPTION
## Summary
- add new fungicide application rate dataset
- support fungicide rates and mix calculations in disease manager
- test new disease utilities
- document fungicide mix feature in README

## Testing
- `pytest -q tests/test_disease_manager.py tests/test_dataset_catalog.py tests/test_profile_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6886020494cc8330a8d9032704bd86c3