### PR TITLE
Fix pest monitor dataset and extended test JSON

### DIFF
--- a/tests/test_run_daily_cycle_extended.py
+++ b/tests/test_run_daily_cycle_extended.py
@@ -18,7 +18,7 @@ def test_run_daily_cycle_extended(tmp_path):
                     "start_date": "2025-01-01",
                     "observed_pests": ["aphids"],
                     "observed_diseases": [],
-                "observed_pest_counts": {"aphids": 12}
+                    "observed_pest_counts": {"aphids": 12},
                 }
             }
         )


### PR DESCRIPTION
## Summary
- allow pest monitor datasets to be overridden with dictionaries
- correct the extended daily cycle test profile JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886021664708330a8f0042e9c68d3e9