### PR TITLE
Add heat memory index module

### DIFF
--- a/data/heat_memory_guidelines.json
+++ b/data/heat_memory_guidelines.json
@@ -1,0 +1,5 @@
+{
+  "default": {"lag_days": 3, "tolerance_delta_c": 0, "ec_adjustment_pct": 0, "foliar_ca_days": 0},
+  "citrus": {"lag_days": 3, "tolerance_delta_c": 2, "ec_adjustment_pct": -15, "foliar_ca_days": 5},
+  "lettuce": {"lag_days": 5, "tolerance_delta_c": -2, "ec_adjustment_pct": 0, "foliar_ca_days": 0}
+}

--- a/plant_engine/heat_memory.py
+++ b/plant_engine/heat_memory.py
@@ -1,0 +1,57 @@
+"""Helpers for modeling heat memory responses by crop."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "heat_memory_guidelines.json"
+
+@lru_cache(maxsize=None)
+def _data() -> Dict[str, Dict[str, float]]:
+    return load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_heat_memory_info",
+    "calculate_heat_memory_index",
+    "recommend_heat_recovery",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with heat memory data."""
+    return list_dataset_entries(_data())
+
+
+def get_heat_memory_info(plant_type: str) -> Dict[str, float] | None:
+    """Return heat memory parameters for ``plant_type`` if available."""
+    return _data().get(normalize_key(plant_type))
+
+
+def calculate_heat_memory_index(plant_type: str, exposure_days: int) -> float:
+    """Return tolerance shift in °C from heat exposure."""
+    info = get_heat_memory_info(plant_type)
+    if not info:
+        return 0.0
+    lag = float(info.get("lag_days", 0))
+    delta = float(info.get("tolerance_delta_c", 0))
+    if lag <= 0:
+        return 0.0
+    fraction = min(1.0, exposure_days / lag)
+    index = fraction * delta
+    return round(index, 2)
+
+
+def recommend_heat_recovery(plant_type: str) -> Dict[str, float]:
+    """Return nutrient adjustments to aid recovery after heat stress."""
+    info = get_heat_memory_info(plant_type) or {}
+    rec: Dict[str, float] = {}
+    ec = info.get("ec_adjustment_pct")
+    if ec:
+        rec["ec_adjustment_pct"] = float(ec)
+    ca = info.get("foliar_ca_days")
+    if ca:
+        rec["foliar_ca_days"] = int(ca)
+    return rec

--- a/tests/test_heat_memory.py
+++ b/tests/test_heat_memory.py
@@ -1,0 +1,30 @@
+from plant_engine.heat_memory import (
+    list_supported_plants,
+    get_heat_memory_info,
+    calculate_heat_memory_index,
+    recommend_heat_recovery,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "citrus" in plants
+    assert "lettuce" in plants
+
+
+def test_get_heat_memory_info():
+    info = get_heat_memory_info("citrus")
+    assert info["lag_days"] == 3
+
+
+def test_calculate_heat_memory_index():
+    assert calculate_heat_memory_index("citrus", 3) == 2.0
+    idx = calculate_heat_memory_index("lettuce", 3)
+    assert round(idx, 2) == -1.2
+
+
+def test_recommend_heat_recovery():
+    rec = recommend_heat_recovery("citrus")
+    assert rec["ec_adjustment_pct"] == -15
+    assert rec["foliar_ca_days"] == 5
+    assert recommend_heat_recovery("lettuce") == {}


### PR DESCRIPTION
## Summary
- add heat memory guideline dataset
- implement `plant_engine.heat_memory` for heat tolerance shift and recovery advice
- test heat memory calculations

## Testing
- `pytest -q tests/test_heat_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_688660e478488330a1548d359b32bc53