### PR TITLE
Add drought tolerance fallback for irrigation interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Optional OpenAI or offline models for nutrient planning
 - Irrigation and fertigation switches with approval queues
 - Configurable irrigation zones with shared solenoids
+- Watering interval defaults to drought tolerance when stage data is missing
 
 ### Data & Analytics
 - Disease and pest treatment recommendations

--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -334,7 +334,13 @@ def get_recommended_interval(plant_type: str, stage: str) -> float | None:
     value = stage_value(_INTERVAL_DATA, plant_type, stage)
     if isinstance(value, (int, float)):
         return float(value)
-    return None
+    # Fall back to drought tolerance data when stage-specific guidance
+    # is unavailable. This ensures a sensible default interval based on
+    # crop water stress tolerance.
+    from .drought_manager import recommend_watering_interval
+
+    interval = recommend_watering_interval(plant_type, default_days=0)
+    return float(interval) if interval > 0 else None
 
 
 def generate_irrigation_schedule(

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -161,7 +161,9 @@ def test_daily_irrigation_target_lookup():
 
 def test_get_recommended_interval():
     assert get_recommended_interval("citrus", "seedling") == 2
-    assert get_recommended_interval("citrus", "unknown") is None
+    # When a stage-specific interval isn't defined the value falls back to
+    # drought tolerance data for the crop.
+    assert get_recommended_interval("citrus", "unknown") == 3
 
 
 def test_generate_irrigation_schedule():


### PR DESCRIPTION
## Summary
- default irrigation intervals to drought tolerance when stage data is missing
- mention watering interval fallback in README
- test the new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659c575808330b94c4c9af2269f29