### PR TITLE
Enhance dataset helper utilities

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -31,6 +31,7 @@ __all__ = [
     "parse_range",
     "deep_update",
     "stage_value",
+    "load_stage_dataset_value",
 ]
 
 
@@ -318,3 +319,17 @@ def stage_value(
         if value is not None:
             return value
     return plant.get(default_key)
+
+def load_stage_dataset_value(
+    filename: str, plant_type: str, stage: str | None, default_key: str = "optimal"
+) -> Any:
+    """Return a stage value from ``filename`` for ``plant_type`` and ``stage``.
+
+    Combines :func:`load_dataset` and :func:`stage_value` for convenience. If the
+    dataset file does not exist or is not a mapping, ``None`` is returned.
+    """
+    data = load_dataset(filename)
+    if not isinstance(data, Mapping):
+        return None
+    return stage_value(data, plant_type, stage, default_key)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from plant_engine.utils import (
     normalize_key,
     clear_dataset_cache,
     stage_value,
+    load_stage_dataset_value,
 )
 
 
@@ -74,3 +75,16 @@ def test_stage_value_fallback():
 def test_stage_value_custom_default():
     data = {"crop": {"phase": 1, "default": 2}}
     assert stage_value(data, "crop", "missing", default_key="default") == 2
+
+
+def test_load_stage_dataset_value():
+    value = load_stage_dataset_value(
+        "soil_moisture_guidelines.json", "citrus", "seedling"
+    )
+    assert value == [30, 50]
+
+    # missing stage falls back to the dataset's 'optimal' entry
+    assert load_stage_dataset_value(
+        "soil_moisture_guidelines.json", "citrus", "missing"
+    ) == [30, 50]
+


### PR DESCRIPTION
## Summary
- add `load_stage_dataset_value` helper to fetch values from stage datasets
- test new helper in `test_utils`

## Testing
- `pytest tests/test_utils.py::test_load_stage_dataset_value -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688659cd0a888330afde61e15beb722a