### PR TITLE
Enhance EC utilities with stage adjustment

### DIFF
--- a/plant_engine/ec_manager.py
+++ b/plant_engine/ec_manager.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Dict, Tuple
 
+from .constants import get_stage_multiplier
+
 from .utils import load_dataset, normalize_key, list_dataset_entries
 
 DATA_FILE = "ec_guidelines.json"
@@ -17,6 +19,7 @@ __all__ = [
     "list_supported_plants",
     "get_ec_range",
     "get_optimal_ec",
+    "get_stage_adjusted_ec_range",
     "classify_ec_level",
     "recommend_ec_adjustment",
 ]
@@ -51,6 +54,19 @@ def get_optimal_ec(plant_type: str, stage: str | None = None) -> float | None:
         return None
     low, high = rng
     return round((low + high) / 2, 2)
+
+
+def get_stage_adjusted_ec_range(
+    plant_type: str, stage: str | None = None
+) -> Tuple[float, float] | None:
+    """Return EC range scaled by the stage multiplier if available."""
+
+    rng = get_ec_range(plant_type, stage)
+    if not rng:
+        return None
+    low, high = rng
+    mult = get_stage_multiplier(stage or "")
+    return round(low * mult, 2), round(high * mult, 2)
 
 
 def classify_ec_level(ec_ds_m: float, plant_type: str, stage: str | None = None) -> str:

--- a/tests/test_ec_manager.py
+++ b/tests/test_ec_manager.py
@@ -17,6 +17,11 @@ def test_get_optimal_ec():
     assert ec_manager.get_optimal_ec("tomato", "fruiting") == 2.75
 
 
+def test_get_stage_adjusted_ec_range():
+    rng = ec_manager.get_stage_adjusted_ec_range("tomato", "fruiting")
+    assert rng == (2.2, 3.85)
+
+
 def test_classify_ec_level():
     assert ec_manager.classify_ec_level(0.7, "lettuce", "seedling") == "low"
     assert ec_manager.classify_ec_level(1.0, "lettuce", "seedling") == "optimal"
@@ -27,3 +32,4 @@ def test_recommend_ec_adjustment():
     assert ec_manager.recommend_ec_adjustment(0.7, "lettuce", "seedling") == "increase"
     assert ec_manager.recommend_ec_adjustment(1.0, "lettuce", "seedling") == "none"
     assert ec_manager.recommend_ec_adjustment(1.3, "lettuce", "seedling") == "decrease"
+


### PR DESCRIPTION
## Summary
- support stage multipliers in EC range calculations
- test stage-adjusted EC ranges

## Testing
- `pytest tests/test_ec_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68875e5fffc88330b67484c1e4fb2e96