### PR TITLE
Improve pest monitor lifecycle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Important categories include:
 - **Environment actions** – recommended steps when temperature or humidity are out of range
 - **Nutrient guidelines** – macronutrient and micronutrient targets by stage
 - **Pest and disease references** – thresholds, prevention tips and treatment options
+- **Pest lifecycle durations** – typical days from egg to adult used for scheduling follow-up treatments
 - **Fungicide recommendations** – suggested organic products for common diseases
 - **Pest scouting methods** – recommended techniques for monitoring common pests
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -83,6 +83,7 @@
   "disease_risk_factors.json": "Environmental factors increasing disease risk.",
   "pest_severity_actions.json": "Actions to take based on pest severity level.",
   "pest_severity_thresholds.json": "Population levels defining pest severity categories.",
+  "pest_lifecycle_days.json": "Average lifecycle duration in days for common pests.",
   "ph_adjustment_factors.json": "Acid/base amounts for pH corrections.",
   "ph_guidelines.json": "Optimal pH ranges for nutrient uptake.",
   "growth_medium_ph_ranges.json": "Recommended pH ranges for common growing media.",

--- a/data/pest_lifecycle_days.json
+++ b/data/pest_lifecycle_days.json
@@ -1,0 +1,5 @@
+{
+  "aphids": 7,
+  "whiteflies": 6,
+  "thrips": 12
+}

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -184,3 +184,21 @@ def test_generate_detailed_monitoring_schedule():
     assert entry["date"] == date(2023, 1, 4)
     assert "aphids" in entry["methods"]
 
+
+def test_lifecycle_helpers():
+    from plant_engine.pest_monitor import (
+        get_lifecycle_days,
+        next_treatment_date,
+        recommend_treatment_schedule,
+    )
+
+    assert get_lifecycle_days("aphids") == 7
+    assert get_lifecycle_days("unknown") is None
+
+    last = date(2024, 1, 1)
+    assert next_treatment_date("aphids", last) == date(2024, 1, 4)
+    assert next_treatment_date("unknown", last) is None
+
+    sched = recommend_treatment_schedule(["aphids"], last, repeats=2)
+    assert sched["aphids"] == [date(2024, 1, 4), date(2024, 1, 7)]
+


### PR DESCRIPTION
## Summary
- fix duplicate loader and add lifecycle dataset to pest monitor
- provide helper functions for determining pest lifecycle-based treatment schedules
- list pest lifecycle data in dataset catalog and docs
- expand tests for new pest lifecycle helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659bdf1d4833099e80690aa3e18e7