### PR TITLE
Add heat index series helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ python -m custom_components.horticulture_assistant.analytics.export_all_growth_y
 - `generate_cycle_irrigation_plan` returns stage irrigation volumes using guideline intervals and durations.
 - `calculate_environment_stddev` computes standard deviation of environment sensor series for tighter control.
 - `calculate_environment_deviation` measures how far readings deviate from target midpoints to highlight adjustments.
+- `calculate_heat_index_series` averages heat index across sequential temperature and humidity readings.
 - `estimate_hvac_energy_series` and `estimate_hvac_cost_series` evaluate energy
   use and cost for sequential HVAC temperature setpoints.
 

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -342,6 +342,7 @@ __all__ = [
     "ppfd_for_target_dli",
     "calculate_dli_series",
     "calculate_vpd_series",
+    "calculate_heat_index_series",
     "get_target_dli",
     "get_target_vpd",
     "get_target_photoperiod",
@@ -1829,6 +1830,28 @@ def calculate_vpd_series(
         count += 1
 
     return round(total / count, 3) if count else 0.0
+
+
+def calculate_heat_index_series(
+    temp_values: Iterable[float], humidity_values: Iterable[float]
+) -> float:
+    """Return average heat index from temperature and humidity pairs."""
+
+    from itertools import zip_longest
+
+    sentinel = object()
+    total = 0.0
+    count = 0
+
+    for t, h in zip_longest(temp_values, humidity_values, fillvalue=sentinel):
+        if sentinel in (t, h):
+            raise ValueError(
+                "temperature and humidity readings must have the same length"
+            )
+        total += calculate_heat_index(float(t), float(h))
+        count += 1
+
+    return round(total / count, 2) if count else 0.0
 
 
 def get_target_dli(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -12,6 +12,7 @@ from plant_engine.environment_manager import (
     calculate_vpd,
     calculate_dew_point,
     calculate_heat_index,
+    calculate_heat_index_series,
     relative_humidity_from_dew_point,
     calculate_absolute_humidity,
     calculate_dli,
@@ -216,6 +217,18 @@ def test_calculate_heat_index():
 def test_calculate_heat_index_invalid():
     with pytest.raises(ValueError):
         calculate_heat_index(25, -10)
+
+
+def test_calculate_heat_index_series():
+    temps = [30, 32, 28]
+    humidity = [70, 65, 80]
+    expected = sum(
+        calculate_heat_index(t, h) for t, h in zip(temps, humidity)
+    ) / len(temps)
+    assert calculate_heat_index_series(temps, humidity) == round(expected, 2)
+
+    with pytest.raises(ValueError):
+        calculate_heat_index_series([30], [50, 60])
 
 
 def test_relative_humidity_from_dew_point():


### PR DESCRIPTION
## Summary
- add `calculate_heat_index_series` helper to environment manager
- document new helper in README
- test the new functionality

## Testing
- `pytest -q tests/test_environment_manager.py::test_calculate_heat_index_series`
- `pytest -q tests/test_environment_manager.py`
- `pytest -q tests/test_root_temperature.py`

------
https://chatgpt.com/codex/tasks/task_e_68875ee9ff808330b741268e7c233fe4