### PR TITLE
Add fertigation volume guidelines

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -121,6 +121,7 @@
   "fertigation_intervals.json": "Recommended days between fertigation events per stage.",
   "fertigation_recipes.json": "Recommended grams per liter of fertilizer products for each stage.",
   "fertigation_loss_factors.json": "Default nutrient loss percentages during fertigation.",
+  "fertigation_volume.json": "Recommended nutrient solution volume in mL per plant per event.",
   "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
   "companion_plants.json": "Companion planting recommendations.",
   "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",

--- a/data/fertigation_volume.json
+++ b/data/fertigation_volume.json
@@ -1,0 +1,5 @@
+{
+  "tomato": {"vegetative": 250, "fruiting": 300, "optimal": 275},
+  "lettuce": {"vegetative": 150, "harvest": 120, "optimal": 150},
+  "strawberry": {"vegetative": 200, "fruiting": 250, "optimal": 225}
+}

--- a/tests/test_fertigation_volume.py
+++ b/tests/test_fertigation_volume.py
@@ -1,0 +1,20 @@
+import pytest
+from plant_engine.fertigation import (
+    get_fertigation_volume,
+    estimate_fertigation_solution_volume,
+)
+
+
+def test_get_fertigation_volume():
+    assert get_fertigation_volume("tomato", "vegetative") == 250
+    assert get_fertigation_volume("lettuce", "harvest") == 120
+    assert get_fertigation_volume("unknown", "stage") is None
+
+
+def test_estimate_fertigation_solution_volume():
+    vol = estimate_fertigation_solution_volume(4, "tomato", "fruiting")
+    assert vol == 1.2
+    assert estimate_fertigation_solution_volume(1, "unknown", "stage") is None
+    with pytest.raises(ValueError):
+        estimate_fertigation_solution_volume(0, "tomato", "vegetative")
+


### PR DESCRIPTION
## Summary
- add fertigation volume dataset and update catalog
- support per-plant fertigation volumes in `fertigation`
- provide helpers to estimate batch solution volume
- test new fertigation volume helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664c6209483309912b8d5fa22722a