### PR TITLE
Add environment quality labels

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -10,6 +10,7 @@
   "solution_guidelines.json": "Optimal nutrient solution EC, pH, temperature and dissolved oxygen ranges.",
   "environment_score_weights.json": "Weights for environment quality metrics.",
   "environment_quality_thresholds.json": "Score boundaries for good, fair and poor classifications.",
+  "environment_quality_labels.json": "Ordered mapping of quality labels to minimum scores.",
   "environment_aliases.json": "Canonical environment metric names mapped to accepted aliases.",
   "default_environment.json": "Fallback environment readings used when sensor data is missing.",
   "pest_guidelines.json": "Common pest control recommendations per crop.",

--- a/data/environment_quality_labels.json
+++ b/data/environment_quality_labels.json
@@ -1,0 +1,6 @@
+{
+  "excellent": 90,
+  "good": 75,
+  "fair": 50,
+  "poor": 0
+}

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -29,6 +29,7 @@ WIND_ACTION_FILE = "wind_actions.json"
 STRATEGY_FILE = "environment_strategies.json"
 SCORE_WEIGHT_FILE = "environment_score_weights.json"
 QUALITY_THRESHOLDS_FILE = "environment_quality_thresholds.json"
+QUALITY_LABELS_FILE = "environment_quality_labels.json"
 CO2_PRICE_FILE = "co2_prices.json"
 CO2_EFFICIENCY_FILE = "co2_method_efficiency.json"
 CLIMATE_DATA_FILE = "climate_zone_guidelines.json"
@@ -346,6 +347,7 @@ __all__ = [
     "humidity_for_target_vpd",
     "get_score_weight",
     "get_environment_quality_thresholds",
+    "get_environment_quality_labels",
     "recommend_light_intensity",
     "recommend_photoperiod",
     "evaluate_heat_stress",
@@ -411,6 +413,7 @@ _TEMPERATURE_ACTIONS: Dict[str, str] = load_dataset(TEMPERATURE_ACTION_FILE)
 _ENV_STRATEGIES: Dict[str, Dict[str, str]] = load_dataset(STRATEGY_FILE)
 _SCORE_WEIGHTS: Dict[str, float] = load_dataset(SCORE_WEIGHT_FILE)
 _QUALITY_THRESHOLDS: Dict[str, float] = load_dataset(QUALITY_THRESHOLDS_FILE)
+_QUALITY_LABELS: Dict[str, float] = load_dataset(QUALITY_LABELS_FILE)
 _CO2_PRICES: Dict[str, float] = load_dataset(CO2_PRICE_FILE)
 _CO2_EFFICIENCY: Dict[str, float] = load_dataset(CO2_EFFICIENCY_FILE)
 _CLIMATE_DATA: Dict[str, Any] = load_dataset(CLIMATE_DATA_FILE)
@@ -435,6 +438,22 @@ def get_environment_quality_thresholds() -> Dict[str, float]:
         "good": float(_QUALITY_THRESHOLDS.get("good", 75)),
         "fair": float(_QUALITY_THRESHOLDS.get("fair", 50)),
     }
+
+
+def get_environment_quality_labels() -> list[tuple[str, float]]:
+    """Return ordered ``[(label, min_score), ...]`` for quality classification."""
+
+    data = _QUALITY_LABELS or _QUALITY_THRESHOLDS
+    labels = []
+    for label, val in data.items():
+        try:
+            labels.append((label, float(val)))
+        except (TypeError, ValueError):
+            continue
+    labels.sort(key=lambda x: x[1], reverse=True)
+    if not labels:
+        labels = [("good", 75), ("fair", 50), ("poor", 0)]
+    return labels
 
 
 def _lookup_stage_data(
@@ -941,13 +960,17 @@ def classify_environment_quality(
     quality bands for specific deployments.
     """
 
-    thresh = thresholds or get_environment_quality_thresholds()
+    if thresholds:
+        labels = [(k, float(v)) for k, v in thresholds.items() if isinstance(v, (int, float))]
+        labels.sort(key=lambda x: x[1], reverse=True)
+    else:
+        labels = get_environment_quality_labels()
+
     score = score_environment(current, plant_type, stage)
-    if score >= thresh.get("good", 75):
-        return "good"
-    if score >= thresh.get("fair", 50):
-        return "fair"
-    return "poor"
+    for label, limit in labels:
+        if score >= limit:
+            return label
+    return labels[-1][0] if labels else "poor"
 
 
 def classify_environment_quality_series(
@@ -958,13 +981,17 @@ def classify_environment_quality_series(
 ) -> str:
     """Return quality classification for averaged environment ``series``."""
 
+    if thresholds:
+        labels = [(k, float(v)) for k, v in thresholds.items() if isinstance(v, (int, float))]
+        labels.sort(key=lambda x: x[1], reverse=True)
+    else:
+        labels = get_environment_quality_labels()
+
     score = score_environment_series(series, plant_type, stage)
-    thresh = thresholds or get_environment_quality_thresholds()
-    if score >= thresh.get("good", 75):
-        return "good"
-    if score >= thresh.get("fair", 50):
-        return "fair"
-    return "poor"
+    for label, limit in labels:
+        if score >= limit:
+            return label
+    return labels[-1][0] if labels else "poor"
 
 
 def score_overall_environment(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -534,7 +534,7 @@ def test_classify_environment_quality():
     good = {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450}
     poor = {"temp_c": 10, "humidity_pct": 30, "light_ppfd": 50, "co2_ppm": 1500}
 
-    assert classify_environment_quality(good, "citrus", "seedling") == "good"
+    assert classify_environment_quality(good, "citrus", "seedling") == "excellent"
     assert classify_environment_quality(poor, "citrus", "seedling") == "poor"
 
 
@@ -553,7 +553,7 @@ def test_classify_environment_quality_series():
         {"temp_c": 24, "humidity_pct": 72, "light_ppfd": 260, "co2_ppm": 460},
     ]
     result = classify_environment_quality_series(series, "citrus", "seedling")
-    assert result == "good"
+    assert result == "excellent"
 
 
 def test_classify_environment_quality_series_custom():

--- a/tests/test_environment_score_sensor.py
+++ b/tests/test_environment_score_sensor.py
@@ -112,4 +112,4 @@ def test_environment_quality_sensor(tmp_path: Path):
         "sensor.pid_raw_co2": "800",
     }
     asyncio.run(sensor_entity.async_update())
-    assert sensor_entity.native_value in {"good", "fair", "poor"}
+    assert sensor_entity.native_value in {"excellent", "good", "fair", "poor"}


### PR DESCRIPTION
## Summary
- add dataset `environment_quality_labels.json`
- load labels in `environment_manager`
- classify environment quality using ordered labels
- expect "excellent" rating in environment tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664c2863483309ceace83ea446caf