### PR TITLE
Improve DAFE data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Important categories include:
 - **Root temperature uptake factors** – relative nutrient uptake efficiency by root zone temperature
 - **Media properties** – recommended pH range and water retention for common substrates
 - **Drought tolerance** – maximum days plants can remain dry before watering
+- **DAFE species profiles** – growth and EC parameters used by the fertigation engine
+- **DAFE media profiles** – porosity and retention factors for supported substrates
 
 The WSDA fertilizer dataset resides under `feature/wsda_refactored_sharded/` which contains an
 `index_sharded/` directory of `.jsonl` shards and a `detail/` directory of per-product records.

--- a/dafe/media_models.py
+++ b/dafe/media_models.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+from plant_engine.utils import load_dataset
+
+# Dataset file residing under ``data/`` used to populate media properties.
+DATA_FILE = "dafe_media_profiles.json"
 
 __all__ = ["MediaProfile", "get_media_profile"]
 
@@ -19,20 +23,17 @@ class MediaProfile:
     tortuosity: float
 
 
+def _profile_data() -> dict:
+    """Return cached media profile data from :data:`DATA_FILE`."""
+
+    return load_dataset(DATA_FILE)
+
+
 @lru_cache(maxsize=None)
 def get_media_profile(media_name: str) -> MediaProfile | None:
-    """Return a :class:`MediaProfile` or ``None`` if ``media_name`` unknown."""
+    """Return a :class:`MediaProfile` for ``media_name`` if available."""
 
-    data = {
-        "coco_coir": {
-            "porosity": 0.78,
-            "fc": 0.55,
-            "pwp": 0.20,
-            "tortuosity": 2.3,
-        }
-    }.get(media_name)
-
+    data = _profile_data().get(media_name)
     if not data:
         return None
-
     return MediaProfile(media_name, **data)

--- a/dafe/species_profiles.py
+++ b/dafe/species_profiles.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+from plant_engine.utils import load_dataset
+
+# Dataset file residing under ``data/`` used to populate known species profiles.
+DATA_FILE = "dafe_species_profiles.json"
 
 __all__ = ["SpeciesProfile", "get_species_profile"]
 
@@ -22,23 +26,17 @@ class SpeciesProfile:
     ec_high: float
 
 
+def _profile_data() -> dict:
+    """Return cached species profile data from :data:`DATA_FILE`."""
+
+    return load_dataset(DATA_FILE)
+
+
 @lru_cache(maxsize=None)
 def get_species_profile(species_name: str) -> SpeciesProfile | None:
-    """Return a :class:`SpeciesProfile` or ``None`` if ``species_name`` unknown."""
+    """Return a :class:`SpeciesProfile` for ``species_name`` if available."""
 
-    data = {
-        "Cannabis_sativa": {
-            "root_depth": "shallow",
-            "dryback_tolerance": "medium",
-            "oxygen_min": 8.0,
-            "ideal_wc_plateau": 0.42,
-            "generative_threshold": 0.035,
-            "ec_low": 1.5,
-            "ec_high": 2.5,
-        }
-    }.get(species_name)
-
+    data = _profile_data().get(species_name)
     if not data:
         return None
-
     return SpeciesProfile(species_name, **data)

--- a/data/dafe_media_profiles.json
+++ b/data/dafe_media_profiles.json
@@ -1,0 +1,8 @@
+{
+  "coco_coir": {
+    "porosity": 0.78,
+    "fc": 0.55,
+    "pwp": 0.20,
+    "tortuosity": 2.3
+  }
+}

--- a/data/dafe_species_profiles.json
+++ b/data/dafe_species_profiles.json
@@ -1,0 +1,11 @@
+{
+  "Cannabis_sativa": {
+    "root_depth": "shallow",
+    "dryback_tolerance": "medium",
+    "oxygen_min": 8.0,
+    "ideal_wc_plateau": 0.42,
+    "generative_threshold": 0.035,
+    "ec_low": 1.5,
+    "ec_high": 2.5
+  }
+}

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,4 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }

--- a/tests/test_dafe.py
+++ b/tests/test_dafe.py
@@ -116,3 +116,33 @@ def test_recommend_fertigation_schedule():
     assert schedule["N"] == 0.8
     assert schedule["P"] == 0.3
     assert schedule["K"] == 0.6
+
+
+def test_profile_data_files(tmp_path, monkeypatch):
+    """Species and media profiles load from dataset files."""
+
+    species_file = tmp_path / "dafe_species_profiles.json"
+    species_file.write_text(
+        '{"testplant": {"root_depth": "shallow", "dryback_tolerance": "low",'
+        ' "oxygen_min": 7, "ideal_wc_plateau": 0.5, "generative_threshold": 0.1,'
+        ' "ec_low": 1.0, "ec_high": 2.0}}'
+    )
+    media_file = tmp_path / "dafe_media_profiles.json"
+    media_file.write_text(
+        '{"rockwool": {"porosity": 0.9, "fc": 0.7, "pwp": 0.1, "tortuosity": 1.5}}'
+    )
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(tmp_path))
+
+    from plant_engine.utils import clear_dataset_cache
+
+    clear_dataset_cache()
+    get_species_profile.cache_clear()
+    get_media_profile.cache_clear()
+
+    sp = get_species_profile("testplant")
+    mp = get_media_profile("rockwool")
+
+    assert sp is not None
+    assert mp is not None
+    assert sp.ec_high == 2.0 and mp.porosity == 0.9


### PR DESCRIPTION
## Summary
- add dataset-driven species and media profiles
- fix JSON syntax in vpd_actions.json
- document new DAFE datasets
- test dynamic profile loading

## Testing
- `pytest tests/test_dafe.py -q`
- `pytest tests/test_climate_guidelines.py -q`
- `pytest -k dafe -q`

------
https://chatgpt.com/codex/tasks/task_e_6887716763f08330af86b7248fcc3aea