### PR TITLE
Add heat memory index tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Important categories include:
 - **Root temperature uptake factors** – relative nutrient uptake efficiency by root zone temperature
 - **Media properties** – recommended pH range and water retention for common substrates
 - **Drought tolerance** – maximum days plants can remain dry before watering
+- **Heat memory profiles** – lag days and nutrient adjustments after heat stress events
 
 The WSDA fertilizer dataset resides under `feature/wsda_refactored_sharded/` which contains an
 `index_sharded/` directory of `.jsonl` shards and a `detail/` directory of per-product records.

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -59,6 +59,7 @@
   "fungicide_recommendations.json": "Organic fungicide options for common diseases.",
   "fungicide_application_rates.json": "Recommended fungicide application rates (g/L or mL/L).",
   "gdd_requirements.json": "Growing degree day requirements by crop.",
+  "heat_memory_profiles.json": "Lag days and recovery guidelines after heat stress.",
   "heat_stress_thresholds.json": "Temperature levels causing heat stress.",
   "humidity_stress_thresholds.json": "Relative humidity levels causing stress.",
   "humidity_actions.json": "Recommended actions for low or high humidity.",

--- a/data/heat_memory_profiles.json
+++ b/data/heat_memory_profiles.json
@@ -1,0 +1,17 @@
+{
+  "default": {
+    "lag_per_day": 1,
+    "ec_reduction_pct": 10,
+    "foliar_ca_days": 3
+  },
+  "citrus": {
+    "lag_per_day": 1,
+    "ec_reduction_pct": 15,
+    "foliar_ca_days": 5
+  },
+  "lettuce": {
+    "lag_per_day": 2,
+    "ec_reduction_pct": 5,
+    "foliar_ca_days": 0
+  }
+}

--- a/plant_engine/heat_memory.py
+++ b/plant_engine/heat_memory.py
@@ -1,0 +1,69 @@
+"""Species-linked heat memory utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "heat_memory_profiles.json"
+
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "apply_heat_event",
+    "HeatMemoryIndex",
+]
+
+
+@dataclass(slots=True)
+class HeatMemoryIndex:
+    """Result describing heat memory adjustments for a plant."""
+
+    plant_id: str
+    lag_days: int
+    ec_reduction_pct: float
+    foliar_ca_days: int
+
+    def as_dict(self) -> Dict[str, float | str]:
+        """Return index data as a plain dictionary."""
+        return {
+            "plant_id": self.plant_id,
+            "lag_days": self.lag_days,
+            "ec_reduction_pct": self.ec_reduction_pct,
+            "foliar_ca_days": self.foliar_ca_days,
+        }
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with heat memory profiles."""
+
+    return list_dataset_entries(_DATA)
+
+
+def _get_profile(plant_type: str) -> Dict[str, float]:
+    plant = _DATA.get(normalize_key(plant_type))
+    if plant is None:
+        plant = _DATA.get("default", {})
+    return plant if isinstance(plant, dict) else {}
+
+
+def apply_heat_event(
+    plant_id: str,
+    plant_type: str,
+    days_above_threshold: int,
+) -> HeatMemoryIndex:
+    """Return heat memory index adjustments for a plant heat event."""
+
+    profile = _get_profile(plant_type)
+    lag_per_day = float(profile.get("lag_per_day", 0))
+    ec_pct = float(profile.get("ec_reduction_pct", 0))
+    ca_days = int(profile.get("foliar_ca_days", 0))
+    lag_days = max(0, int(round(lag_per_day * days_above_threshold)))
+    return HeatMemoryIndex(
+        plant_id=plant_id,
+        lag_days=lag_days,
+        ec_reduction_pct=ec_pct,
+        foliar_ca_days=ca_days,
+    )

--- a/tests/test_heat_memory.py
+++ b/tests/test_heat_memory.py
@@ -1,0 +1,21 @@
+from plant_engine.heat_memory import list_supported_plants, apply_heat_event
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "citrus" in plants
+    assert "lettuce" in plants
+
+
+def test_apply_heat_event():
+    result = apply_heat_event("Citrus_001", "citrus", 3)
+    assert result.lag_days == 3
+    assert result.ec_reduction_pct == 15
+    assert result.foliar_ca_days == 5
+
+
+def test_apply_heat_event_default():
+    result = apply_heat_event("Unknown_001", "unknown", 2)
+    assert result.lag_days == 2
+    assert result.ec_reduction_pct == 10
+    assert result.foliar_ca_days == 3


### PR DESCRIPTION
## Summary
- add basic dataset for species heat memory profiles
- implement `plant_engine.heat_memory` module for computing heat recovery actions
- add unit tests for heat memory
- document new dataset in README and catalog
- expose results via `as_dict`

## Testing
- `pytest tests/test_heat_memory.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68865a415cb883309e314e5630ad9943