### PR TITLE
Add labor efficiency tracker utility

### DIFF
--- a/custom_components/horticulture_assistant/utils/labor_tracker.py
+++ b/custom_components/horticulture_assistant/utils/labor_tracker.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import List, Optional, Dict
+
+from .path_utils import data_path
+from .json_io import load_json, save_json
+
+__all__ = [
+    "LaborEntry",
+    "LaborLog",
+]
+
+
+@dataclass(slots=True)
+class LaborEntry:
+    """Single labor activity record."""
+
+    zone_id: str | None
+    plant_id: str | None
+    task: str
+    minutes: float
+    timestamp: str
+    notes: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+class LaborLog:
+    """Log and analyze labor activities."""
+
+    def __init__(self, data_file: str | None = None, hass=None) -> None:
+        if data_file is None:
+            data_file = data_path(hass, "labor_log.json")
+        self._data_file = data_file
+        self._entries: List[LaborEntry] = []
+        try:
+            raw = load_json(self._data_file)
+            if isinstance(raw, list):
+                for item in raw:
+                    try:
+                        self._entries.append(
+                            LaborEntry(
+                                zone_id=item.get("zone_id"),
+                                plant_id=item.get("plant_id"),
+                                task=item["task"],
+                                minutes=float(item["minutes"]),
+                                timestamp=item["timestamp"],
+                                notes=item.get("notes"),
+                            )
+                        )
+                    except Exception:
+                        continue
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
+    @property
+    def entries(self) -> List[LaborEntry]:
+        return list(self._entries)
+
+    def _save(self) -> None:
+        save_json(self._data_file, [e.to_dict() for e in self._entries])
+
+    def log_time(
+        self,
+        task: str,
+        minutes: float,
+        *,
+        zone_id: str | None = None,
+        plant_id: str | None = None,
+        timestamp: datetime | None = None,
+        notes: str | None = None,
+    ) -> None:
+        if timestamp is None:
+            timestamp = datetime.now()
+        entry = LaborEntry(
+            zone_id=zone_id,
+            plant_id=plant_id,
+            task=task,
+            minutes=minutes,
+            timestamp=timestamp.isoformat(),
+            notes=notes,
+        )
+        self._entries.append(entry)
+        self._save()
+
+    def total_minutes(self, *, zone_id: str | None = None, task: str | None = None) -> float:
+        total = 0.0
+        for e in self._entries:
+            if zone_id is not None and e.zone_id != zone_id:
+                continue
+            if task is not None and e.task != task:
+                continue
+            total += e.minutes
+        return total
+
+    def compute_roi(self, yield_by_zone: Dict[str, float]) -> Dict[str, float]:
+        roi: Dict[str, float] = {}
+        zones = {e.zone_id for e in self._entries if e.zone_id}
+        for zid in zones:
+            minutes = self.total_minutes(zone_id=zid)
+            hours = minutes / 60.0 if minutes else 0.0
+            yield_g = yield_by_zone.get(zid, 0.0)
+            roi[zid] = yield_g / hours if hours > 0 else 0.0
+        return roi
+
+    def high_effort_low_return(self, yield_by_zone: Dict[str, float], threshold: float) -> List[str]:
+        roi = self.compute_roi(yield_by_zone)
+        return [z for z, value in roi.items() if value < threshold]
+
+    def minutes_by_task(self, *, zone_id: str | None = None) -> Dict[str, float]:
+        """Aggregate labor minutes by task, optionally filtering by zone."""
+        totals: Dict[str, float] = {}
+        for e in self._entries:
+            if zone_id is not None and e.zone_id != zone_id:
+                continue
+            totals[e.task] = totals.get(e.task, 0.0) + e.minutes
+        return totals
+
+    def high_effort_tasks(self, threshold_minutes: float, *, zone_id: str | None = None) -> List[str]:
+        """Return tasks whose logged minutes exceed the threshold."""
+        totals = self.minutes_by_task(zone_id=zone_id)
+        return [task for task, minutes in totals.items() if minutes > threshold_minutes]

--- a/tests/test_labor_tracker.py
+++ b/tests/test_labor_tracker.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from custom_components.horticulture_assistant.utils.labor_tracker import (
+    LaborLog,
+)
+
+
+def test_log_and_summary(tmp_path):
+    file_path = tmp_path / "labor.json"
+    log = LaborLog(data_file=str(file_path))
+    log.log_time("mixing", 30.0, zone_id="1")
+    log.log_time("pruning", 15.0, zone_id="1")
+    log.log_time("cleaning", 60.0, zone_id="2")
+    assert log.total_minutes(zone_id="1") == 45.0
+    assert log.total_minutes(task="cleaning") == 60.0
+
+
+def test_roi_and_high_effort(tmp_path):
+    file_path = tmp_path / "labor.json"
+    log = LaborLog(data_file=str(file_path))
+    log.log_time("harvesting", 120.0, zone_id="A")
+    log.log_time("mixing", 60.0, zone_id="B")
+    yields = {"A": 600.0, "B": 200.0}
+    roi = log.compute_roi(yields)
+    assert round(roi["A"], 2) == 300.0  # 600 g over 2 hours
+    assert round(roi["B"], 2) == 200.0  # 200 g over 1 hour
+    low = log.high_effort_low_return(yields, threshold=250.0)
+    assert low == ["B"]
+
+
+def test_task_minutes_and_high_effort(tmp_path):
+    file_path = tmp_path / "labor.json"
+    log = LaborLog(data_file=str(file_path))
+    log.log_time("mixing", 30.0, zone_id="1")
+    log.log_time("mixing", 40.0, zone_id="2")
+    log.log_time("harvesting", 10.0, zone_id="2")
+    totals = log.minutes_by_task()
+    assert totals["mixing"] == 70.0
+    high = log.high_effort_tasks(50.0)
+    assert high == ["mixing"]


### PR DESCRIPTION
## Summary
- add `labor_tracker` utility for logging labor and computing labor ROI
- expand tracker with task-level summaries
- test labor tracker operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688660b4a9bc8330b51a4eaf475fae52