### PR TITLE
Enhance dataset utilities

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from importlib import import_module
 
-from . import utils, environment_tips, media_manager, ingredients
+from . import utils, environment_tips, media_manager, ingredients, reference_data
+from .reference_data import load_reference_data
 from .utils import *  # noqa: F401,F403
 from .environment_tips import *  # noqa: F401,F403
 from .media_manager import *  # noqa: F401,F403
@@ -24,6 +25,7 @@ __all__ = sorted(
     | set(environment_tips.__all__)
     | set(media_manager.__all__)
     | set(ingredients.__all__)
+    | {"load_reference_data"}
     | {
         "NutrientManagementReport",
         "generate_nutrient_management_report",

--- a/plant_engine/reference_data.py
+++ b/plant_engine/reference_data.py
@@ -1,0 +1,32 @@
+"""Convenient access to common horticultural reference datasets."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict
+
+from .utils import load_dataset
+
+REFERENCE_FILES = {
+    "nutrient_guidelines": "nutrient_guidelines.json",
+    "environment_guidelines": "environment_guidelines.json",
+    "pest_guidelines": "pest_guidelines.json",
+    "growth_stages": "growth_stages.json",
+}
+
+__all__ = ["load_reference_data", "REFERENCE_FILES"]
+
+
+@lru_cache(maxsize=None)
+def load_reference_data() -> Dict[str, Dict[str, Any]]:
+    """Return consolidated horticultural reference data.
+
+    The resulting mapping caches dataset contents so subsequent calls avoid
+    additional disk reads.
+    """
+
+    data: Dict[str, Dict[str, Any]] = {}
+    for key, filename in REFERENCE_FILES.items():
+        content = load_dataset(filename)
+        data[key] = content if isinstance(content, dict) else {}
+    return data

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "save_json",
     "load_data",
     "load_dataset",
+    "load_datasets",
     "lazy_dataset",
     "clear_dataset_cache",
     "dataset_paths",
@@ -258,6 +259,20 @@ def lazy_dataset(filename: str):
         return load_dataset(filename)
 
     return _loader
+
+
+@lru_cache(maxsize=None)
+def load_datasets(*filenames: str) -> Dict[str, Dict[str, Any]]:
+    """Return multiple datasets keyed by filename.
+
+    Each file is loaded via :func:`load_dataset` and the results are cached to
+    minimize disk access when called repeatedly.
+    """
+
+    data: Dict[str, Dict[str, Any]] = {}
+    for name in filenames:
+        data[name] = load_dataset(name)
+    return data
 
 
 def clear_dataset_cache() -> None:

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,0 +1,8 @@
+import plant_engine.reference_data as ref
+
+
+def test_load_reference_data_keys():
+    data = ref.load_reference_data()
+    for key in ref.REFERENCE_FILES:
+        assert key in data
+        assert isinstance(data[key], dict)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,3 +88,17 @@ def test_load_stage_dataset_value():
         "soil_moisture_guidelines.json", "citrus", "missing"
     ) == [30, 50]
 
+
+def test_load_datasets(monkeypatch, tmp_path):
+    base = tmp_path / "data"
+    base.mkdir()
+    (base / "one.json").write_text('{"a": 1}')
+    (base / "two.json").write_text('{"b": 2}')
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base))
+    clear_dataset_cache()
+    import importlib
+    import plant_engine.utils as utils
+    importlib.reload(utils)
+    data = utils.load_datasets("one.json", "two.json")
+    assert data == {"one.json": {"a": 1}, "two.json": {"b": 2}}
+


### PR DESCRIPTION
## Summary
- add helper `load_datasets` for loading multiple datasets at once
- centralize horticulture reference data in new `reference_data` module
- export `load_reference_data` from `plant_engine`
- test new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664d182008330a86dc8419c414f15