### PR TITLE
Add pH + synergy deficiency helper

### DIFF
--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -247,3 +247,24 @@ def test_calculate_all_deficiencies_with_synergy():
     deficits = calculate_all_deficiencies_with_synergy(current, "tomato", "fruiting")
     assert deficits["P"] == 6.0
     assert round(deficits["B"], 2) == 0.03
+
+
+def test_calculate_all_deficiencies_with_ph_and_synergy():
+    from plant_engine.nutrient_manager import (
+        calculate_all_deficiencies_with_ph_and_synergy,
+    )
+
+    current = {
+        "N": 80,
+        "P": 60,
+        "K": 120,
+        "Fe": 4.0,
+        "B": 0.5,
+    }
+
+    deficits = calculate_all_deficiencies_with_ph_and_synergy(
+        current, "tomato", "fruiting", 7.5
+    )
+
+    assert deficits["P"] > 0
+    assert deficits["Fe"] > 0


### PR DESCRIPTION
## Summary
- support combined pH and synergy nutrient deficiency calculation
- test the new helper to ensure expected behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688664b2e69c8330a1ac315b70646eb2