### PR TITLE
Refactor pest monitor dataset access

### DIFF
--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -36,19 +36,13 @@ _THRESHOLDS = lazy_dataset(DATA_FILE)
 _RISK_FACTORS = lazy_dataset(RISK_DATA_FILE)
 _SEVERITY_ACTIONS = lazy_dataset(SEVERITY_ACTIONS_FILE)
 _SEVERITY_THRESHOLDS = lazy_dataset(SEVERITY_THRESHOLD_FILE)
-
-
-def _load(obj):
-    """Return dataset contents regardless of lazy or eager storage."""
-
-    return obj() if callable(obj) else obj
 _MONITOR_INTERVALS = lazy_dataset(MONITOR_INTERVAL_FILE)
 _RISK_MODIFIERS = lazy_dataset(RISK_INTERVAL_MOD_FILE)
 _SCOUTING_METHODS = lazy_dataset(SCOUTING_METHOD_FILE)
 
 
-def _load(data):
-    """Return dataset contents supporting direct dict overrides."""
+def _resolve_dataset(data):
+    """Return dataset contents from a lazy loader or raw mapping."""
 
     return data() if callable(data) else data
 
@@ -68,6 +62,7 @@ __all__ = [
     "get_severity_action",
     "get_severity_thresholds",
     "get_monitoring_interval",
+    "get_all_monitoring_intervals",
     "risk_adjusted_monitor_interval",
     "next_monitor_date",
     "generate_monitoring_schedule",
@@ -84,20 +79,34 @@ def get_pest_thresholds(plant_type: str) -> Dict[str, int]:
     ``"citrus"`` map to the same dataset entry.
     """
 
-    data = _load(_THRESHOLDS)
+    data = _resolve_dataset(_THRESHOLDS)
     return data.get(normalize_key(plant_type), {})
 
 
 def list_supported_plants() -> list[str]:
     """Return plant types with pest threshold definitions."""
 
-    return list_dataset_entries(_load(_THRESHOLDS))
+    return list_dataset_entries(_resolve_dataset(_THRESHOLDS))
 
 
 def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | None:
     """Return recommended days between scouting events for a plant stage."""
 
-    return _get_interval(_load(_MONITOR_INTERVALS), plant_type, stage)
+    return _get_interval(_resolve_dataset(_MONITOR_INTERVALS), plant_type, stage)
+
+
+def get_all_monitoring_intervals(plant_type: str) -> Dict[str, int]:
+    """Return monitoring interval in days for all stages of ``plant_type``."""
+
+    data = _resolve_dataset(_MONITOR_INTERVALS)
+    plant = data.get(normalize_key(plant_type), {})
+    intervals: Dict[str, int] = {}
+    for stage, days in plant.items():
+        try:
+            intervals[stage] = int(days)
+        except (TypeError, ValueError):
+            continue
+    return intervals
 
 
 def risk_adjusted_monitor_interval(
@@ -118,7 +127,7 @@ def risk_adjusted_monitor_interval(
     elif any(r == "moderate" for r in risks.values()):
         level = "moderate"
 
-    modifiers = _load(_RISK_MODIFIERS)
+    modifiers = _resolve_dataset(_RISK_MODIFIERS)
     modifier = modifiers.get(level, 1.0)
     interval = int(round(base * modifier))
     return max(1, interval)
@@ -129,7 +138,7 @@ def next_monitor_date(
 ) -> date | None:
     """Return the next pest scouting date based on interval guidelines."""
 
-    return _next_date(_load(_MONITOR_INTERVALS), plant_type, stage, last_date)
+    return _next_date(_resolve_dataset(_MONITOR_INTERVALS), plant_type, stage, last_date)
 
 
 def generate_monitoring_schedule(
@@ -140,7 +149,7 @@ def generate_monitoring_schedule(
 ) -> list[date]:
     """Return list of upcoming monitoring dates."""
 
-    return _generate_schedule(_load(_MONITOR_INTERVALS), plant_type, stage, start, events)
+    return _generate_schedule(_resolve_dataset(_MONITOR_INTERVALS), plant_type, stage, start, events)
 
 
 def generate_detailed_monitoring_schedule(
@@ -160,21 +169,21 @@ def generate_detailed_monitoring_schedule(
 def get_severity_action(level: str) -> str:
     """Return recommended action for a severity ``level``."""
 
-    actions = _load(_SEVERITY_ACTIONS)
+    actions = _resolve_dataset(_SEVERITY_ACTIONS)
     return actions.get(level.lower(), "")
 
 
 def get_scouting_method(pest: str) -> str:
     """Return recommended scouting approach for ``pest``."""
 
-    methods = _load(_SCOUTING_METHODS)
+    methods = _resolve_dataset(_SCOUTING_METHODS)
     return methods.get(normalize_key(pest), "")
 
 
 def get_severity_thresholds(pest: str) -> Dict[str, float]:
     """Return population thresholds for severity levels of ``pest``."""
 
-    thresholds = _load(_SEVERITY_THRESHOLDS)
+    thresholds = _resolve_dataset(_SEVERITY_THRESHOLDS)
     return thresholds.get(normalize_key(pest), {})
 
 
@@ -248,7 +257,7 @@ def estimate_pest_risk(
 ) -> Dict[str, str]:
     """Return pest risk level based on environmental conditions."""
 
-    factors = _load(_RISK_FACTORS).get(normalize_key(plant_type), {})
+    factors = _resolve_dataset(_RISK_FACTORS).get(normalize_key(plant_type), {})
     if not factors:
         return {}
 

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -13,6 +13,7 @@ from plant_engine.pest_monitor import (
     next_monitor_date,
     generate_monitoring_schedule,
     generate_detailed_monitoring_schedule,
+    get_all_monitoring_intervals,
     risk_adjusted_monitor_interval,
     get_scouting_method,
     get_severity_thresholds,
@@ -120,6 +121,12 @@ def test_get_monitoring_interval():
     assert get_monitoring_interval("citrus", "fruiting") == 3
     assert get_monitoring_interval("CITRUS") == 5
     assert get_monitoring_interval("unknown") is None
+
+
+def test_get_all_monitoring_intervals():
+    intervals = get_all_monitoring_intervals("citrus")
+    assert intervals["seedling"] == 7
+    assert intervals["fruiting"] == 3
 
 
 def test_next_monitor_date():


### PR DESCRIPTION
## Summary
- simplify dataset loading in `pest_monitor`
- expose `get_all_monitoring_intervals` helper
- add unit tests for new helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659c945b88330b0bdb09ad1219478