### PR TITLE
Add disease scouting methods and integrate

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -21,6 +21,7 @@
     "ipm_guidelines.json": "Integrated pest management practices by crop.",
     "disease_guidelines.json": "Treatment guidance for common plant diseases.",
     "disease_prevention.json": "Preventative measures to reduce disease incidence.",
+    "disease_scouting_methods.json": "Recommended scouting techniques for common diseases.",
     "growth_stages.json": "Expected duration and notes for each growth stage.",
     "stage_tasks.json": "Common tasks to perform during each growth stage.",
     "germination_duration.json": "Typical days from sowing to germination by crop.",
@@ -164,5 +165,5 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/disease_scouting_methods.json
+++ b/data/disease_scouting_methods.json
@@ -1,0 +1,7 @@
+{
+  "citrus_greening": "Inspect mottled leaves and use yellow sticky traps for psyllid vectors.",
+  "root_rot": "Excavate small roots near the stem and look for discolored or mushy tissue.",
+  "blight": "Look for dark lesions on stems and leaves, especially in humid conditions.",
+  "powdery_mildew": "Check leaf surfaces for white powdery spots using 10x magnification.",
+  "downy_mildew": "Inspect lower leaf surfaces for purple or gray fuzz early in the morning."
+}

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,4 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }

--- a/tests/test_disease_monitor.py
+++ b/tests/test_disease_monitor.py
@@ -11,6 +11,8 @@ from plant_engine.disease_monitor import (
     risk_adjusted_monitor_interval,
     next_monitor_date,
     generate_monitoring_schedule,
+    generate_detailed_monitoring_schedule,
+    get_scouting_method,
     get_severity_action,
     summarize_disease_management,
 )
@@ -117,3 +119,15 @@ def test_summarize_disease_management():
     assert summary.get("risk_score") is not None
     assert "next_monitor_date" in summary
 
+
+def test_get_scouting_method():
+    method = get_scouting_method("powdery mildew")
+    assert "powdery" in method.lower()
+
+def test_generate_detailed_monitoring_schedule():
+    start = date(2023, 1, 1)
+    plan = generate_detailed_monitoring_schedule("citrus", "fruiting", start, 2)
+    assert len(plan) == 2
+    entry = plan[0]
+    assert entry["date"] == date(2023, 1, 5)
+    assert "citrus greening" in entry["methods"]


### PR DESCRIPTION
## Summary
- add `disease_scouting_methods.json` and reference it in dataset catalog
- integrate scouting methods in `disease_monitor`
- expose `generate_detailed_monitoring_schedule` and `get_scouting_method`
- fix trailing commas in example datasets
- test new disease monitoring helpers

## Testing
- `pytest tests/test_disease_monitor.py -q`
- `pytest tests/test_pest_monitor.py::test_generate_detailed_monitoring_schedule -q`


------
https://chatgpt.com/codex/tasks/task_e_6887716b6dc4833080d631b7d7b3f914