### PR TITLE
Add dataset category organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Helper scripts live in the `scripts/` directory.
   current readings.
 - `monitor_schedule.py` outputs an integrated pest and disease monitoring
   schedule for a plant stage.
+- `dataset_info.py` lists available datasets and categories.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
 - `profile_manager.py` manages sensors, preferences, templates and history files. `attach-sensor` appends new sensors, while `detach-sensor` removes them. Other subcommands include `list-sensors`, `show-prefs`, `list-logs`, `set-pref`, `load-default`, `show-history`, `show-global`, and `list-globals`. `--plants-dir` and `--global-dir` operate on alternate directories.
 

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -30,6 +30,7 @@ __all__ = [
     "list_dataset_info",
     "search_datasets",
     "list_datasets_by_category",
+    "list_dataset_info_by_category",
     "get_dataset_path",
     "load_dataset_file",
 ]
@@ -40,9 +41,13 @@ class DatasetCatalog:
     """Helper object for discovering bundled datasets."""
 
     base_dir: Path = field(default_factory=get_data_dir)
-    extra_dirs: tuple[Path, ...] = field(default_factory=lambda: tuple(get_extra_dirs()))
+    extra_dirs: tuple[Path, ...] = field(
+        default_factory=lambda: tuple(get_extra_dirs())
+    )
     overlay_dir: Path | None = field(default_factory=get_overlay_dir)
-    catalog_file: Path = field(default_factory=lambda: get_data_dir() / "dataset_catalog.json")
+    catalog_file: Path = field(
+        default_factory=lambda: get_data_dir() / "dataset_catalog.json"
+    )
 
     def _iter_paths(self) -> List[Path]:
         """Return search paths honoring init parameters."""
@@ -184,6 +189,17 @@ def list_datasets_by_category() -> Dict[str, List[str]]:
     return DEFAULT_CATALOG.list_by_category()
 
 
+def list_dataset_info_by_category() -> Dict[str, Dict[str, str]]:
+    """Return dataset descriptions grouped by top-level directory."""
+
+    by_cat = DEFAULT_CATALOG.list_by_category()
+    info = DEFAULT_CATALOG.list_info()
+    result: Dict[str, Dict[str, str]] = {}
+    for cat, names in by_cat.items():
+        result[cat] = {n: info.get(n, "") for n in names}
+    return result
+
+
 def get_dataset_path(name: str) -> Path | None:
     """Return absolute path to ``name`` if found in the catalog."""
 
@@ -204,4 +220,3 @@ def refresh_datasets() -> None:
     from .utils import clear_dataset_cache
 
     clear_dataset_cache()
-

--- a/scripts/dataset_info.py
+++ b/scripts/dataset_info.py
@@ -17,6 +17,8 @@ ROOT = ensure_repo_root_on_path()
 from plant_engine.datasets import (
     list_datasets,
     list_dataset_info,
+    list_datasets_by_category,
+    list_dataset_info_by_category,
     search_datasets,
 )
 
@@ -35,6 +37,13 @@ def main(argv: list[str] | None = None) -> None:
     search_parser = sub.add_parser("search", help="search dataset names")
     search_parser.add_argument("term", help="search term")
 
+    cat_parser = sub.add_parser("categories", help="list datasets grouped by directory")
+    cat_parser.add_argument(
+        "--describe",
+        action="store_true",
+        help="include dataset descriptions in output",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "list":
@@ -52,6 +61,22 @@ def main(argv: list[str] | None = None) -> None:
         for name, desc in results.items():
             line = f"{name}: {desc}" if desc else name
             print(line)
+        return
+
+    if args.command == "categories":
+        if args.describe:
+            groups = list_dataset_info_by_category()
+            for cat, mapping in groups.items():
+                print(f"[{cat}]")
+                for name, desc in mapping.items():
+                    line = f"  {name}: {desc}" if desc else f"  {name}"
+                    print(line)
+        else:
+            groups = list_datasets_by_category()
+            for cat, names in groups.items():
+                print(f"[{cat}]")
+                for name in names:
+                    print(f"  {name}")
         return
 
 

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -78,6 +78,16 @@ def test_list_datasets_by_category():
     assert "nutrient_guidelines.json" in cats["root"]
 
 
+def test_list_dataset_info_by_category():
+    info = datasets.list_dataset_info_by_category()
+    assert "fertilizers" in info
+    fert = info["fertilizers"]
+    assert "fertilizers/fertilizer_products.json" in fert
+    root_info = info["root"]
+    assert "nutrient_guidelines.json" in root_info
+    assert isinstance(root_info["nutrient_guidelines.json"], str)
+
+
 def test_catalog_custom_dir(tmp_path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()

--- a/tests/test_dataset_info_script.py
+++ b/tests/test_dataset_info_script.py
@@ -25,3 +25,15 @@ def test_search_cli():
     )
     out = result.stdout
     assert "nutrient_guidelines.json" in out
+
+
+def test_categories_cli():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "categories", "--describe"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = result.stdout
+    assert "[fertilizers]" in out
+    assert "fertilizers/fertilizer_products.json" in out


### PR DESCRIPTION
## Summary
- provide `list_dataset_info_by_category` for grouped dataset discovery
- extend `dataset_info.py` CLI with a `categories` subcommand
- document the new CLI tool in README
- test grouped dataset functions and CLI behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a3951c888330831cd81289f073f4