### PR TITLE
Add fertilizer data and fix pest threshold helper

### DIFF
--- a/data/fertilizers/fertilizer_application_methods.json
+++ b/data/fertilizers/fertilizer_application_methods.json
@@ -1,5 +1,13 @@
 {
   "foxfarm_grow_big": "soil drench",
   "magriculture": "foliar",
-  "intrepid_granular_potash_0_0_60": "broadcast"
+  "intrepid_granular_potash_0_0_60": "broadcast",
+  "earth_care_plus_5_6_6": "broadcast",
+  "fertibor_15_b": "soil",
+  "granubor_15_b": "soil",
+  "acadian_liquid_seaweed_0_0_5": "foliar",
+  "calcium_nitrate": "fertigation",
+  "magnesium_sulfate": "fertigation",
+  "potassium_phosphate": "fertigation",
+  "chelated_fe": "fertigation"
 }

--- a/data/fertilizers/fertilizer_application_rates.json
+++ b/data/fertilizers/fertilizer_application_rates.json
@@ -1,5 +1,13 @@
 {
   "foxfarm_grow_big": 5.0,
   "magriculture": 2.5,
-  "intrepid_granular_potash_0_0_60": 1.0
+  "intrepid_granular_potash_0_0_60": 1.0,
+  "earth_care_plus_5_6_6": 8.0,
+  "fertibor_15_b": 1.0,
+  "granubor_15_b": 1.0,
+  "acadian_liquid_seaweed_0_0_5": 2.0,
+  "calcium_nitrate": 1.5,
+  "magnesium_sulfate": 1.0,
+  "potassium_phosphate": 1.2,
+  "chelated_fe": 0.5
 }

--- a/data/fertilizers/fertilizer_prices.json
+++ b/data/fertilizers/fertilizer_prices.json
@@ -1,5 +1,13 @@
 {
   "foxfarm_grow_big": 20.0,
   "magriculture": 10.0,
-  "intrepid_granular_potash_0_0_60": 5.0
+  "intrepid_granular_potash_0_0_60": 5.0,
+  "earth_care_plus_5_6_6": 8.0,
+  "fertibor_15_b": 4.5,
+  "granubor_15_b": 6.0,
+  "acadian_liquid_seaweed_0_0_5": 12.0,
+  "calcium_nitrate": 120.0,
+  "magnesium_sulfate": 12.0,
+  "potassium_phosphate": 4.0,
+  "chelated_fe": 15.0
 }

--- a/data/fertilizers/fertilizer_products.json
+++ b/data/fertilizers/fertilizer_products.json
@@ -239,4 +239,29 @@
       "Calcium Sulfate (CaSO42H2O)": null
     }
   }
+
+,  "calcium_nitrate": {
+    "density_kg_per_l": 1.1,
+    "guaranteed_analysis": {"N": 0.155, "Ca": 0.19},
+    "product_name": "Calcium Nitrate 15.5-0-0",
+    "wsda_product_number": null
+  },
+  "magnesium_sulfate": {
+    "density_kg_per_l": 1.68,
+    "guaranteed_analysis": {"Mg": 0.098, "S": 0.13},
+    "product_name": "Magnesium Sulfate",
+    "wsda_product_number": null
+  },
+  "potassium_phosphate": {
+    "density_kg_per_l": 1.2,
+    "guaranteed_analysis": {"P2O5": 0.52, "K2O": 0.34},
+    "product_name": "Monopotassium Phosphate",
+    "wsda_product_number": null
+  },
+  "chelated_fe": {
+    "density_kg_per_l": 1.3,
+    "guaranteed_analysis": {"Fe": 0.06},
+    "product_name": "Chelated Iron 6%",
+    "wsda_product_number": null
+  }
 }

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -162,8 +162,8 @@ def get_scouting_method(pest: str) -> str:
 def get_severity_thresholds(pest: str) -> Dict[str, float]:
     """Return population thresholds for severity levels of ``pest``."""
 
-    thresholds = _SEVERITY_THRESHOLDS()
-    return thresholds.get(normalize_key(pest), {})
+    base = _SEVERITY_THRESHOLDS() if callable(_SEVERITY_THRESHOLDS) else _SEVERITY_THRESHOLDS
+    return base.get(normalize_key(pest), {})
 
 
 def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -85,6 +85,8 @@ def test_invalid_inputs():
 def test_calculate_fertilizer_cost():
     cost = calculate_fertilizer_cost("foxfarm_grow_big", 10)
     assert round(cost, 2) == 0.2
+    cost2 = calculate_fertilizer_cost("calcium_nitrate", 10)
+    assert round(cost2, 2) == 1.2
     with pytest.raises(ValueError):
         calculate_fertilizer_cost("foxfarm_grow_big", -1)
     with pytest.raises(KeyError):
@@ -256,6 +258,13 @@ def test_calculate_mass_for_target_ppm():
         calculate_mass_for_target_ppm("foxfarm_grow_big", "X", 10, 1)
 
 
+def test_new_product_pricing():
+    info = get_product_info("calcium_nitrate")
+    assert info.product_name
+    costs = estimate_cost_per_nutrient("calcium_nitrate")
+    assert "N" in costs and costs["N"] > 0
+
+
 def test_get_application_method():
     assert get_application_method("foxfarm_grow_big") == "soil drench"
     assert get_application_method("magriculture") == "foliar"
@@ -264,6 +273,7 @@ def test_get_application_method():
 
 def test_get_application_rate():
     assert get_application_rate("foxfarm_grow_big") == 5.0
+    assert get_application_rate("calcium_nitrate") == 1.5
     assert get_application_rate("unknown") is None
 
 
@@ -279,6 +289,7 @@ def test_calculate_recommended_application():
 def test_catalog_lists_products():
     ids = CATALOG.list_products()
     assert "foxfarm_grow_big" in ids
+    assert "calcium_nitrate" in ids
     info = CATALOG.get_product_info("foxfarm_grow_big")
     assert info.product_name
 


### PR DESCRIPTION
## Summary
- expand fertilizer datasets with additional products and pricing
- update fertilizer application data
- make pest monitor resilient to dict overrides
- extend tests to cover new fertilizer entries

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886021b33f08330b04af45f3e4f615d