### PR TITLE
Improve dataset path caching

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -194,6 +194,7 @@ def dataset_paths() -> tuple[Path, ...]:
     return _PATH_CACHE
 
 
+@lru_cache(maxsize=None)
 def dataset_search_paths(include_overlay: bool = False) -> tuple[Path, ...]:
     """Return dataset search paths optionally including overlay first."""
 
@@ -282,6 +283,7 @@ def clear_dataset_cache() -> None:
     global _PATH_CACHE, _ENV_STATE, _OVERLAY_CACHE, _OVERLAY_ENV_VALUE
     load_dataset.cache_clear()
     dataset_file.cache_clear()
+    dataset_search_paths.cache_clear()
     _PATH_CACHE = None
     _ENV_STATE = None
     _OVERLAY_CACHE = None


### PR DESCRIPTION
## Summary
- cache dataset search path results to avoid recomputing
- reset the cache in `clear_dataset_cache`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a37e29e08330b1d9d68f99735dee