### PR TITLE
Add config flow menu and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The bundled datasets are not exhaustive and may contain inaccuracies. Always cro
 
 Plant profiles are stored in the `plants/` directory and can be created through the config flow or edited manually.
 
+Once you have at least one plant configured, open **Settings → Devices & Services → Horticulture Assistant**. From here you can manage existing plant entries or choose **Add Plant** to create another entry without returning to the integrations list.
+
 ---
 
 ## Installation

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -35,6 +35,9 @@ class ConfigFlowBase:
     def async_show_form(self, **kwargs):
         return {"type": "form", **kwargs}
 
+    def async_show_menu(self, **kwargs):
+        return {"type": "menu", **kwargs}
+
     def async_create_entry(self, **kwargs):
         self.created_entry = kwargs
         return {"type": "create_entry", **kwargs}
@@ -141,3 +144,12 @@ def test_options_flow(monkeypatch):
     assert recorded["enable_auto_approve"] is True
     assert opt_flow._data["profile_generated"] is True
     assert opt_flow._data["plant_id"] == "pid1"
+
+
+def test_init_menu(monkeypatch):
+    flow = Flow()
+    entries = [types.SimpleNamespace(entry_id="eid1", data={"plant_name": "Tom"})]
+    hass = types.SimpleNamespace(config_entries=types.SimpleNamespace(async_entries=lambda domain: entries))
+    flow.hass = hass
+    result = asyncio.run(flow.async_step_init())
+    assert result["type"] == "menu"


### PR DESCRIPTION
## Summary
- add an integration menu step so the integration page can start new entries or manage existing ones
- document accessing the integration page to add plants
- update tests for the new menu step

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_config_flow.py::test_full_flow tests/test_config_flow.py::test_profile_error tests/test_config_flow.py::test_options_flow tests/test_config_flow.py::test_init_menu -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a363d51883308d264d36645709ce