### PR TITLE
Improve pest management helpers

### DIFF
--- a/plant_engine/pest_manager.py
+++ b/plant_engine/pest_manager.py
@@ -114,6 +114,22 @@ def recommend_release_rates(pests: Iterable[str]) -> Dict[str, Dict[str, float]]
     return rec
 
 
+def calculate_release_quantities(
+    pests: Iterable[str], area_m2: float
+) -> Dict[str, float]:
+    """Return total beneficial insect counts for ``area_m2`` of crop."""
+
+    if area_m2 <= 0:
+        raise ValueError("area_m2 must be positive")
+
+    rates = recommend_release_rates(pests)
+    totals: Dict[str, float] = {}
+    for pest_rates in rates.values():
+        for insect, rate in pest_rates.items():
+            totals[insect] = round(totals.get(insect, 0.0) + rate * area_m2, 2)
+    return totals
+
+
 def get_organic_controls(pest: str) -> List[str]:
     """Return organic control options for ``pest``."""
 
@@ -211,6 +227,7 @@ __all__ = [
     "recommend_beneficials",
     "get_beneficial_release_rate",
     "recommend_release_rates",
+    "calculate_release_quantities",
     "get_organic_controls",
     "recommend_organic_controls",
     "get_pest_prevention",

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -42,15 +42,11 @@ def _load(obj):
     """Return dataset contents regardless of lazy or eager storage."""
 
     return obj() if callable(obj) else obj
+
+
 _MONITOR_INTERVALS = lazy_dataset(MONITOR_INTERVAL_FILE)
 _RISK_MODIFIERS = lazy_dataset(RISK_INTERVAL_MOD_FILE)
 _SCOUTING_METHODS = lazy_dataset(SCOUTING_METHOD_FILE)
-
-
-def _load(data):
-    """Return dataset contents supporting direct dict overrides."""
-
-    return data() if callable(data) else data
 
 __all__ = [
     "list_supported_plants",

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -137,3 +137,10 @@ def test_build_pest_management_plan_includes_organic():
 def test_build_pest_management_plan_includes_scientific_name():
     plan = build_pest_management_plan("citrus", ["aphids"])
     assert plan["aphids"]["scientific_name"] == "Aphidoidea"
+
+
+def test_calculate_release_quantities():
+    from plant_engine.pest_manager import calculate_release_quantities
+
+    qty = calculate_release_quantities(["aphids"], 10)
+    assert qty["ladybugs"] == 50


### PR DESCRIPTION
## Summary
- fix duplicate loader helper in `pest_monitor`
- add `calculate_release_quantities` to `pest_manager`
- test new release quantity helper

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659bfe234833099abed1286fe52c8