### PR TITLE
Enhance key normalization utilities

### DIFF
--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -25,7 +25,11 @@ clear_dataset_cache()
 _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 _RATIO_DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(RATIO_DATA_FILE)
 _WEIGHTS: Dict[str, float] = load_dataset(WEIGHT_DATA_FILE)
-_TAG_MODIFIERS: Dict[str, Dict[str, float]] = load_dataset(TAG_MODIFIER_FILE)
+_RAW_TAG_MODIFIERS: Dict[str, Dict[str, float]] = load_dataset(TAG_MODIFIER_FILE)
+# Normalize modifier keys for consistent lookups regardless of hyphen/space use
+_TAG_MODIFIERS: Dict[str, Dict[str, float]] = {
+    normalize_key(k): v for k, v in _RAW_TAG_MODIFIERS.items()
+} if isinstance(_RAW_TAG_MODIFIERS, dict) else {}
 
 __all__ = [
     "list_supported_plants",

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -273,8 +273,21 @@ def clear_dataset_cache() -> None:
 
 
 def normalize_key(key: str) -> str:
-    """Return ``key`` normalized for case-insensitive dataset lookups."""
-    return str(key).lower().replace(" ", "_")
+    """Return ``key`` normalized for case-insensitive dataset lookups.
+
+    The function uses :meth:`str.casefold` for robust case-insensitive
+    matching and normalizes whitespace, hyphens and underscores to a single
+    underscore character. Multiple adjacent separators are collapsed to avoid
+    accidental duplication.
+    """
+
+    # ``casefold`` handles non ASCII characters better than ``lower``
+    value = str(key).casefold()
+    # Replace common separators with spaces then collapse to single underscores
+    for sep in ("_", "-"):
+        value = value.replace(sep, " ")
+    parts = [p for p in value.strip().split() if p]
+    return "_".join(parts)
 
 
 def list_dataset_entries(dataset: Mapping[str, Any]) -> list[str]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,11 @@ def test_normalize_key_spaces_replaced():
     assert normalize_key("My Plant") == "my_plant"
 
 
+def test_normalize_key_hyphen_and_extra_whitespace():
+    """Hyphens and repeated separators collapse to single underscores."""
+    assert normalize_key("My-Plant  Name") == "my_plant_name"
+
+
 def test_normalize_key_non_string():
     assert normalize_key(123) == "123"
 


### PR DESCRIPTION
## Summary
- improve `normalize_key` to handle hyphens and repeated separators
- normalize nutrient tag modifier keys when datasets load
- test hyphen/whitespace handling

## Testing
- `pytest tests/test_nutrient_manager.py::test_apply_tag_modifiers -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664be83108330b342569db2926dde