### PR TITLE
Add growth cycle task planner

### DIFF
--- a/tests/test_stage_tasks.py
+++ b/tests/test_stage_tasks.py
@@ -4,6 +4,7 @@ from plant_engine.stage_tasks import (
     get_stage_tasks,
     list_supported_plants,
     generate_task_schedule,
+    generate_cycle_task_plan,
 )
 
 
@@ -26,3 +27,9 @@ def test_generate_task_schedule():
     assert len(schedule) == 3
     assert schedule[0].tasks
     assert schedule[0].date == date(2025, 1, 1)
+
+
+def test_generate_cycle_task_plan():
+    plan = generate_cycle_task_plan("tomato", date(2025, 1, 1))
+    assert len(plan) == 19
+    assert plan[0].date == date(2025, 1, 1)


### PR DESCRIPTION
## Summary
- extend stage tasks with `generate_cycle_task_plan`
- test cycle task plan generation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659d0db5c8330b6ad2313e19d78c3