### PR TITLE
Enhance growth stage summaries

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -252,18 +252,34 @@ def get_germination_duration(plant_type: str) -> int | None:
 
 
 def growth_stage_summary(
-    plant_type: str, start_date: date | None = None
+    plant_type: str,
+    start_date: date | None = None,
+    *,
+    include_guidelines: bool = False,
 ) -> Dict[str, Any]:
-    """Return growth stage durations and optional harvest date."""
+    """Return growth stage durations with optional guideline data.
+
+    When ``include_guidelines`` is ``True`` each stage entry also contains
+    recommended environment and nutrient targets pulled from the respective
+    datasets. This avoids repetitive lookups when generating reports.
+    """
 
     stages = list_growth_stages(plant_type)
-    summary = [
-        {
+    summary = []
+    for stage in stages:
+        entry = {
             "stage": stage,
             "duration_days": get_stage_duration(plant_type, stage),
         }
-        for stage in stages
-    ]
+        if include_guidelines:
+            from .environment_manager import get_environment_guidelines
+            from .nutrient_manager import get_recommended_levels
+
+            entry["environment"] = get_environment_guidelines(
+                plant_type, stage
+            ).as_dict()
+            entry["nutrients"] = get_recommended_levels(plant_type, stage)
+        summary.append(entry)
 
     result = {"plant_type": plant_type, "stages": summary}
 

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -143,6 +143,12 @@ def test_growth_stage_summary():
     assert stages["seedling"] == 30
 
 
+def test_growth_stage_summary_with_guidelines():
+    data = growth_stage_summary("citrus", include_guidelines=True)
+    first = data["stages"][0]
+    assert "environment" in first and "nutrients" in first
+
+
 def test_growth_stage_summary_unknown():
     result = growth_stage_summary("unknown")
     assert result["stages"] == []


### PR DESCRIPTION
## Summary
- enrich `growth_stage_summary` to optionally include environment and nutrient guidelines
- verify new behaviour in tests

## Testing
- `pytest tests/test_growth_stage.py::test_growth_stage_summary_with_guidelines -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875ea5e11c8330800f6b280f6d6125