### PR TITLE
Fix dataset loader duplication

### DIFF
--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -38,19 +38,15 @@ _SEVERITY_ACTIONS = lazy_dataset(SEVERITY_ACTIONS_FILE)
 _SEVERITY_THRESHOLDS = lazy_dataset(SEVERITY_THRESHOLD_FILE)
 
 
-def _load(obj):
-    """Return dataset contents regardless of lazy or eager storage."""
+def _resolve(data):
+    """Return dataset contents, resolving cached loader callables."""
 
-    return obj() if callable(obj) else obj
+    return data() if callable(data) else data
+
+
 _MONITOR_INTERVALS = lazy_dataset(MONITOR_INTERVAL_FILE)
 _RISK_MODIFIERS = lazy_dataset(RISK_INTERVAL_MOD_FILE)
 _SCOUTING_METHODS = lazy_dataset(SCOUTING_METHOD_FILE)
-
-
-def _load(data):
-    """Return dataset contents supporting direct dict overrides."""
-
-    return data() if callable(data) else data
 
 __all__ = [
     "list_supported_plants",
@@ -84,20 +80,20 @@ def get_pest_thresholds(plant_type: str) -> Dict[str, int]:
     ``"citrus"`` map to the same dataset entry.
     """
 
-    data = _load(_THRESHOLDS)
+    data = _resolve(_THRESHOLDS)
     return data.get(normalize_key(plant_type), {})
 
 
 def list_supported_plants() -> list[str]:
     """Return plant types with pest threshold definitions."""
 
-    return list_dataset_entries(_load(_THRESHOLDS))
+    return list_dataset_entries(_resolve(_THRESHOLDS))
 
 
 def get_monitoring_interval(plant_type: str, stage: str | None = None) -> int | None:
     """Return recommended days between scouting events for a plant stage."""
 
-    return _get_interval(_load(_MONITOR_INTERVALS), plant_type, stage)
+    return _get_interval(_resolve(_MONITOR_INTERVALS), plant_type, stage)
 
 
 def risk_adjusted_monitor_interval(
@@ -118,7 +114,7 @@ def risk_adjusted_monitor_interval(
     elif any(r == "moderate" for r in risks.values()):
         level = "moderate"
 
-    modifiers = _load(_RISK_MODIFIERS)
+    modifiers = _resolve(_RISK_MODIFIERS)
     modifier = modifiers.get(level, 1.0)
     interval = int(round(base * modifier))
     return max(1, interval)
@@ -129,7 +125,7 @@ def next_monitor_date(
 ) -> date | None:
     """Return the next pest scouting date based on interval guidelines."""
 
-    return _next_date(_load(_MONITOR_INTERVALS), plant_type, stage, last_date)
+    return _next_date(_resolve(_MONITOR_INTERVALS), plant_type, stage, last_date)
 
 
 def generate_monitoring_schedule(
@@ -140,7 +136,7 @@ def generate_monitoring_schedule(
 ) -> list[date]:
     """Return list of upcoming monitoring dates."""
 
-    return _generate_schedule(_load(_MONITOR_INTERVALS), plant_type, stage, start, events)
+    return _generate_schedule(_resolve(_MONITOR_INTERVALS), plant_type, stage, start, events)
 
 
 def generate_detailed_monitoring_schedule(
@@ -160,21 +156,21 @@ def generate_detailed_monitoring_schedule(
 def get_severity_action(level: str) -> str:
     """Return recommended action for a severity ``level``."""
 
-    actions = _load(_SEVERITY_ACTIONS)
+    actions = _resolve(_SEVERITY_ACTIONS)
     return actions.get(level.lower(), "")
 
 
 def get_scouting_method(pest: str) -> str:
     """Return recommended scouting approach for ``pest``."""
 
-    methods = _load(_SCOUTING_METHODS)
+    methods = _resolve(_SCOUTING_METHODS)
     return methods.get(normalize_key(pest), "")
 
 
 def get_severity_thresholds(pest: str) -> Dict[str, float]:
     """Return population thresholds for severity levels of ``pest``."""
 
-    thresholds = _load(_SEVERITY_THRESHOLDS)
+    thresholds = _resolve(_SEVERITY_THRESHOLDS)
     return thresholds.get(normalize_key(pest), {})
 
 
@@ -248,7 +244,7 @@ def estimate_pest_risk(
 ) -> Dict[str, str]:
     """Return pest risk level based on environmental conditions."""
 
-    factors = _load(_RISK_FACTORS).get(normalize_key(plant_type), {})
+    factors = _resolve(_RISK_FACTORS).get(normalize_key(plant_type), {})
     if not factors:
         return {}
 


### PR DESCRIPTION
## Summary
- refactor pest monitor to use single dataset resolver
- update calls to new `_resolve` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659ced4508330a39fa1e109454bab