### PR TITLE
Implement fertilizer inventory usage forecasting

### DIFF
--- a/custom_components/horticulture_assistant/utils/inventory_usage_forecast.py
+++ b/custom_components/horticulture_assistant/utils/inventory_usage_forecast.py
@@ -1,0 +1,89 @@
+"""Track fertilizer usage and forecast inventory depletion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+from .product_inventory import ProductInventory
+
+
+@dataclass
+class UsageEvent:
+    """Record of a single fertilizer application."""
+
+    product_id: str
+    batch_id: str
+    amount: float
+    unit: str
+    zone: Optional[str] = None
+    date: datetime = field(default_factory=datetime.now)
+
+
+class UsageForecaster:
+    """Log fertilizer use and predict when inventory will be depleted."""
+
+    def __init__(self, inventory: ProductInventory) -> None:
+        self.inventory = inventory
+        self.usage_log: Dict[str, List[UsageEvent]] = {}
+
+    def apply_product(
+        self,
+        product_id: str,
+        amount: float,
+        unit: str,
+        zone: Optional[str] = None,
+        date: Optional[datetime] = None,
+    ) -> str:
+        """Deduct ``amount`` from inventory and log the usage.
+
+        Returns the batch ID that was consumed. Raises ``ValueError`` if
+        the inventory does not contain enough product.
+        """
+
+        batch_id = self.inventory.consume_product(product_id, amount)
+        if batch_id is None:
+            raise ValueError(f"Insufficient quantity of {product_id}")
+
+        event = UsageEvent(
+            product_id=product_id,
+            batch_id=batch_id,
+            amount=amount,
+            unit=unit,
+            zone=zone,
+            date=date or datetime.now(),
+        )
+        self.usage_log.setdefault(product_id, []).append(event)
+        return batch_id
+
+    def forecast_runout(self, product_id: str, lookback_days: int = 30) -> Optional[float]:
+        """Return estimated days until ``product_id`` is depleted.
+
+        Uses the average daily usage over the last ``lookback_days`` days. If no
+        usage is recorded in that period, ``None`` is returned.
+        """
+
+        logs = self.usage_log.get(product_id, [])
+        if not logs:
+            return None
+
+        cutoff = datetime.now() - timedelta(days=lookback_days)
+        recent = [e for e in logs if e.date >= cutoff]
+        if not recent:
+            return None
+
+        first_date = min(e.date for e in recent)
+        days_span = max((datetime.now() - first_date).days + 1, 1)
+        total_used = sum(e.amount for e in recent)
+        avg_daily = total_used / days_span
+        if avg_daily <= 0:
+            return None
+
+        remaining = self.inventory.get_total_quantity(product_id)
+        if remaining <= 0:
+            return 0.0
+        return round(remaining / avg_daily, 2)
+
+
+__all__ = ["UsageEvent", "UsageForecaster"]

--- a/tests/test_inventory_usage_forecast.py
+++ b/tests/test_inventory_usage_forecast.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+
+from custom_components.horticulture_assistant.utils.product_inventory import (
+    ProductInventory,
+    InventoryRecord,
+)
+from custom_components.horticulture_assistant.utils.inventory_usage_forecast import (
+    UsageForecaster,
+)
+
+
+def test_usage_logging_and_forecast():
+    inv = ProductInventory()
+    rec1 = InventoryRecord(
+        product_id="grow",
+        batch_id="b1",
+        quantity_remaining=100.0,
+        unit="g",
+        storage_location="shed",
+    )
+    rec2 = InventoryRecord(
+        product_id="grow",
+        batch_id="b2",
+        quantity_remaining=100.0,
+        unit="g",
+        storage_location="shed",
+    )
+    inv.add_record(rec1)
+    inv.add_record(rec2)
+
+    forecaster = UsageForecaster(inv)
+
+    forecaster.apply_product(
+        "grow",
+        30.0,
+        "g",
+        zone="zone1",
+        date=datetime.now() - timedelta(days=2),
+    )
+    forecaster.apply_product(
+        "grow",
+        30.0,
+        "g",
+        zone="zone1",
+        date=datetime.now() - timedelta(days=1),
+    )
+    forecaster.apply_product("grow", 20.0, "g", zone="zone1")
+
+    assert len(forecaster.usage_log["grow"]) == 3
+    assert inv.get_total_quantity("grow") == 120.0
+
+    days = forecaster.forecast_runout("grow")
+    assert days and 4.0 < days < 5.0
+
+
+def test_forecast_no_usage():
+    inv = ProductInventory()
+    inv.add_record(
+        InventoryRecord(
+            product_id="f",
+            batch_id="b",
+            quantity_remaining=10.0,
+            unit="g",
+            storage_location="shed",
+        )
+    )
+    forecaster = UsageForecaster(inv)
+    assert forecaster.forecast_runout("f") is None


### PR DESCRIPTION
## Summary
- track usage events and forecast depletion
- tests for the new UsageForecaster utility

## Testing
- `pytest tests/test_inventory_usage_forecast.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688663259684833097aa7b961a56a41d