### PR TITLE
Implement phenological milestone predictions

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -59,6 +59,7 @@
   "fungicide_recommendations.json": "Organic fungicide options for common diseases.",
   "fungicide_application_rates.json": "Recommended fungicide application rates (g/L or mL/L).",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
+  "phenological_milestones.json": "GDD triggers for key phenological events.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",
   "humidity_actions.json": "Recommended actions for low or high humidity.",

--- a/data/phenological_milestones.json
+++ b/data/phenological_milestones.json
@@ -1,0 +1,19 @@
+{
+  "tomato": {
+    "leaf_emergence": {"gdd": 50, "photoperiod_hours": 18},
+    "flower_initiation": {"gdd": 450, "photoperiod_hours": 12},
+    "fruiting_onset": {"gdd": 700, "photoperiod_hours": 12}
+  },
+  "citrus": {
+    "leaf_emergence": {"gdd": 150, "photoperiod_hours": 16},
+    "bud_break": {"gdd": 400, "photoperiod_hours": 16},
+    "flower_initiation": {"gdd": 850, "photoperiod_hours": 12},
+    "fruiting_onset": {"gdd": 1100, "photoperiod_hours": 12}
+  },
+  "buddhas_hand": {
+    "leaf_emergence": {"gdd": 150, "photoperiod_hours": 16},
+    "bud_break": {"gdd": 500, "photoperiod_hours": 16},
+    "flower_initiation": {"gdd": 870, "photoperiod_hours": 12},
+    "fruiting_onset": {"gdd": 1150, "photoperiod_hours": 12}
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -41,4 +41,16 @@ def __getattr__(name: str):
         __all__.append(name)
         __all__.extend(getattr(module, "__all__", []))
         return module
+    if name == "phenology":
+        module = import_module(".phenology", __name__)
+        globals()[name] = module
+        __all__.append(name)
+        __all__.extend(getattr(module, "__all__", []))
+        return module
+    if name == "thermal_time":
+        module = import_module(".thermal_time", __name__)
+        globals()[name] = module
+        __all__.append(name)
+        __all__.extend(getattr(module, "__all__", []))
+        return module
     raise AttributeError(f"module 'plant_engine' has no attribute {name!r}")

--- a/plant_engine/phenology.py
+++ b/plant_engine/phenology.py
@@ -1,0 +1,124 @@
+"""Phenological milestone prediction utilities."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Dict, Iterable
+
+from . import thermal_time
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "phenological_milestones.json"
+
+_DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_milestone_info",
+    "get_milestone_gdd_requirement",
+    "get_milestone_photoperiod_requirement",
+    "predict_milestone",
+    "estimate_days_to_milestone",
+    "estimate_milestone_date",
+    "format_milestone_prediction",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with phenological milestone data."""
+    return list_dataset_entries(_DATA)
+
+
+def get_milestone_info(plant_type: str, milestone: str) -> dict:
+    """Return info for ``milestone`` of ``plant_type``."""
+    return _DATA.get(normalize_key(plant_type), {}).get(normalize_key(milestone), {})
+
+
+def get_milestone_gdd_requirement(plant_type: str, milestone: str) -> float | None:
+    """Return GDD requirement for reaching ``milestone``."""
+    info = get_milestone_info(plant_type, milestone)
+    value = info.get("gdd")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def get_milestone_photoperiod_requirement(
+    plant_type: str, milestone: str
+) -> float | None:
+    """Return day length requirement for ``milestone`` if available."""
+    info = get_milestone_info(plant_type, milestone)
+    value = info.get("photoperiod_hours")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def predict_milestone(plant_type: str, milestone: str, accumulated_gdd: float) -> bool:
+    """Return ``True`` if ``accumulated_gdd`` meets the milestone requirement."""
+    req = get_milestone_gdd_requirement(plant_type, milestone)
+    if req is None:
+        return False
+    return accumulated_gdd >= req
+
+
+def estimate_days_to_milestone(
+    plant_type: str,
+    milestone: str,
+    temps: Iterable[tuple[float, float]],
+    base_temp_c: float = 10.0,
+) -> int | None:
+    """Return estimated days needed to reach ``milestone`` using ``temps``."""
+    requirement = get_milestone_gdd_requirement(plant_type, milestone)
+    if requirement is None:
+        return None
+
+    accumulated = 0.0
+    for day, (t_min, t_max) in enumerate(temps, start=1):
+        accumulated += thermal_time.calculate_gdd(t_min, t_max, base_temp_c)
+        if accumulated >= requirement:
+            return day
+
+    return None
+
+
+def estimate_milestone_date(
+    plant_type: str,
+    milestone: str,
+    start_date: date,
+    temps: Iterable[tuple[float, float]],
+    base_temp_c: float = 10.0,
+) -> date | None:
+    """Return predicted date when ``milestone`` will be reached."""
+    days = estimate_days_to_milestone(plant_type, milestone, temps, base_temp_c)
+    if days is None:
+        return None
+    return start_date + timedelta(days=days)
+
+
+def format_milestone_prediction(
+    plant_name: str,
+    plant_type: str,
+    milestone: str,
+    accumulated_gdd: float,
+    temps: Iterable[tuple[float, float]],
+    base_temp_c: float = 10.0,
+) -> str:
+    """Return human-friendly milestone prediction message.
+
+    The message references ``plant_name`` and includes the expected
+    days to reach ``milestone`` based on the provided temperature
+    forecast ``temps``. A small ±2 day window is given to account
+    for uncertainty in the forecast.
+    """
+
+    days = estimate_days_to_milestone(
+        plant_type, milestone, temps, base_temp_c
+    )
+    if days is None:
+        return (
+            f"{plant_name} has reached {accumulated_gdd:.0f} GDD since last reset."
+        )
+
+    low = max(0, days - 2)
+    high = days + 2
+    return (
+        f"{plant_name} has reached {accumulated_gdd:.0f} GDD since last reset. "
+        f"Expect {milestone.replace('_', ' ')} within {low}–{high} days."
+    )
+

--- a/tests/test_phenology.py
+++ b/tests/test_phenology.py
@@ -1,0 +1,42 @@
+import datetime
+from plant_engine import phenology
+
+
+def test_get_milestone_gdd_requirement():
+    assert phenology.get_milestone_gdd_requirement("citrus", "flower_initiation") == 850
+
+
+def test_get_milestone_photoperiod_requirement():
+    assert phenology.get_milestone_photoperiod_requirement("citrus", "flower_initiation") == 12
+
+
+def test_predict_milestone():
+    assert phenology.predict_milestone("citrus", "flower_initiation", 900)
+    assert not phenology.predict_milestone("citrus", "flower_initiation", 800)
+
+
+def test_estimate_days_to_milestone():
+    temps = [(20, 30)] * 60
+    days = phenology.estimate_days_to_milestone("tomato", "fruiting_onset", temps)
+    assert isinstance(days, int) and 0 < days <= 60
+
+
+def test_estimate_milestone_date():
+    temps = [(20, 30)] * 60
+    start = datetime.date(2025, 1, 1)
+    date = phenology.estimate_milestone_date("tomato", "fruiting_onset", start, temps)
+    assert date is None or date >= start
+
+
+def test_format_milestone_prediction():
+    temps = [(20, 30)] * 80
+    msg = phenology.format_milestone_prediction(
+        "Buddha's Hand",
+        "buddhas_hand",
+        "flower_initiation",
+        accumulated_gdd=870,
+        temps=temps,
+    )
+    assert "Buddha's Hand" in msg
+    assert "flower initiation" in msg
+


### PR DESCRIPTION
## Summary
- introduce `phenological_milestones.json` dataset
- document dataset in `dataset_catalog.json`
- add `phenology` module with milestone prediction helpers
- test phenology utilities
- extend dataset for Buddha's Hand cultivar and add a message helper
- expose phenology utilities via package init
- add photoperiod requirements for milestones and accessor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68865a6606748330b99d2ed1c97cfec2