### PR TITLE
Add nighttime strategy dataset and module

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -160,5 +160,6 @@
   "propagation_guidelines.json": "Recommended environmental conditions for plant propagation methods.",
   "drought_tolerance.json": "Relative drought tolerance and max dry days for each crop.",
   "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
+  "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
   "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/nighttime_strategies.json
+++ b/data/nighttime_strategies.json
@@ -1,0 +1,30 @@
+{
+  "citrus": {
+    "night_activity": "growth",
+    "irrigate": true,
+    "temperature_drop_c": 2,
+    "fan_cycles": "normal",
+    "fertigation_stop_hours": 0
+  },
+  "avocado": {
+    "night_activity": "growth",
+    "irrigate": true,
+    "temperature_drop_c": 2,
+    "fan_cycles": "normal",
+    "fertigation_stop_hours": 0
+  },
+  "iris": {
+    "night_activity": "rest",
+    "irrigate": false,
+    "temperature_drop_c": 5,
+    "fan_cycles": "low",
+    "fertigation_stop_hours": 0
+  },
+  "begonia": {
+    "night_activity": "rest",
+    "irrigate": false,
+    "temperature_drop_c": 5,
+    "fan_cycles": "low",
+    "fertigation_stop_hours": 2
+  }
+}

--- a/plant_engine/nighttime_strategy.py
+++ b/plant_engine/nighttime_strategy.py
@@ -1,0 +1,55 @@
+"""Nighttime optimization guidelines for each plant species."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "nighttime_strategies.json"
+
+_DATA: Dict[str, Dict[str, object]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_nighttime_strategy",
+    "recommend_nighttime_actions",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with nighttime strategy definitions."""
+    return list_dataset_entries(_DATA)
+
+
+def get_nighttime_strategy(plant_type: str) -> Dict[str, object]:
+    """Return nighttime strategy mapping for ``plant_type``."""
+    return _DATA.get(normalize_key(plant_type), {})
+
+
+def recommend_nighttime_actions(plant_type: str) -> Dict[str, object]:
+    """Return recommended nighttime actions for ``plant_type``."""
+    strategy = get_nighttime_strategy(plant_type)
+    if not strategy:
+        return {}
+
+    actions: Dict[str, object] = {}
+    if not strategy.get("irrigate", True):
+        actions["skip_irrigation"] = True
+    else:
+        factor = strategy.get("irrigation_factor")
+        if factor is not None:
+            actions["irrigation_factor"] = float(factor)
+
+    temp_drop = strategy.get("temperature_drop_c")
+    if temp_drop is not None:
+        actions["temperature_drop_c"] = float(temp_drop)
+
+    fan_cycles = strategy.get("fan_cycles")
+    if fan_cycles:
+        actions["fan_cycles"] = str(fan_cycles)
+
+    fert_stop = strategy.get("fertigation_stop_hours")
+    if fert_stop is not None:
+        actions["fertigation_stop_hours"] = float(fert_stop)
+
+    return actions

--- a/tests/test_nighttime_strategy.py
+++ b/tests/test_nighttime_strategy.py
@@ -1,0 +1,22 @@
+from plant_engine.nighttime_strategy import (
+    list_supported_plants,
+    get_nighttime_strategy,
+    recommend_nighttime_actions,
+)
+
+
+def test_list_supported_plants_contains_known():
+    plants = list_supported_plants()
+    assert "citrus" in plants
+    assert "begonia" in plants
+
+
+def test_get_nighttime_strategy():
+    strat = get_nighttime_strategy("citrus")
+    assert strat.get("night_activity") == "growth"
+
+
+def test_recommend_nighttime_actions():
+    actions = recommend_nighttime_actions("begonia")
+    assert actions.get("skip_irrigation") is True
+    assert actions.get("fertigation_stop_hours") == 2


### PR DESCRIPTION
## Summary
- add `nighttime_strategies.json` dataset
- implement `plant_engine.nighttime_strategy` helpers
- register dataset in `dataset_catalog.json`
- test nighttime strategy helpers

## Testing
- `pytest tests/test_nighttime_strategy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886cefe586083309ed1ef15e0508548