### PR TITLE
Improve path handling utilities

### DIFF
--- a/plant_engine/approval_queue.py
+++ b/plant_engine/approval_queue.py
@@ -80,7 +80,7 @@ def queue_threshold_updates(
         changes=changes,
     )
 
-    save_json(str(pending_file), record.as_dict())
+    save_json(pending_file, record.as_dict())
 
     _LOGGER.info("Queued %d threshold changes for %s", len(changes), plant_id)
     return pending_file
@@ -102,9 +102,9 @@ def apply_approved_thresholds(plant_path: str | Path, pending_file: str | Path) 
         _LOGGER.error("Plant profile not found: %s", plant_p)
         return 0
 
-    pending = load_json(str(pending_p))
+    pending = load_json(pending_p)
 
-    plant = load_json(str(plant_p))
+    plant = load_json(plant_p)
     updated = plant.get("thresholds", {})
 
     applied = 0
@@ -114,7 +114,7 @@ def apply_approved_thresholds(plant_path: str | Path, pending_file: str | Path) 
             applied += 1
 
     plant["thresholds"] = updated
-    save_json(str(plant_p), plant)
+    save_json(plant_p, plant)
 
     _LOGGER.info(
         "Applied %d approved changes for %s", applied, pending.get("plant_id")
@@ -129,5 +129,5 @@ def list_pending_changes(plant_id: str, base_dir: Path | None = None) -> Dict[st
     path = directory / f"{plant_id}.json"
     if not path.exists():
         return None
-    return load_json(str(path))
+    return load_json(path)
 

--- a/plant_engine/engine.py
+++ b/plant_engine/engine.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from typing import Dict, Mapping, Any
+from pathlib import Path
 
 from functools import lru_cache
 
@@ -176,7 +177,7 @@ def run_daily_cycle(plant_id: str) -> Dict[str, Any]:
 
     # Step 9: Write daily report JSON
     os.makedirs(OUTPUT_DIR, exist_ok=True)
-    out_path = os.path.join(OUTPUT_DIR, f"{plant_id}.json")
+    out_path = Path(OUTPUT_DIR) / f"{plant_id}.json"
     save_json(out_path, report)
     _LOGGER.info("Daily report saved for %s", plant_id)
 

--- a/plant_engine/nutrient_efficiency.py
+++ b/plant_engine/nutrient_efficiency.py
@@ -1,6 +1,7 @@
 """Calculate nutrient use efficiency from application and yield logs."""
 
 import os
+from pathlib import Path
 from typing import Dict, Tuple
 
 from .utils import load_json
@@ -14,8 +15,8 @@ YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 def _load_totals(plant_id: str) -> Tuple[Dict[str, float], float]:
     """Return total nutrients applied (mg) and total yield (g)."""
 
-    path_nutrients = os.path.join(NUTRIENT_DIR, f"{plant_id}.json")
-    if not os.path.exists(path_nutrients):
+    path_nutrients = Path(NUTRIENT_DIR) / f"{plant_id}.json"
+    if not path_nutrients.exists():
         raise FileNotFoundError(f"No nutrient record found for {plant_id}")
 
     nutrient_log = load_json(path_nutrients)
@@ -25,8 +26,8 @@ def _load_totals(plant_id: str) -> Tuple[Dict[str, float], float]:
         for k, v in entry.get("nutrients_mg", {}).items():
             total_applied_mg[k] = total_applied_mg.get(k, 0.0) + float(v)
 
-    path_yield = os.path.join(YIELD_DIR, f"{plant_id}.json")
-    if not os.path.exists(path_yield):
+    path_yield = Path(YIELD_DIR) / f"{plant_id}.json"
+    if not path_yield.exists():
         raise FileNotFoundError(f"No yield record found for {plant_id}")
 
     yield_data = load_json(path_yield)

--- a/plant_engine/water_deficit_tracker.py
+++ b/plant_engine/water_deficit_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from typing import Dict, Optional, Any
@@ -66,9 +67,9 @@ def update_water_balance(
 
     os.makedirs(storage_path, exist_ok=True)
     today = datetime.now().strftime("%Y-%m-%d")
-    file_path = os.path.join(storage_path, f"{plant_id}.json")
+    file_path = Path(storage_path) / f"{plant_id}.json"
 
-    if os.path.exists(file_path):
+    if file_path.exists():
         history = load_json(file_path)
     else:
         history = {}
@@ -117,8 +118,8 @@ def update_water_balance(
 
 def load_water_balance(plant_id: str, storage_path: str = STORAGE_PATH) -> Dict[str, Any]:
     """Return the logged water balance history for ``plant_id``."""
-    file_path = os.path.join(storage_path, f"{plant_id}.json")
-    if not os.path.exists(file_path):
+    file_path = Path(storage_path) / f"{plant_id}.json"
+    if not file_path.exists():
         return {}
     return load_json(file_path)
 

--- a/plant_engine/yield_manager.py
+++ b/plant_engine/yield_manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict, List
@@ -34,15 +35,16 @@ class HarvestRecord:
         return asdict(self)
 
 
-def _yield_path(plant_id: str) -> str:
+def _yield_path(plant_id: str) -> Path:
     """Return file path for the plant yield history."""
-    return os.path.join(YIELD_DIR, f"{plant_id}.json")
+    return Path(YIELD_DIR) / f"{plant_id}.json"
 
 
 def _load_raw_history(plant_id: str) -> Dict[str, List[Dict[str, object]]]:
     """Return raw history mapping from disk."""
-    if os.path.exists(_yield_path(plant_id)):
-        return load_json(_yield_path(plant_id))
+    path = _yield_path(plant_id)
+    if path.exists():
+        return load_json(path)
     return {"harvests": []}
 
 

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -25,13 +25,13 @@ def test_queue_and_apply(tmp_path, monkeypatch):
     assert pending_data["changes"]["soil_moisture_pct"]["proposed_value"] == 35
 
     # Approve one change
-    pending = load_json(str(pending_file))
+    pending = load_json(pending_file)
     pending["changes"]["soil_moisture_pct"]["status"] = "approved"
     pending_file.write_text(json.dumps(pending))
 
     # Apply
-    approval_queue.apply_approved_thresholds(str(plant_path), str(pending_file))
-    updated = load_json(str(plant_path))
+    approval_queue.apply_approved_thresholds(plant_path, pending_file)
+    updated = load_json(plant_path)
     assert updated["thresholds"]["soil_moisture_pct"] == 35
     assert "ec" not in updated["thresholds"]
 

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -78,14 +78,14 @@ def test_classify_pest_severity_custom_thresholds(tmp_path, monkeypatch):
     from plant_engine.utils import clear_dataset_cache, load_dataset
 
     clear_dataset_cache()
-    pest_monitor._SEVERITY_THRESHOLDS = load_dataset(pest_monitor.SEVERITY_THRESHOLD_FILE)
+    pest_monitor._SEVERITY_THRESHOLDS = lambda: load_dataset(pest_monitor.SEVERITY_THRESHOLD_FILE)
 
     severity = pest_monitor.classify_pest_severity("citrus", {"aphids": 9})
     assert severity["aphids"] == "severe"
 
     monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR")
     clear_dataset_cache()
-    pest_monitor._SEVERITY_THRESHOLDS = load_dataset(pest_monitor.SEVERITY_THRESHOLD_FILE)
+    pest_monitor._SEVERITY_THRESHOLDS = lambda: load_dataset(pest_monitor.SEVERITY_THRESHOLD_FILE)
 
 
 def test_get_severity_thresholds():

--- a/tests/test_push_to_approval_queue.py
+++ b/tests/test_push_to_approval_queue.py
@@ -15,6 +15,6 @@ def test_push_to_approval_queue(tmp_path):
     assert record["plant_id"] == "foo"
     path = data_dir / "foo.json"
     assert path.exists()
-    saved = load_json(str(path))
+    saved = load_json(path)
     assert saved["changes"]["ec"]["proposed_value"] == 2.0
     assert saved["changes"]["ec"]["previous_value"] == 1.5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,20 +26,20 @@ def test_normalize_key_non_string():
 def test_load_json_success(tmp_path):
     path = tmp_path / "data.json"
     path.write_text('{"a":1}')
-    assert load_json(str(path)) == {"a": 1}
+    assert load_json(path) == {"a": 1}
 
 
 def test_load_json_missing(tmp_path):
     missing = tmp_path / "missing.json"
     with pytest.raises(FileNotFoundError):
-        load_json(str(missing))
+        load_json(missing)
 
 
 def test_load_json_invalid(tmp_path):
     bad = tmp_path / "bad.json"
     bad.write_text("{oops}")
     with pytest.raises(ValueError):
-        load_json(str(bad))
+        load_json(bad)
 
 
 def test_clear_dataset_cache(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- support pathlib inputs in utilities and update callers
- update approval queue and other modules to use Path
- tweak pest monitor tests for stable dataset loader
- ensure YAML and other dependencies installed
- adjust tests for Path objects

## Testing
- `pytest tests/test_utils.py tests/test_approval_queue.py tests/test_push_to_approval_queue.py tests/test_water_deficit.py tests/test_yield_manager.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860208a06483309d66903c880f3375