### PR TITLE
Improve reference data loading and GA conversion

### DIFF
--- a/plant_engine/reference_data.py
+++ b/plant_engine/reference_data.py
@@ -11,10 +11,11 @@ REFERENCE_FILES = {
     "nutrient_guidelines": "nutrient_guidelines.json",
     "environment_guidelines": "environment_guidelines.json",
     "pest_guidelines": "pest_guidelines.json",
+    "disease_guidelines": "disease_guidelines.json",
     "growth_stages": "growth_stages.json",
 }
 
-__all__ = ["load_reference_data", "REFERENCE_FILES"]
+__all__ = ["load_reference_data", "REFERENCE_FILES", "get_reference_dataset"]
 
 
 @lru_cache(maxsize=None)
@@ -30,3 +31,24 @@ def load_reference_data() -> Dict[str, Dict[str, Any]]:
         content = load_dataset(filename)
         data[key] = content if isinstance(content, dict) else {}
     return data
+
+
+@lru_cache(maxsize=None)
+def get_reference_dataset(name: str) -> Dict[str, Any]:
+    """Return a single reference dataset by key.
+
+    Parameters
+    ----------
+    name : str
+        Dataset identifier from :data:`REFERENCE_FILES`.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a known reference dataset.
+    """
+
+    if name not in REFERENCE_FILES:
+        raise KeyError(f"Unknown reference dataset '{name}'")
+    content = load_dataset(REFERENCE_FILES[name])
+    return content if isinstance(content, dict) else {}

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,3 +1,4 @@
+import pytest
 import plant_engine.reference_data as ref
 
 
@@ -6,3 +7,14 @@ def test_load_reference_data_keys():
     for key in ref.REFERENCE_FILES:
         assert key in data
         assert isinstance(data[key], dict)
+
+
+def test_get_reference_dataset_valid():
+    for key in ref.REFERENCE_FILES:
+        ds = ref.get_reference_dataset(key)
+        assert isinstance(ds, dict)
+
+
+def test_get_reference_dataset_invalid():
+    with pytest.raises(KeyError):
+        ref.get_reference_dataset("unknown")


### PR DESCRIPTION
## Summary
- expose disease guidelines via `REFERENCE_FILES`
- add helper to fetch individual reference datasets
- cache `convert_guaranteed_analysis` results
- test new reference dataset loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875ee4b9c083309d3086b7b8c0e80d