### PR TITLE
Add area water cost helper

### DIFF
--- a/plant_engine/water_usage.py
+++ b/plant_engine/water_usage.py
@@ -16,6 +16,7 @@ __all__ = [
     "list_supported_plants",
     "get_daily_use",
     "estimate_area_use",
+    "estimate_area_water_cost",
     "estimate_stage_total_use",
     "estimate_cycle_total_use",
     "estimate_stage_water_cost",
@@ -79,6 +80,22 @@ def estimate_cycle_total_use(plant_type: str) -> float:
         if daily > 0 and duration:
             total += daily * duration
     return round(total, 1)
+
+
+def estimate_area_water_cost(
+    plant_type: str,
+    stage: str,
+    area_m2: float,
+    region: str | None = None,
+) -> float:
+    """Return daily watering cost for ``area_m2`` of crop."""
+
+    volume_ml = estimate_area_use(plant_type, stage, area_m2)
+    if volume_ml <= 0:
+        return 0.0
+    from .water_costs import estimate_water_cost
+
+    return estimate_water_cost(volume_ml / 1000.0, region)
 
 
 def estimate_stage_water_cost(

--- a/tests/test_water_cost_integration.py
+++ b/tests/test_water_cost_integration.py
@@ -6,6 +6,12 @@ def test_estimate_stage_water_cost():
     assert round(cost, 4) == round(0.002 * 6300 / 1000, 4)
 
 
+def test_estimate_area_water_cost():
+    cost = water_usage.estimate_area_water_cost("lettuce", "vegetative", 1.0)
+    expected_ml = water_usage.estimate_area_use("lettuce", "vegetative", 1.0)
+    assert round(cost, 4) == round(0.002 * expected_ml / 1000, 4)
+
+
 def test_estimate_cycle_water_cost():
     cost = water_usage.estimate_cycle_water_cost("lettuce", "california")
     expected_ml = water_usage.estimate_cycle_total_use("lettuce")


### PR DESCRIPTION
## Summary
- add estimate_area_water_cost helper to water_usage module
- test new helper with water cost integration tests

## Testing
- `pytest -q tests/test_water_usage.py tests/test_water_usage_totals.py tests/test_water_cost_integration.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688664bce2748330b05b4635a1162193