### PR TITLE
Add ingredient profile utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Important categories include:
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions
+- **Fertilizer ingredient profiles** – nutrient content, chemical formulas, physical form and aliases for raw salts. Use `plant_engine.ingredients.get_ingredient_profile()` to access them programmatically
 - **Stock solution recipes** – injection ratios for automated fertigation
 - **Fertilizer compatibility** – warnings for mixing products that react poorly
 - **Soil pH guidelines** – optimal soil pH ranges for supported crops

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -105,6 +105,7 @@
   "climate_zone_guidelines.json": "Temperature and humidity targets for common climate zones.",
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",
+  "fertilizers/fertilizer_ingredients.json": "Base nutrient content, chemical formulas, physical form and aliases for fertilizer ingredients.",
   "fertilizers/fertilizer_application_methods.json": "Recommended application methods for each fertilizer product.",
   "fertilizers/fertilizer_application_rates.json": "Recommended grams per liter of fertilizer product.",
   "fertilizers/fertilizer_compatibility.json": "Compatibility warnings for mixing fertilizer products.",

--- a/data/fertilizers/fertilizer_ingredients.json
+++ b/data/fertilizers/fertilizer_ingredients.json
@@ -1,0 +1,227 @@
+{
+  "ammonium_nitrate": {
+    "aliases": [
+      "Ammonium Nitrate"
+    ],
+    "chemical_formula": "NH4NO3",
+    "form": "solid",
+    "nutrient_content": {
+      "N": 0.34
+    }
+  },
+  "ammonium_phosphate": {
+    "aliases": [
+      "Ammonium Phosphate"
+    ],
+    "chemical_formula": "(NH4)3PO4",
+    "form": "solid",
+    "nutrient_content": {
+      "N": 0.11,
+      "P": 0.088
+    }
+  },
+  "boric_acid": {
+    "aliases": [
+      "Boric Acid"
+    ],
+    "chemical_formula": "H3BO3",
+    "form": "solid",
+    "nutrient_content": {
+      "B": 0.175
+    }
+  },
+  "calcium_nitrate": {
+    "aliases": [
+      "Calcium Nitrate"
+    ],
+    "chemical_formula": "Ca(NO3)2·4H2O",
+    "form": "solid",
+    "nutrient_content": {
+      "Ca": 0.19,
+      "N": 0.155
+    }
+  },
+  "copper_edta": {
+    "aliases": [
+      "Copper EDTA",
+      "Cu EDTA",
+      "chelated_cu"
+    ],
+    "chemical_formula": "C10H12N2O8CuNa2",
+    "form": "solid",
+    "nutrient_content": {
+      "Cu": 0.15
+    }
+  },
+  "iron_edta": {
+    "aliases": [
+      "Iron EDTA",
+      "Fe EDTA",
+      "chelated_fe"
+    ],
+    "chemical_formula": "C10H12N2O8FeNa",
+    "form": "solid",
+    "nutrient_content": {
+      "Fe": 0.12
+    }
+  },
+  "magnesium_nitrate": {
+    "aliases": [
+      "Magnesium Nitrate"
+    ],
+    "chemical_formula": "Mg(NO3)2·6H2O",
+    "form": "solid",
+    "nutrient_content": {
+      "Mg": 0.095,
+      "N": 0.109
+    }
+  },
+  "magnesium_sulfate": {
+    "aliases": [
+      "Magnesium Sulfate Heptahydrate",
+      "Magnesium Sulfate",
+      "Epsom Salt"
+    ],
+    "chemical_formula": "MgSO4·7H2O",
+    "form": "solid",
+    "nutrient_content": {
+      "Mg": 0.098,
+      "S": 0.129
+    }
+  },
+  "manganese_edta": {
+    "aliases": [
+      "Manganese EDTA",
+      "Mn EDTA",
+      "chelated_mn"
+    ],
+    "chemical_formula": "C10H12N2O8MnNa2",
+    "form": "solid",
+    "nutrient_content": {
+      "Mn": 0.13
+    }
+  },
+  "monoammonium_phosphate": {
+    "aliases": [
+      "Monoammonium Phosphate",
+      "MAP"
+    ],
+    "chemical_formula": "NH4H2PO4",
+    "form": "solid",
+    "nutrient_content": {
+      "N": 0.11,
+      "P": 0.22
+    }
+  },
+  "monopotassium_phosphate": {
+    "aliases": [
+      "Monopotassium Phosphate"
+    ],
+    "chemical_formula": "KH2PO4",
+    "form": "solid",
+    "nutrient_content": {
+      "K": 0.287,
+      "P": 0.227
+    }
+  },
+  "phosphoric_acid": {
+    "aliases": [
+      "Phosphoric Acid"
+    ],
+    "chemical_formula": "H3PO4",
+    "form": "liquid",
+    "nutrient_content": {
+      "P": 0.52
+    }
+  },
+  "potassium_chloride": {
+    "aliases": [
+      "Potassium Chloride",
+      "KCl"
+    ],
+    "chemical_formula": "KCl",
+    "form": "solid",
+    "nutrient_content": {
+      "K": 0.5
+    }
+  },
+  "potassium_nitrate": {
+    "aliases": [
+      "Potassium Nitrate"
+    ],
+    "chemical_formula": "KNO3",
+    "form": "solid",
+    "nutrient_content": {
+      "K": 0.38,
+      "N": 0.13
+    }
+  },
+  "potassium_sulfate": {
+    "aliases": [
+      "Potassium Sulfate"
+    ],
+    "chemical_formula": "K2SO4",
+    "form": "solid",
+    "nutrient_content": {
+      "K": 0.449,
+      "S": 0.184
+    }
+  },
+  "protein_hydrolysate": {
+    "aliases": [
+      "Protein Hydrolysate"
+    ],
+    "form": "liquid",
+    "nutrient_content": {}
+  },
+  "sea_kelp": {
+    "aliases": [
+      "Sea Kelp",
+      "Seaweed"
+    ],
+    "form": "liquid",
+    "nutrient_content": {}
+  },
+  "sodium_borate": {
+    "aliases": [
+      "Sodium Borate"
+    ],
+    "chemical_formula": "Na2B4O7·10H2O",
+    "form": "solid",
+    "nutrient_content": {
+      "B": 0.113
+    }
+  },
+  "sodium_molybdate": {
+    "aliases": [
+      "Sodium Molybdate"
+    ],
+    "chemical_formula": "Na2MoO4·2H2O",
+    "form": "solid",
+    "nutrient_content": {
+      "Mo": 0.396
+    }
+  },
+  "urea": {
+    "aliases": [
+      "Urea"
+    ],
+    "chemical_formula": "CO(NH2)2",
+    "form": "solid",
+    "nutrient_content": {
+      "N": 0.46
+    }
+  },
+  "zinc_edta": {
+    "aliases": [
+      "Zinc EDTA",
+      "Zn EDTA",
+      "chelated_zn"
+    ],
+    "chemical_formula": "C10H12N2O8ZnNa2",
+    "form": "solid",
+    "nutrient_content": {
+      "Zn": 0.14
+    }
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from importlib import import_module
 
-from . import utils, environment_tips, media_manager
+from . import utils, environment_tips, media_manager, ingredients
 from .utils import *  # noqa: F401,F403
 from .environment_tips import *  # noqa: F401,F403
 from .media_manager import *  # noqa: F401,F403
+from .ingredients import *  # noqa: F401,F403
 from .nutrient_planner import (
     NutrientManagementReport,
     generate_nutrient_management_report,
@@ -22,6 +23,7 @@ __all__ = sorted(
     set(utils.__all__)
     | set(environment_tips.__all__)
     | set(media_manager.__all__)
+    | set(ingredients.__all__)
     | {
         "NutrientManagementReport",
         "generate_nutrient_management_report",

--- a/plant_engine/ingredients.py
+++ b/plant_engine/ingredients.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Tuple, List
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "fertilizers/fertilizer_ingredients.json"
+
+
+@dataclass(frozen=True, slots=True)
+class IngredientProfile:
+    """Profile describing a fertilizer ingredient."""
+
+    name: str
+    nutrient_content: Dict[str, float]
+    chemical_formula: str | None = None
+    form: str | None = None
+    aliases: Tuple[str, ...] = ()
+
+
+@lru_cache(maxsize=None)
+def _load_profiles() -> Tuple[Dict[str, IngredientProfile], Dict[str, str]]:
+    data = load_dataset(DATA_FILE)
+    profiles: Dict[str, IngredientProfile] = {}
+    alias_map: Dict[str, str] = {}
+    for name, info in data.items():
+        canonical = normalize_key(name)
+        nutrient_content = {
+            k: float(v) for k, v in info.get("nutrient_content", {}).items()
+        }
+        aliases = tuple(info.get("aliases", []))
+        profiles[canonical] = IngredientProfile(
+            name=canonical,
+            nutrient_content=nutrient_content,
+            chemical_formula=info.get("chemical_formula"),
+            form=info.get("form"),
+            aliases=aliases,
+        )
+        for alias in aliases:
+            alias_map[normalize_key(alias)] = canonical
+    return profiles, alias_map
+
+
+def get_ingredient_profile(name: str) -> IngredientProfile | None:
+    """Return :class:`IngredientProfile` for ``name`` or ``None`` if unknown."""
+
+    profiles, alias_map = _load_profiles()
+    key = normalize_key(name)
+    canonical = alias_map.get(key, key)
+    return profiles.get(canonical)
+
+
+def list_ingredients() -> List[str]:
+    """Return sorted canonical ingredient names."""
+
+    profiles, _ = _load_profiles()
+    return sorted(profiles.keys())
+
+
+__all__ = ["IngredientProfile", "get_ingredient_profile", "list_ingredients"]

--- a/tests/test_ingredient_profiles.py
+++ b/tests/test_ingredient_profiles.py
@@ -1,0 +1,21 @@
+from plant_engine.ingredients import get_ingredient_profile, list_ingredients
+
+
+def test_get_ingredient_profile():
+    profile = get_ingredient_profile("urea")
+    assert profile
+    assert profile.nutrient_content["N"] == 0.46
+    assert profile.chemical_formula == "CO(NH2)2"
+
+
+def test_alias_lookup():
+    profile = get_ingredient_profile("Epsom Salt")
+    assert profile
+    assert profile.name == "magnesium_sulfate"
+    assert profile.form == "solid"
+
+
+def test_list_ingredients():
+    ingredients = list_ingredients()
+    assert "urea" in ingredients
+    assert "magnesium_sulfate" in ingredients


### PR DESCRIPTION
## Summary
- add bullet in README describing how to load ingredient profiles
- implement `plant_engine.ingredients` with `IngredientProfile` dataclass
- expose ingredient helpers through package `__init__`
- test ingredient profile lookup and alias resolution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886245d8dfc8330a512f0881b783cef