### PR TITLE
Add chilling injury risk forecaster

### DIFF
--- a/data/chill_sensitivity.json
+++ b/data/chill_sensitivity.json
@@ -1,0 +1,4 @@
+{
+  "default": {"buffer_c": 0},
+  "monstera": {"buffer_c": 3}
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -159,6 +159,7 @@
   "feature/wsda_refactored_sharded/index_sharded/": "Sharded index of WSDA fertilizer products",
   "propagation_guidelines.json": "Recommended environmental conditions for plant propagation methods.",
   "drought_tolerance.json": "Relative drought tolerance and max dry days for each crop.",
+  "chill_sensitivity.json": "Early warning temperature buffer for chilling injury risk.",
   "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
   "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/plant_engine/chill_risk.py
+++ b/plant_engine/chill_risk.py
@@ -1,0 +1,72 @@
+"""Forecast chilling injury risk based on upcoming temperatures."""
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+COLD_DATA_FILE = "cold_stress_thresholds.json"
+SENSITIVITY_FILE = "chill_sensitivity.json"
+
+_COLD_THRESHOLDS: Mapping[str, float] = load_dataset(COLD_DATA_FILE)
+_SENSITIVITY: Mapping[str, Mapping[str, float]] = load_dataset(SENSITIVITY_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_chill_buffer",
+    "forecast_chilling_risk",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with chill sensitivity data."""
+    return list_dataset_entries(_SENSITIVITY)
+
+
+def get_chill_buffer(plant_type: str) -> float:
+    """Return early warning buffer in °C for ``plant_type``."""
+    entry = _SENSITIVITY.get(normalize_key(plant_type)) or _SENSITIVITY.get("default")
+    if isinstance(entry, Mapping):
+        try:
+            return float(entry.get("buffer_c", 0))
+        except (TypeError, ValueError):
+            return 0.0
+    return 0.0
+
+
+def _cold_threshold(plant_type: str) -> float | None:
+    try:
+        return float(_COLD_THRESHOLDS.get(normalize_key(plant_type), _COLD_THRESHOLDS.get("default")))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def forecast_chilling_risk(
+    plant_type: str,
+    ambient_lows_c: Sequence[float],
+    root_lows_c: Sequence[float],
+    past_events: int = 0,
+) -> str:
+    """Return ``low``, ``moderate`` or ``high`` chilling injury risk."""
+    threshold = _cold_threshold(plant_type)
+    if threshold is None:
+        return "low"
+
+    buffer = get_chill_buffer(plant_type)
+    temps = [float(t) for t in ambient_lows_c if t is not None]
+    temps += [float(t) for t in root_lows_c if t is not None]
+    if not temps:
+        return "low"
+
+    min_temp = min(temps)
+    if min_temp <= threshold:
+        risk = "high"
+    elif min_temp <= threshold + buffer:
+        risk = "moderate"
+    else:
+        risk = "low"
+
+    if past_events > 0 and risk != "high":
+        risk = "high" if buffer >= 2 else "moderate"
+
+    return risk

--- a/tests/test_chill_risk.py
+++ b/tests/test_chill_risk.py
@@ -1,0 +1,23 @@
+from plant_engine.chill_risk import (
+    list_supported_plants,
+    get_chill_buffer,
+    forecast_chilling_risk,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "monstera" in plants
+
+
+def test_get_chill_buffer():
+    assert get_chill_buffer("monstera") == 3
+    assert get_chill_buffer("unknown") == 0
+
+
+def test_forecast_chilling_risk():
+    risk = forecast_chilling_risk("monstera", [6], [18], past_events=0)
+    assert risk == "moderate"
+    risk = forecast_chilling_risk("monstera", [4], [17], past_events=1)
+    assert risk == "high"
+


### PR DESCRIPTION
## Summary
- add species chill sensitivity dataset
- support new dataset entry in catalog
- implement `chill_risk` module for forecasting chilling injury
- test chill risk forecasting

## Testing
- `pytest -q tests/test_chill_risk.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d349784c83308929823d1428eca7