### PR TITLE
Add root zone moisture thresholds

### DIFF
--- a/plant_engine/rootzone_model.py
+++ b/plant_engine/rootzone_model.py
@@ -28,6 +28,8 @@ __all__ = [
     "estimate_water_capacity",
     "calculate_remaining_water",
     "soil_moisture_pct",
+    "moisture_threshold_volume",
+    "moisture_threshold_pct",
     "get_soil_parameters",
     "get_infiltration_rate",
     "estimate_infiltration_time",
@@ -220,4 +222,21 @@ def soil_moisture_pct(rootzone: RootZone, available_ml: float) -> float:
     """Return current soil moisture as a percentage of capacity."""
 
     return rootzone.moisture_pct(available_ml)
+
+
+def moisture_threshold_volume(rootzone: RootZone) -> float:
+    """Return available water volume that triggers irrigation."""
+
+    return float(rootzone.readily_available_water_ml)
+
+
+def moisture_threshold_pct(rootzone: RootZone) -> float:
+    """Return soil moisture percentage that triggers irrigation."""
+
+    if rootzone.total_available_water_ml <= 0:
+        return 0.0
+    pct = (
+        rootzone.readily_available_water_ml / rootzone.total_available_water_ml
+    ) * 100
+    return round(pct, 1)
 

--- a/tests/test_rootzone_model.py
+++ b/tests/test_rootzone_model.py
@@ -7,6 +7,8 @@ from plant_engine.rootzone_model import (
     soil_moisture_pct,
     get_infiltration_rate,
     estimate_infiltration_time,
+    moisture_threshold_volume,
+    moisture_threshold_pct,
     RootZone,
 )
 import pytest
@@ -114,4 +116,12 @@ def test_estimate_infiltration_time():
     assert estimate_infiltration_time(1000, 1.0, "unknown") is None
     with pytest.raises(ValueError):
         estimate_infiltration_time(-1, 1.0, "loam")
+
+
+def test_moisture_threshold_helpers():
+    rz = estimate_water_capacity(10, area_cm2=100, texture="loam")
+    assert moisture_threshold_volume(rz) == rz.readily_available_water_ml
+    pct = moisture_threshold_pct(rz)
+    expected = (rz.readily_available_water_ml / rz.total_available_water_ml) * 100
+    assert pct == round(expected, 1)
 


### PR DESCRIPTION
## Summary
- add helpers for irrigation trigger thresholds
- expose functions for threshold volume and percentage
- test new soil moisture threshold helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68875ea09b3c83309c069307d6df24f3