### PR TITLE
Enhance recommendation engine with environment suggestions

### DIFF
--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -45,6 +45,8 @@ def test_recommendation_engine_environment_notes():
     eng = _setup_engine(auto=False)
     rec = eng.recommend("p1")
     assert any("temperature" in n for n in rec.notes)
+    assert rec.environment is not None
+    assert "temperature" in rec.environment.adjustments
 
 
 def test_recommendation_engine_recommend_all_and_reset():


### PR DESCRIPTION
## Summary
- add environment recommendations to `RecommendationEngine`
- expose `EnvironmentRecommendation` in recommendation bundle
- update tests for new environment field

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688664cf61d483309b5829cb12c6baf6