### PR TITLE
Improve DAFE data models and expose fertigation helper

### DIFF
--- a/dafe/__init__.py
+++ b/dafe/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 
 __all__ = [
+    "SpeciesProfile",
+    "MediaProfile",
     "get_species_profile",
     "get_media_profile",
     "calculate_effective_diffusion",
@@ -13,6 +15,7 @@ __all__ = [
     "get_current_ec",
     "get_current_wc",
     "generate_pulse_schedule",
+    "recommend_fertigation_schedule",
     "calculate_ec_drift",
     "load_config",
     "parse_args",
@@ -23,12 +26,15 @@ __all__ = [
 _MODULE_MAP = {
     "get_species_profile": "species_profiles",
     "get_media_profile": "media_models",
+    "SpeciesProfile": "species_profiles",
+    "MediaProfile": "media_models",
     "calculate_effective_diffusion": "diffusion_model",
     "calculate_diffusion_flux": "diffusion_model",
     "estimate_diffusion_mass": "diffusion_model",
     "get_current_ec": "ec_tracker",
     "get_current_wc": "wc_monitor",
     "generate_pulse_schedule": "pulse_scheduler",
+    "recommend_fertigation_schedule": "fertigation",
     "calculate_ec_drift": "ec_model",
     "load_config": "utils",
     "parse_args": "main",

--- a/dafe/fertigation.py
+++ b/dafe/fertigation.py
@@ -1,0 +1,28 @@
+"""Convenience wrappers for fertigation utilities."""
+
+from __future__ import annotations
+
+from typing import Mapping, Dict
+
+from plant_engine.fertigation import recommend_fertigation_schedule as _recommend
+
+__all__ = ["recommend_fertigation_schedule"]
+
+
+def recommend_fertigation_schedule(
+    plant_type: str,
+    stage: str,
+    volume_l: float,
+    purity: Mapping[str, float] | None = None,
+    *,
+    product: str | None = None,
+) -> Dict[str, float]:
+    """Return fertilizer grams for a nutrient solution.
+
+    This is a thin wrapper around
+    :func:`plant_engine.fertigation.recommend_fertigation_schedule`
+    allowing DAFE to expose nutrient planning features without
+    requiring callers to import :mod:`plant_engine` directly.
+    """
+
+    return _recommend(plant_type, stage, volume_l, purity, product=product)

--- a/dafe/main.py
+++ b/dafe/main.py
@@ -94,8 +94,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     D_eff = calculate_effective_diffusion(
         D_base=D_base,
         vwc=wc,
-        porosity=media_profile["porosity"],
-        tortuosity=media_profile["tortuosity"],
+        porosity=media_profile.porosity,
+        tortuosity=media_profile.tortuosity,
     )
 
     nutrient_params = {"D_base": D_base}

--- a/dafe/media_models.py
+++ b/dafe/media_models.py
@@ -1,18 +1,38 @@
-"""Substrate property definitions for DAFE."""
+"""Media profile definitions for the Diffusion-Aware Fertigation Engine."""
 
 from __future__ import annotations
 
-__all__ = ["get_media_profile"]
+from dataclasses import dataclass
+from functools import lru_cache
+
+__all__ = ["MediaProfile", "get_media_profile"]
 
 
-def get_media_profile(media_name: str) -> dict | None:
-    """Return a media profile dictionary or ``None`` if unknown."""
-    profiles = {
+@dataclass(frozen=True, slots=True)
+class MediaProfile:
+    """Container object describing substrate properties."""
+
+    name: str
+    porosity: float
+    fc: float
+    pwp: float
+    tortuosity: float
+
+
+@lru_cache(maxsize=None)
+def get_media_profile(media_name: str) -> MediaProfile | None:
+    """Return a :class:`MediaProfile` or ``None`` if ``media_name`` unknown."""
+
+    data = {
         "coco_coir": {
             "porosity": 0.78,
             "fc": 0.55,
             "pwp": 0.20,
             "tortuosity": 2.3,
         }
-    }
-    return profiles.get(media_name)
+    }.get(media_name)
+
+    if not data:
+        return None
+
+    return MediaProfile(media_name, **data)

--- a/dafe/pulse_scheduler.py
+++ b/dafe/pulse_scheduler.py
@@ -55,10 +55,10 @@ def generate_pulse_schedule(
 
     for offset in range(hours):
         hour = start_hour + offset
-        if wc < species_profile["ideal_wc_plateau"]:
+        if wc < species_profile.ideal_wc_plateau:
             pulse_volume = int(30 + D_eff * 100000)
-            ec_low = species_profile.get("ec_low", 1.5)
-            ec_high = species_profile.get("ec_high", 2.5)
+            ec_low = species_profile.ec_low
+            ec_high = species_profile.ec_high
             if ec > ec_high:
                 pulse_volume = int(pulse_volume * 0.8)
             elif ec < ec_low:
@@ -66,8 +66,8 @@ def generate_pulse_schedule(
             mass_mg = estimate_diffusion_mass(
                 D_base,
                 wc,
-                media_profile["porosity"],
-                media_profile["tortuosity"],
+                media_profile.porosity,
+                media_profile.tortuosity,
                 conc_high,
                 conc_low,
                 distance_cm,

--- a/dafe/species_profiles.py
+++ b/dafe/species_profiles.py
@@ -1,21 +1,44 @@
-"""Mock species profiles for DAFE."""
+"""Species profile definitions for the Diffusion-Aware Fertigation Engine."""
 
 from __future__ import annotations
 
-__all__ = ["get_species_profile"]
+from dataclasses import dataclass
+from functools import lru_cache
+
+__all__ = ["SpeciesProfile", "get_species_profile"]
 
 
-def get_species_profile(species_name: str) -> dict | None:
-    """Return a species profile dictionary or ``None`` if unknown."""
-    profiles = {
+@dataclass(frozen=True, slots=True)
+class SpeciesProfile:
+    """Container object describing plant characteristics."""
+
+    name: str
+    root_depth: str
+    dryback_tolerance: str
+    oxygen_min: float
+    ideal_wc_plateau: float
+    generative_threshold: float
+    ec_low: float
+    ec_high: float
+
+
+@lru_cache(maxsize=None)
+def get_species_profile(species_name: str) -> SpeciesProfile | None:
+    """Return a :class:`SpeciesProfile` or ``None`` if ``species_name`` unknown."""
+
+    data = {
         "Cannabis_sativa": {
             "root_depth": "shallow",
             "dryback_tolerance": "medium",
-            "oxygen_min": 8,
+            "oxygen_min": 8.0,
             "ideal_wc_plateau": 0.42,
             "generative_threshold": 0.035,
             "ec_low": 1.5,
             "ec_high": 2.5,
         }
-    }
-    return profiles.get(species_name)
+    }.get(species_name)
+
+    if not data:
+        return None
+
+    return SpeciesProfile(species_name, **data)

--- a/dafe/utils.py
+++ b/dafe/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from functools import lru_cache
 import yaml
 
 __all__ = ["mm_to_cm", "load_config"]
@@ -16,7 +17,9 @@ def mm_to_cm(value_mm: float) -> float:
 CONFIG_FILE = Path(__file__).resolve().with_name("dafe_config.yaml")
 
 
+@lru_cache(maxsize=None)
 def load_config(path: str | Path = CONFIG_FILE) -> dict:
     """Return configuration values from ``dafe_config.yaml``."""
+
     with open(path, "r", encoding="utf-8") as fh:
         return yaml.safe_load(fh)

--- a/tests/test_dafe.py
+++ b/tests/test_dafe.py
@@ -15,9 +15,9 @@ def test_generate_pulse_schedule():
 
     species = get_species_profile("Cannabis_sativa")
     media = get_media_profile("coco_coir")
-    wc = species["ideal_wc_plateau"] - 0.01
+    wc = species.ideal_wc_plateau - 0.01
     D_eff = calculate_effective_diffusion(
-        1e-5, wc, media["porosity"], media["tortuosity"]
+        1e-5, wc, media.porosity, media.tortuosity
     )
     base_volume = int(30 + D_eff * 100000)
 
@@ -52,9 +52,9 @@ def test_custom_pulse_window():
 
     species = get_species_profile("Cannabis_sativa")
     media = get_media_profile("coco_coir")
-    wc = species["ideal_wc_plateau"] - 0.01
+    wc = species.ideal_wc_plateau - 0.01
     D_eff = calculate_effective_diffusion(
-        1e-5, wc, media["porosity"], media["tortuosity"]
+        1e-5, wc, media.porosity, media.tortuosity
     )
 
     schedule = generate_pulse_schedule(
@@ -107,3 +107,12 @@ def test_main_json_output():
     m1 = data1[0]["mass_mg"]
     m2 = data2[0]["mass_mg"]
     assert m2 > m1 * 5.9 and m2 < m1 * 6.1
+
+
+def test_recommend_fertigation_schedule():
+    from dafe import recommend_fertigation_schedule
+
+    schedule = recommend_fertigation_schedule("citrus", "vegetative", 10)
+    assert schedule["N"] == 0.8
+    assert schedule["P"] == 0.3
+    assert schedule["K"] == 0.6


### PR DESCRIPTION
## Summary
- refactor DAFE species and media profiles to dataclasses
- cache configuration loading
- use dataclass attributes in main and scheduler
- add `fertigation` wrapper exposing nutrient schedule calculations
- update tests for new data models and add fertigation test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659b72514833083da0bf9c6c504ac