### PR TITLE
Enhance nutrient interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Important categories include:
 - **Pest and disease references** – thresholds, prevention tips and treatment options
 - **Fungicide recommendations** – suggested organic products for common diseases
 - **Pest scouting methods** – recommended techniques for monitoring common pests
+- **Nutrient antagonism** – reduction factors when one nutrient inhibits uptake of another
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -7,6 +7,7 @@
   "nutrient_tag_modifiers.json": "Tag-based multipliers for nutrient targets.",
   "nutrient_efficiency_targets.json": "Typical nutrient use efficiency (g yield per mg applied) for each crop.",
   "nutrient_synergies.json": "Synergy factors for nutrient pairs to adjust recommendations.",
+  "nutrient_antagonisms.json": "Reduction factors when one nutrient inhibits another.",
   "solution_guidelines.json": "Optimal nutrient solution EC, pH, temperature and dissolved oxygen ranges.",
   "environment_score_weights.json": "Weights for environment quality metrics.",
   "environment_quality_thresholds.json": "Score boundaries for good, fair and poor classifications.",

--- a/data/nutrient_antagonisms.json
+++ b/data/nutrient_antagonisms.json
@@ -1,0 +1,4 @@
+{
+  "k_ca": {"factor": 0.9, "message": "High potassium reduces calcium uptake"},
+  "p_zn": {"factor": 0.85, "message": "Phosphorus can inhibit zinc availability"}
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -18,6 +18,11 @@ from .nutrient_synergy import (
     get_synergy_factor,
     apply_synergy_adjustments,
 )
+from .nutrient_antagonism import (
+    list_antagonism_pairs,
+    get_antagonism_factor,
+    apply_antagonism_adjustments,
+)
 
 __all__ = sorted(
     set(utils.__all__)
@@ -30,6 +35,9 @@ __all__ = sorted(
         "list_synergy_pairs",
         "get_synergy_factor",
         "apply_synergy_adjustments",
+        "list_antagonism_pairs",
+        "get_antagonism_factor",
+        "apply_antagonism_adjustments",
     }
 )
 

--- a/plant_engine/nutrient_antagonism.py
+++ b/plant_engine/nutrient_antagonism.py
@@ -1,0 +1,63 @@
+"""Nutrient antagonism adjustments for fertilizer recommendations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Tuple
+
+from .utils import load_dataset, list_dataset_entries
+
+DATA_FILE = "nutrient_antagonisms.json"
+
+@dataclass(frozen=True)
+class AntagonismInfo:
+    factor: float
+    message: str = ""
+
+_DATA: Dict[str, Dict[str, object]] = load_dataset(DATA_FILE)
+_ANTAGONISM_MAP: Dict[Tuple[str, str], AntagonismInfo] = {}
+for key, info in _DATA.items():
+    if not isinstance(info, Mapping):
+        continue
+    try:
+        n1, n2 = key.split("_")
+        factor = float(info.get("factor", 1.0))
+        msg = str(info.get("message", ""))
+        _ANTAGONISM_MAP[(n1, n2)] = AntagonismInfo(factor=factor, message=msg)
+    except Exception:
+        continue
+
+__all__ = [
+    "list_antagonism_pairs",
+    "get_antagonism_info",
+    "get_antagonism_factor",
+    "apply_antagonism_adjustments",
+]
+
+
+def list_antagonism_pairs() -> list[str]:
+    """Return all nutrient pairs with antagonism data."""
+    return list_dataset_entries(_DATA)
+
+
+def get_antagonism_info(pair: str) -> Dict[str, object]:
+    """Return raw antagonism entry for ``pair`` if defined."""
+    return _DATA.get(pair.lower(), {})
+
+
+def get_antagonism_factor(n1: str, n2: str) -> float | None:
+    """Return antagonism factor for nutrients ``n1`` and ``n2`` if available."""
+    info = _ANTAGONISM_MAP.get((n1.lower(), n2.lower())) or _ANTAGONISM_MAP.get(
+        (n2.lower(), n1.lower())
+    )
+    return info.factor if info else None
+
+
+def apply_antagonism_adjustments(levels: Mapping[str, float]) -> Dict[str, float]:
+    """Return ``levels`` adjusted using defined antagonism factors."""
+    result = {k: float(v) for k, v in levels.items()}
+    key_map = {k.lower(): k for k in levels}
+    for (n1, n2), info in _ANTAGONISM_MAP.items():
+        if n1.lower() in key_map and n2.lower() in key_map:
+            target = key_map[n2.lower()]
+            result[target] = round(result[target] * info.factor, 2)
+    return result

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -57,6 +57,8 @@ __all__ = [
     "calculate_cycle_deficiency_index",
     "get_synergy_adjusted_levels",
     "calculate_all_deficiencies_with_synergy",
+    "get_interaction_adjusted_levels",
+    "calculate_all_deficiencies_with_interactions",
 ]
 
 
@@ -560,6 +562,37 @@ def calculate_all_deficiencies_with_synergy(
     """Return overall deficiencies using synergy-adjusted guidelines."""
 
     targets = get_synergy_adjusted_levels(plant_type, stage)
+    deficits: Dict[str, float] = {}
+    for nutrient, target in targets.items():
+        try:
+            current = float(current_levels.get(nutrient, 0.0))
+        except (TypeError, ValueError):
+            current = 0.0
+        diff = round(target - current, 2)
+        if diff > 0:
+            deficits[nutrient] = diff
+    return deficits
+
+
+def get_interaction_adjusted_levels(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return nutrient targets adjusted for synergies and antagonisms."""
+
+    levels = get_all_recommended_levels(plant_type, stage)
+    if not levels:
+        return {}
+    from .nutrient_synergy import apply_synergy_adjustments
+    from .nutrient_antagonism import apply_antagonism_adjustments
+
+    levels = apply_synergy_adjustments(levels)
+    return apply_antagonism_adjustments(levels)
+
+
+def calculate_all_deficiencies_with_interactions(
+    current_levels: Mapping[str, float], plant_type: str, stage: str
+) -> Dict[str, float]:
+    """Return deficiencies using synergy and antagonism adjusted guidelines."""
+
+    targets = get_interaction_adjusted_levels(plant_type, stage)
     deficits: Dict[str, float] = {}
     for nutrient, target in targets.items():
         try:

--- a/tests/test_nutrient_antagonism.py
+++ b/tests/test_nutrient_antagonism.py
@@ -1,0 +1,22 @@
+from plant_engine.nutrient_antagonism import (
+    list_antagonism_pairs,
+    get_antagonism_factor,
+    apply_antagonism_adjustments,
+)
+
+
+def test_list_antagonism_pairs():
+    pairs = list_antagonism_pairs()
+    assert "k_ca" in pairs
+    assert "p_zn" in pairs
+
+
+def test_get_antagonism_factor_case_insensitive():
+    assert get_antagonism_factor("K", "CA") == 0.9
+
+
+def test_apply_antagonism_adjustments():
+    levels = {"k": 200, "ca": 100, "p": 50, "zn": 10}
+    adjusted = apply_antagonism_adjustments(levels)
+    assert adjusted["ca"] == 90.0
+    assert adjusted["zn"] == 8.5

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -247,3 +247,33 @@ def test_calculate_all_deficiencies_with_synergy():
     deficits = calculate_all_deficiencies_with_synergy(current, "tomato", "fruiting")
     assert deficits["P"] == 6.0
     assert round(deficits["B"], 2) == 0.03
+
+
+def test_get_interaction_adjusted_levels():
+    from plant_engine.nutrient_manager import get_interaction_adjusted_levels
+
+    levels = get_interaction_adjusted_levels("tomato", "fruiting")
+    assert levels["P"] == 66.0
+    assert levels["Ca"] == 54.0
+    assert round(levels["Zn"], 2) == 0.51
+
+
+def test_calculate_all_deficiencies_with_interactions():
+    from plant_engine.nutrient_manager import calculate_all_deficiencies_with_interactions
+
+    current = {
+        "N": 80,
+        "P": 60,
+        "K": 120,
+        "Ca": 60,
+        "Mg": 30,
+        "Fe": 4.0,
+        "Mn": 1.2,
+        "Zn": 0.4,
+        "B": 0.5,
+        "Cu": 0.1,
+        "Mo": 0.05,
+    }
+    deficits = calculate_all_deficiencies_with_interactions(current, "tomato", "fruiting")
+    assert deficits["P"] == 6.0
+    assert round(deficits["Zn"], 2) == 0.11


### PR DESCRIPTION
## Summary
- document nutrient antagonism dataset
- list nutrient antagonism data in the catalog
- add new nutrient_antagonism helper module
- adjust nutrient manager to handle synergy and antagonism
- expose antagonism helpers at package level
- test antagonism adjustments and manager helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664c9bbb4833085a5289e49a07f4d