### PR TITLE
Add profit estimation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Plant profiles are stored in the `plants/` directory and can be created through 
 - Automatic pesticide rotation planning
 - Summaries of reentry and harvest restrictions for applied pesticides
 - Automated fertigation planning with cost estimates
+- Yield-based revenue and profit projections
+- Expected profit forecasts based on estimated production costs
 
 ---
 

--- a/data/crop_market_prices.json
+++ b/data/crop_market_prices.json
@@ -1,0 +1,5 @@
+{
+  "lettuce": 3.0,
+  "tomato": 2.5,
+  "strawberry": 5.0
+}

--- a/data/crop_production_costs.json
+++ b/data/crop_production_costs.json
@@ -1,0 +1,5 @@
+{
+  "lettuce": 1.2,
+  "tomato": 1.6,
+  "strawberry": 3.0
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -104,6 +104,8 @@
   "yield_estimates.json": "Expected total yields for common cultivars.",
   "co2_prices.json": "Cost per kg of CO₂ for enrichment.",
   "co2_method_efficiency.json": "Relative CO₂ delivery efficiency by enrichment method.",
+  "crop_market_prices.json": "Market price per kilogram for harvested crops.",
+  "crop_production_costs.json": "Typical production cost per kilogram for common crops.",
   "climate_zone_guidelines.json": "Temperature and humidity targets for common climate zones.",
   "fertilizers/fertilizer_prices.json": "Per-unit costs for fertilizer products.",
   "fertilizers/fertilizer_products.json": "Guaranteed analysis for fertilizers.",

--- a/plant_engine/profit_estimator.py
+++ b/plant_engine/profit_estimator.py
@@ -1,0 +1,99 @@
+"""Utilities for estimating crop revenue and profit."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .utils import load_dataset, normalize_key
+from . import yield_manager
+
+PRICE_FILE = "crop_market_prices.json"
+COST_FILE = "crop_production_costs.json"
+
+# Cached datasets at import time
+_PRICES: Dict[str, float] = load_dataset(PRICE_FILE)
+_COSTS: Dict[str, float] = load_dataset(COST_FILE)
+
+__all__ = [
+    "list_supported_crops",
+    "get_crop_price",
+    "estimate_revenue",
+    "estimate_profit",
+    "list_costed_crops",
+    "get_crop_cost",
+    "estimate_expected_revenue",
+    "estimate_expected_profit",
+]
+
+
+def list_supported_crops() -> list[str]:
+    """Return plant types with market price data."""
+    return sorted(_PRICES.keys())
+
+
+def get_crop_price(plant_type: str) -> float | None:
+    """Return price per kilogram for ``plant_type`` if known."""
+    key = normalize_key(plant_type)
+    value = _PRICES.get(key)
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def estimate_revenue(plant_id: str, plant_type: str) -> float:
+    """Return revenue for harvested yield of ``plant_id``."""
+    price = get_crop_price(plant_type)
+    if price is None:
+        return 0.0
+    total_kg = yield_manager.get_total_yield(plant_id) / 1000.0
+    return round(total_kg * price, 2)
+
+
+def estimate_profit(
+    plant_id: str,
+    plant_type: str,
+    costs: Mapping[str, float] | None = None,
+) -> float:
+    """Return estimated profit after subtracting ``costs`` from revenue."""
+    revenue = estimate_revenue(plant_id, plant_type)
+    total_cost = sum(float(v) for v in (costs or {}).values())
+    return round(revenue - total_cost, 2)
+
+
+def list_costed_crops() -> list[str]:
+    """Return plant types with production cost data."""
+    return sorted(_COSTS.keys())
+
+
+def get_crop_cost(plant_type: str) -> float | None:
+    """Return production cost per kilogram for ``plant_type`` if known."""
+    key = normalize_key(plant_type)
+    value = _COSTS.get(key)
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def estimate_expected_revenue(plant_type: str) -> float | None:
+    """Return expected revenue based on yield estimates."""
+    yield_g = yield_manager.get_yield_estimate(plant_type)
+    price = get_crop_price(plant_type)
+    if yield_g is None or price is None:
+        return None
+    return round(yield_g / 1000.0 * price, 2)
+
+
+def estimate_expected_profit(
+    plant_type: str,
+    extra_costs: Mapping[str, float] | None = None,
+) -> float | None:
+    """Return expected profit using yield and production cost estimates."""
+    revenue = estimate_expected_revenue(plant_type)
+    if revenue is None:
+        return None
+    cost_per_kg = get_crop_cost(plant_type) or 0.0
+    yield_g = yield_manager.get_yield_estimate(plant_type) or 0.0
+    base_cost = cost_per_kg * (yield_g / 1000.0)
+    total_cost = base_cost + sum(float(v) for v in (extra_costs or {}).values())
+    return round(revenue - total_cost, 2)

--- a/tests/test_profit_estimator.py
+++ b/tests/test_profit_estimator.py
@@ -1,0 +1,43 @@
+from plant_engine import yield_manager
+from plant_engine import profit_estimator
+from plant_engine import utils
+import importlib
+
+
+def test_get_crop_price():
+    assert profit_estimator.get_crop_price("lettuce") == 3.0
+    assert profit_estimator.get_crop_price("unknown") is None
+
+
+def test_estimate_profit(tmp_path):
+    plant_id = "profitplant"
+    yield_manager.YIELD_DIR = str(tmp_path)
+    yield_manager.record_harvest(plant_id, grams=1000)
+    profit = profit_estimator.estimate_profit(plant_id, "lettuce", {"water": 0.5, "fertilizer": 0.3})
+    # revenue = 1kg * $3 = 3.0, cost=0.8, profit=2.2
+    assert profit == 2.2
+
+
+def test_estimate_expected_profit(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "crop_market_prices.json").write_text('{"lettuce": 3}')
+    (data_dir / "crop_production_costs.json").write_text('{"lettuce": 1}')
+    (data_dir / "yield_estimates.json").write_text('{"lettuce": 1000}')
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    from plant_engine import utils
+    utils.clear_dataset_cache()
+    import importlib
+    importlib.reload(yield_manager)
+    importlib.reload(profit_estimator)
+
+    profit = profit_estimator.estimate_expected_profit("lettuce")
+    # revenue = 1kg * $3 = 3, cost = 1kg * $1 = 1, profit = 2
+    assert profit == 2.0
+
+    # clear modified dataset state
+    monkeypatch.delenv("HORTICULTURE_DATA_DIR", raising=False)
+    utils.clear_dataset_cache()
+    importlib.reload(yield_manager)
+    importlib.reload(profit_estimator)


### PR DESCRIPTION
## Summary
- add crop market price dataset
- document profit projections in README
- hook dataset into catalog
- implement `profit_estimator` for revenue and profit utilities
- test profit estimator functionality


------
https://chatgpt.com/codex/tasks/task_e_6886638e0b808330a76751356171d39e