### PR TITLE
Add species precipitation risk predictor

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -160,6 +160,7 @@
   "propagation_guidelines.json": "Recommended environmental conditions for plant propagation methods.",
   "drought_tolerance.json": "Relative drought tolerance and max dry days for each crop.",
   "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
+  "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
   "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
   "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/species_precipitation_risk.json
+++ b/data/species_precipitation_risk.json
@@ -1,0 +1,16 @@
+{
+  "iris": [
+    {
+      "nutrients": ["Fe", "P"],
+      "ph_threshold": 6.4,
+      "message": "FePO4 precipitation risk; use FeEDDHA instead of FeEDTA"
+    }
+  ],
+  "citrus": [
+    {
+      "nutrients": ["Fe", "Ca"],
+      "ph_threshold": 6.5,
+      "message": "Fe precipitates with Ca at high pH"
+    }
+  ]
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -24,6 +24,10 @@ from .nutrient_absorption import (
     get_absorption_rates,
     apply_absorption_rates,
 )
+from .precipitation_risk import (
+    list_supported_plants as list_precipitation_plants,
+    estimate_precipitation_risk,
+)
 
 __all__ = sorted(
     set(utils.__all__)
@@ -40,6 +44,8 @@ __all__ = sorted(
         "list_absorption_stages",
         "get_absorption_rates",
         "apply_absorption_rates",
+        "list_precipitation_plants",
+        "estimate_precipitation_risk",
     }
 )
 

--- a/plant_engine/precipitation_risk.py
+++ b/plant_engine/precipitation_risk.py
@@ -1,0 +1,69 @@
+"""Mineral precipitation risk assessment utilities."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+from .utils import load_dataset, list_dataset_entries, normalize_key
+
+DATA_FILE = "species_precipitation_risk.json"
+
+_DATA: Dict[str, Iterable[Dict[str, object]]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_precipitation_rules",
+    "estimate_precipitation_risk",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with precipitation risk definitions."""
+    return list_dataset_entries(_DATA)
+
+
+def get_precipitation_rules(plant_type: str) -> Iterable[Dict[str, object]]:
+    """Return precipitation risk rules for ``plant_type``."""
+    data = _DATA.get(normalize_key(plant_type))
+    return data if isinstance(data, Iterable) else []
+
+
+def estimate_precipitation_risk(
+    plant_type: str,
+    dosing_history: Mapping[str, float],
+    ph: float,
+    ec: float,
+) -> Dict[str, Dict[str, object]]:
+    """Return precipitation risk levels for ``plant_type``.
+
+    Parameters
+    ----------
+    plant_type : str
+        Crop identifier for dataset lookup.
+    dosing_history : Mapping[str, float]
+        Recent nutrient application amounts.
+    ph : float
+        Solution pH.
+    ec : float
+        Solution EC in mS/cm.
+    """
+
+    rules = get_precipitation_rules(plant_type)
+    risks: Dict[str, Dict[str, object]] = {}
+    for rule in rules:
+        nutrients = rule.get("nutrients")
+        if not isinstance(nutrients, Iterable):
+            continue
+        if not all(n in dosing_history for n in nutrients):
+            continue
+        ph_threshold = rule.get("ph_threshold")
+        if ph_threshold is not None and ph <= float(ph_threshold):
+            continue
+        ec_threshold = rule.get("ec_threshold")
+        if ec_threshold is not None and ec < float(ec_threshold):
+            continue
+        pair = "_".join(nutrients)
+        risks[pair] = {
+            "level": "high",
+            "message": str(rule.get("message", "")),
+        }
+    return risks

--- a/tests/test_precipitation_risk.py
+++ b/tests/test_precipitation_risk.py
@@ -1,0 +1,23 @@
+from plant_engine.precipitation_risk import (
+    list_supported_plants,
+    estimate_precipitation_risk,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "iris" in plants
+    assert "citrus" in plants
+
+
+def test_estimate_precipitation_risk_high():
+    dosing = {"Fe": 1.0, "P": 0.5}
+    risk = estimate_precipitation_risk("iris", dosing, ph=6.5, ec=1.2)
+    assert risk["Fe_P"]["level"] == "high"
+    assert "EDDHA" in risk["Fe_P"]["message"]
+
+
+def test_estimate_precipitation_risk_none():
+    dosing = {"Fe": 1.0, "P": 0.5}
+    risk = estimate_precipitation_risk("iris", dosing, ph=6.2, ec=1.0)
+    assert risk == {}


### PR DESCRIPTION
## Summary
- add precipitation risk dataset and utilities
- expose precipitation risk in plant_engine
- include dataset entry in catalog
- cover with tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d54045708330b2eb4f845d7449ee