### PR TITLE
Add irrigation zone removal helper

### DIFF
--- a/custom_components/horticulture_assistant/utils/zone_registry.py
+++ b/custom_components/horticulture_assistant/utils/zone_registry.py
@@ -22,6 +22,7 @@ __all__ = [
     "detach_plants",
     "attach_solenoids",
     "detach_solenoids",
+    "remove_zone",
 ]
 
 
@@ -147,5 +148,15 @@ def detach_solenoids(zone_id: str, solenoids: List[str], hass=None) -> bool:
     if not zone:
         return False
     zone.solenoids = [sid for sid in zone.solenoids if sid not in solenoids]
+    return save_zones(zones, hass)
+
+
+def remove_zone(zone_id: str, hass=None) -> bool:
+    """Delete ``zone_id`` from the registry and persist changes."""
+
+    zones = load_zones(hass)
+    if str(zone_id) not in zones:
+        return False
+    zones.pop(str(zone_id))
     return save_zones(zones, hass)
 

--- a/tests/test_zone_registry.py
+++ b/tests/test_zone_registry.py
@@ -9,6 +9,7 @@ from custom_components.horticulture_assistant.utils.zone_registry import (
     detach_plants,
     attach_solenoids,
     detach_solenoids,
+    remove_zone,
 )
 
 
@@ -63,4 +64,8 @@ def test_zone_registry_modify(tmp_path, monkeypatch):
 
     assert detach_solenoids("3", ["x"])
     assert load_zones()["3"].solenoids == ["y"]
+
+    assert remove_zone("3")
+    assert "3" not in load_zones()
+
 


### PR DESCRIPTION
## Summary
- add `remove_zone` utility for irrigation zone registry
- test zone removal functionality

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_zone_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68875e8096008330a8e3f39991610363