### PR TITLE
Improve reference dataset access

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ Important categories include:
 - **Fertilizer ingredient profiles** – nutrient content, chemical formulas, physical form and aliases for raw salts. Use `plant_engine.ingredients.get_ingredient_profile()` to access them programmatically
 - **Stock solution recipes** – injection ratios for automated fertigation
 - **Fertilizer compatibility** – warnings for mixing products that react poorly
+- **pH adjustment factors** – acid/base volumes for correcting solution pH
+- **Nutrient synergy factors** – multipliers accounting for nutrient interactions
+- **Pest prevention guidelines** – cultural practices to reduce pest pressure
 - **Soil pH guidelines** – optimal soil pH ranges for supported crops
 - **Root temperature uptake factors** – relative nutrient uptake efficiency by root zone temperature
 - **Media properties** – recommended pH range and water retention for common substrates

--- a/plant_engine/reference_data.py
+++ b/plant_engine/reference_data.py
@@ -12,9 +12,14 @@ REFERENCE_FILES = {
     "environment_guidelines": "environment_guidelines.json",
     "pest_guidelines": "pest_guidelines.json",
     "growth_stages": "growth_stages.json",
+    # additional commonly used datasets
+    "ph_guidelines": "ph_guidelines.json",
+    "pest_prevention": "pest_prevention.json",
+    "nutrient_absorption_rates": "nutrient_absorption_rates.json",
+    "nutrient_synergies": "nutrient_synergies.json",
 }
 
-__all__ = ["load_reference_data", "REFERENCE_FILES"]
+__all__ = ["load_reference_data", "get_reference_dataset", "REFERENCE_FILES"]
 
 
 @lru_cache(maxsize=None)
@@ -30,3 +35,19 @@ def load_reference_data() -> Dict[str, Dict[str, Any]]:
         content = load_dataset(filename)
         data[key] = content if isinstance(content, dict) else {}
     return data
+
+
+def get_reference_dataset(name: str) -> Dict[str, Any]:
+    """Return a single reference dataset by key.
+
+    Parameters
+    ----------
+    name : str
+        Dataset identifier from :data:`REFERENCE_FILES`.
+    """
+
+    filename = REFERENCE_FILES.get(name)
+    if not filename:
+        raise KeyError(name)
+    content = load_dataset(filename)
+    return content if isinstance(content, dict) else {}

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -6,3 +6,9 @@ def test_load_reference_data_keys():
     for key in ref.REFERENCE_FILES:
         assert key in data
         assert isinstance(data[key], dict)
+
+
+def test_get_reference_dataset():
+    data = ref.get_reference_dataset("ph_guidelines")
+    assert isinstance(data, dict)
+    assert "citrus" in data


### PR DESCRIPTION
## Summary
- integrate additional horticulture datasets in `reference_data`
- expose `get_reference_dataset` utility
- document new datasets in the README
- test new functionality

## Testing
- `pytest tests/test_reference_data.py tests/test_ph_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68875ef99fd88330b517c8be97021d10