### PR TITLE
Add synergy deficiency index

### DIFF
--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -247,3 +247,15 @@ def test_calculate_all_deficiencies_with_synergy():
     deficits = calculate_all_deficiencies_with_synergy(current, "tomato", "fruiting")
     assert deficits["P"] == 6.0
     assert round(deficits["B"], 2) == 0.03
+
+
+def test_calculate_synergy_deficiency_index():
+    from plant_engine.nutrient_manager import (
+        get_synergy_adjusted_levels,
+        calculate_synergy_deficiency_index,
+    )
+
+    targets = get_synergy_adjusted_levels("tomato", "fruiting")
+    zero = {n: 0 for n in targets}
+    assert calculate_synergy_deficiency_index(zero, "tomato", "fruiting") >= 99
+    assert calculate_synergy_deficiency_index(targets, "tomato", "fruiting") == 0.0


### PR DESCRIPTION
## Summary
- add `_deficiency_index_for_targets` helper for nutrient ratios
- compute standard and synergy deficiency indexes using helper
- expose new `calculate_synergy_deficiency_index`
- test synergy deficiency scoring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688664b783348330b59607d1fe296e69