### PR TITLE
Add pesticide active ingredients dataset

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -128,6 +128,7 @@
   "pesticide_phytotoxicity.json": "Crop-specific phytotoxicity risk levels for pesticide products.",
   "pesticide_application_rates.json": "Recommended pesticide application rates in ml or g per liter.",
   "pesticide_prices.json": "Cost per unit of pesticide product.",
+  "pesticide_active_ingredients.json": "Key properties for common pesticide active ingredients.",
   "risk_score_map.json": "Numeric weights for risk level scoring.",
   "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
   "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/pesticide_active_ingredients.json
+++ b/data/pesticide_active_ingredients.json
@@ -1,0 +1,72 @@
+{
+  "imidacloprid": {
+    "class": "neonicotinoid",
+    "mode_of_action": "acetylcholine receptor agonist",
+    "reentry_interval_hours": 12,
+    "withdrawal_days": 7,
+    "toxicity": "moderate"
+  },
+  "spinosad": {
+    "class": "spinosyn",
+    "mode_of_action": "nicotinic acetylcholine receptor modulator",
+    "reentry_interval_hours": 4,
+    "withdrawal_days": 1,
+    "toxicity": "low"
+  },
+  "pyrethrin": {
+    "class": "pyrethroid",
+    "mode_of_action": "sodium channel modulator",
+    "reentry_interval_hours": 0,
+    "withdrawal_days": 0,
+    "toxicity": "low"
+  },
+  "sulfur": {
+    "class": "inorganic",
+    "mode_of_action": "cellular respiration disruptor",
+    "reentry_interval_hours": 0,
+    "withdrawal_days": 0,
+    "toxicity": "low"
+  },
+  "copper_sulfate": {
+    "class": "inorganic",
+    "mode_of_action": "multi-site",
+    "reentry_interval_hours": 24,
+    "withdrawal_days": 0,
+    "toxicity": "high"
+  },
+  "neem_oil": {
+    "class": "botanical",
+    "mode_of_action": "multiple",
+    "reentry_interval_hours": 4,
+    "withdrawal_days": 0,
+    "toxicity": "low"
+  },
+  "acephate": {
+    "class": "organophosphate",
+    "mode_of_action": "acetylcholinesterase inhibitor",
+    "reentry_interval_hours": 24,
+    "withdrawal_days": 3,
+    "toxicity": "high"
+  },
+  "bifenthrin": {
+    "class": "pyrethroid",
+    "mode_of_action": "sodium channel modulator",
+    "reentry_interval_hours": 12,
+    "withdrawal_days": 1,
+    "toxicity": "moderate"
+  },
+  "potassium_bicarbonate": {
+    "class": "inorganic",
+    "mode_of_action": "cell membrane disruptor",
+    "reentry_interval_hours": 1,
+    "withdrawal_days": 0,
+    "toxicity": "low"
+  },
+  "bacillus_thuringiensis": {
+    "class": "microbial",
+    "mode_of_action": "midgut membrane disruptor",
+    "reentry_interval_hours": 4,
+    "withdrawal_days": 0,
+    "toxicity": "low"
+  }
+}

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -13,6 +13,7 @@ ROTATION_FILE = "pesticide_rotation_intervals.json"
 PHYTO_FILE = "pesticide_phytotoxicity.json"
 RATE_FILE = "pesticide_application_rates.json"
 PRICE_FILE = "pesticide_prices.json"
+ACTIVE_FILE = "pesticide_active_ingredients.json"
 
 # Cached withdrawal data mapping product names to waiting days
 _DATA: Dict[str, int] = load_dataset(DATA_FILE)
@@ -22,6 +23,7 @@ _ROTATION: Dict[str, int] = load_dataset(ROTATION_FILE)
 _PHYTO: Dict[str, Dict[str, str]] = load_dataset(PHYTO_FILE)
 _RATES: Dict[str, float] = load_dataset(RATE_FILE)
 _PRICES: Dict[str, float] = load_dataset(PRICE_FILE)
+_ACTIVE: Dict[str, Dict[str, object]] = load_dataset(ACTIVE_FILE)
 
 __all__ = [
     "get_withdrawal_days",
@@ -44,6 +46,8 @@ __all__ = [
     "estimate_application_cost",
     "calculate_application_amount",
     "summarize_pesticide_restrictions",
+    "get_active_ingredient_info",
+    "list_active_ingredients",
 ]
 
 
@@ -314,3 +318,15 @@ def summarize_pesticide_restrictions(
     if earliest_harvest is not None:
         info["harvest_date"] = earliest_harvest
     return info
+
+
+def get_active_ingredient_info(name: str) -> Dict[str, object] | None:
+    """Return detailed info for a pesticide active ingredient."""
+
+    return _ACTIVE.get(name.lower())
+
+
+def list_active_ingredients() -> List[str]:
+    """Return sorted list of known active ingredient names."""
+
+    return sorted(_ACTIVE.keys())

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -179,4 +179,18 @@ def test_get_pesticide_price_and_cost():
     assert cost == 0.15
 
 
+def test_active_ingredient_info():
+    from plant_engine.pesticide_manager import (
+        get_active_ingredient_info,
+        list_active_ingredients,
+    )
+
+    info = get_active_ingredient_info("spinosad")
+    assert info["class"] == "spinosyn"
+    assert "mode_of_action" in info
+
+    ingredients = list_active_ingredients()
+    assert "imidacloprid" in ingredients
+
+
 


### PR DESCRIPTION
## Summary
- add new dataset `pesticide_active_ingredients.json`
- document dataset in `dataset_catalog.json`
- expose active ingredient info via `pesticide_manager`
- test new API
- expand dataset with additional active ingredients

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688624d5e9f88330b9e3cc2a16f6dd11