### PR TITLE
Improve nutrient efficiency utilities

### DIFF
--- a/custom_components/horticulture_assistant/utils/nutrient_use_efficiency.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_use_efficiency.py
@@ -276,6 +276,25 @@ class NutrientUseEfficiency:
             return 0.0
         return score_efficiency(eff, plant_type)
 
+    def compare_to_expected(
+        self, plant_id: str, plant_type: str, stage: str
+    ) -> Dict[str, float]:
+        """Return applied minus expected nutrient totals for a stage."""
+
+        from plant_engine.nutrient_uptake import estimate_stage_totals
+
+        expected = estimate_stage_totals(plant_type, stage)
+        if not expected:
+            return {}
+
+        applied = self.total_nutrients_applied(plant_id)
+        diff: Dict[str, float] = {}
+        for nut in set(expected) | set(applied):
+            exp = float(expected.get(nut, 0.0))
+            act = float(applied.get(nut, 0.0))
+            diff[nut] = round(act - exp, 2)
+        return diff
+
     def get_usage_summary(self, plant_id: str, by: str) -> Dict[str, Dict[str, float]]:
         """
         Summarize nutrient usage for a plant, grouped by a time period or lifecycle stage.

--- a/tests/test_nutrient_use_efficiency_util.py
+++ b/tests/test_nutrient_use_efficiency_util.py
@@ -38,3 +38,36 @@ def test_log_and_save(tmp_path, monkeypatch):
     assert nue.yield_log["p2"] == 200
     data = json.loads((data_dir / "nutrient_use.json").read_text())
     assert data["p2"][0]["nutrients"]["P"] == 50
+
+
+def test_compare_to_expected(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "nutrient_use.json").write_text(json.dumps({
+        "p1": [
+            {"date": "2025-01-01", "nutrients": {"N": 150, "P": 60}, "stage": "veg"}
+        ]
+    }))
+    (data_dir / "yield_logs.json").write_text("{}")
+    (data_dir / "nutrient_uptake.json").write_text(json.dumps({
+        "tomato": {"veg": {"N": 100, "P": 40}}
+    }))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    import importlib
+    import plant_engine.nutrient_uptake as nu
+    import plant_engine.growth_stage as gs
+    importlib.reload(nu)
+    importlib.reload(gs)
+    monkeypatch.setattr(gs, "get_stage_duration", lambda a, b: 1)
+
+    nue = NutrientUseEfficiency()
+    diff = nue.compare_to_expected("p1", "tomato", "veg")
+    assert diff["N"] == 50
+    assert diff["P"] == 20
+    # restore default datasets for subsequent tests
+    from plant_engine.utils import clear_dataset_cache
+    monkeypatch.delenv("HORTICULTURE_DATA_DIR", raising=False)
+    clear_dataset_cache()
+    importlib.reload(nu)
+    importlib.reload(gs)


### PR DESCRIPTION
## Summary
- extend nutrient usage utility with a method to compare applied fertilizer to expected uptake
- add regression test covering new comparison method and ensure dataset caches reset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688659b89c18833080232b6e40b4548e