### PR TITLE
Add inoculant attribute dataset

### DIFF
--- a/data/bioinoculant_attributes.json
+++ b/data/bioinoculant_attributes.json
@@ -1,0 +1,27 @@
+{
+  "Trichoderma harzianum": {
+    "category": "fungal",
+    "preferred_environment": "soil applications at pH 5-7",
+    "mode_of_action": "competition and parasitism"
+  },
+  "Trichoderma viride": {
+    "category": "fungal",
+    "preferred_environment": "seed coating or soil drench",
+    "mode_of_action": "antagonistic to soil fungi"
+  },
+  "Bacillus subtilis": {
+    "category": "bacterial",
+    "preferred_environment": "foliar or root zone spray",
+    "mode_of_action": "produces antimicrobial compounds"
+  },
+  "Azospirillum brasilense": {
+    "category": "bacterial",
+    "preferred_environment": "root inoculation",
+    "mode_of_action": "nitrogen fixation and growth promotion"
+  },
+  "Pseudomonas fluorescens": {
+    "category": "bacterial",
+    "preferred_environment": "seed treatment or soil drench",
+    "mode_of_action": "suppresses root pathogens"
+  }
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -43,6 +43,7 @@
   "beneficial_insects.json": "Natural predators for common greenhouse pests.",
   "beneficial_release_rates.json": "Recommended release rates of beneficial insects per m^2.",
   "bioinoculant_guidelines.json": "Recommended microbial inoculants for improved nutrient uptake.",
+  "bioinoculant_attributes.json": "Key attributes and usage notes for common microbial inoculants.",
   "crop_coefficients.json": "Crop coefficients for evapotranspiration models.",
   "crop_coefficient_modifiers.json": "Environmental adjustment factors for crop coefficients.",
   "disease_thresholds.json": "Severity thresholds triggering treatments.",

--- a/plant_engine/bioinoculant_info.py
+++ b/plant_engine/bioinoculant_info.py
@@ -1,0 +1,32 @@
+"""Lookup helper for microbial inoculant attributes."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import lazy_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "bioinoculant_attributes.json"
+
+_data = lazy_dataset(DATA_FILE)
+
+__all__ = [
+    "list_inoculants",
+    "get_inoculant_info",
+]
+
+
+def list_inoculants() -> list[str]:
+    """Return all inoculant names available in the dataset."""
+    return list_dataset_entries(_data())
+
+
+def get_inoculant_info(name: str) -> Dict[str, str]:
+    """Return attribute mapping for ``name``.
+
+    Lookup is case-insensitive and ignores spaces/underscores.
+    """
+    norm = normalize_key(name)
+    for key, value in _data().items():
+        if normalize_key(key) == norm:
+            return value
+    return {}

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -11,6 +11,7 @@ from . import (
     nutrient_manager,
     micro_manager,
     bioinoculant_manager,
+    bioinoculant_info,
     pest_manager,
     pest_monitor,
     disease_manager,
@@ -39,6 +40,9 @@ class GuidelineSummary:
     pest_thresholds: Dict[str, int] = dataclass_field(default_factory=dict)
     beneficial_insects: Dict[str, list[str]] = dataclass_field(default_factory=dict)
     bioinoculants: List[str] = dataclass_field(default_factory=list)
+    bioinoculant_details: Dict[str, Dict[str, str]] = dataclass_field(
+        default_factory=dict
+    )
     ph_range: List[float] = dataclass_field(default_factory=list)
     ec_range: List[float] = dataclass_field(default_factory=list)
     irrigation_volume_ml: float | None = None
@@ -72,10 +76,17 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
             for s in growth_stage.list_growth_stages(plant_type)
         }
 
+    inoculants = bioinoculant_manager.get_recommended_inoculants(plant_type)
+    details = {name: bioinoculant_info.get_inoculant_info(name) for name in inoculants}
+
     summary = GuidelineSummary(
         environment=environment_manager.get_environmental_targets(plant_type, stage),
-        nutrients=nutrient_manager.get_recommended_levels(plant_type, stage) if stage else {},
-        micronutrients=micro_manager.get_recommended_levels(plant_type, stage) if stage else {},
+        nutrients=nutrient_manager.get_recommended_levels(plant_type, stage)
+        if stage
+        else {},
+        micronutrients=micro_manager.get_recommended_levels(plant_type, stage)
+        if stage
+        else {},
         pest_guidelines=pest_manager.get_pest_guidelines(plant_type),
         pest_prevention=pest_manager.get_pest_prevention(plant_type),
         ipm_guidelines=pest_manager.get_ipm_guidelines(plant_type),
@@ -83,7 +94,8 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         disease_prevention=disease_manager.get_disease_prevention(plant_type),
         pest_thresholds=thresholds,
         beneficial_insects=beneficial,
-        bioinoculants=bioinoculant_manager.get_recommended_inoculants(plant_type),
+        bioinoculants=inoculants,
+        bioinoculant_details=details,
         ph_range=ph_manager.get_ph_range(plant_type, stage),
         ec_range=list(ec_manager.get_ec_range(plant_type, stage) or []),
         irrigation_volume_ml=(

--- a/tests/test_bioinoculant_info.py
+++ b/tests/test_bioinoculant_info.py
@@ -1,0 +1,13 @@
+from plant_engine import bioinoculant_info as info
+
+
+def test_list_inoculants():
+    inoculants = info.list_inoculants()
+    assert "Trichoderma harzianum" in inoculants
+    assert "Bacillus subtilis" in inoculants
+
+
+def test_get_inoculant_info():
+    data = info.get_inoculant_info("Trichoderma harzianum")
+    assert data.get("category") == "fungal"
+    assert info.get_inoculant_info("unknown") == {}

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -14,6 +14,7 @@ def test_get_guideline_summary():
     assert data["pest_thresholds"]["aphids"] == 5
     assert "ladybugs" in data["beneficial_insects"]["aphids"]
     assert data["bioinoculants"] == []
+    assert data["bioinoculant_details"] == {}
     assert "aphids" in data["pest_prevention"]
     assert "general" in data["ipm_guidelines"]
     assert data["irrigation_volume_ml"] == 300
@@ -26,10 +27,12 @@ def test_guideline_summary_no_stage():
     data = get_guideline_summary("citrus")
     assert "stages" in data and "vegetative" in data["stages"]
 
+
 def test_guideline_summary_bioinoculants():
     data = get_guideline_summary("tomato", "fruiting")
     assert "Trichoderma harzianum" in data["bioinoculants"]
+    assert "Trichoderma harzianum" in data["bioinoculant_details"]
+    assert data["bioinoculant_details"]["Trichoderma harzianum"]["category"] == "fungal"
     # stage tasks should include entries for the requested stage
     assert "fruiting" in data["stage_tasks"]
     assert "Maintain high potassium" in data["stage_tasks"]["fruiting"][1]
-


### PR DESCRIPTION
## Summary
- add a dataset with information on common microbial inoculants
- expose helper functions in `bioinoculant_info`
- document new dataset in catalog
- test inoculant info helper
- show inoculant details in guideline summaries

## Testing
- `pytest tests/test_bioinoculant_info.py tests/test_guidelines.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68862509176c833085dc1bb18d108863