### PR TITLE
Improve automation helper reuse

### DIFF
--- a/custom_components/horticulture_assistant/automation/helpers.py
+++ b/custom_components/horticulture_assistant/automation/helpers.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Iterable, Tuple
+from typing import Any, Dict, Iterable, Mapping, Tuple
 
 from ..utils.json_io import load_json, save_json
 
@@ -34,4 +34,17 @@ def append_json_log(log_path: Path, entry: Dict) -> None:
             pass
     log_entries.append(entry)
     save_json(str(log_path), log_entries)
+
+
+def latest_env(profile: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return the most recent environment readings from ``profile``."""
+
+    data: Mapping[str, Any] = {}
+    general = profile.get("general")
+    if isinstance(general, Mapping):
+        data = general.get("latest_env") or {}
+    if not data:
+        data = profile.get("latest_env") or {}
+    return dict(data) if isinstance(data, Mapping) else {}
+
 

--- a/custom_components/horticulture_assistant/automation/run_automation_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_automation_cycle.py
@@ -15,7 +15,7 @@ from datetime import datetime
 
 from custom_components.horticulture_assistant.utils.path_utils import plants_path
 
-from .helpers import iter_profiles, append_json_log
+from .helpers import iter_profiles, append_json_log, latest_env
 
 # Global override: disable automation if False
 ENABLE_AUTOMATION = False
@@ -53,22 +53,10 @@ def _get_moisture_threshold(profile: dict) -> float | None:
     return None
 
 
-def _latest_env(profile: dict) -> dict:
-    """Return the most recent environment readings from ``profile``."""
-
-    data = {}
-    gen = profile.get("general")
-    if isinstance(gen, dict):
-        data = gen.get("latest_env", {}) or {}
-    if not data:
-        data = profile.get("latest_env", {})
-    return data if isinstance(data, dict) else {}
-
-
 def _get_current_moisture(profile: dict) -> float | None:
     """Return latest soil moisture reading from profile data."""
 
-    data = _latest_env(profile)
+    data = latest_env(profile)
     for key in ("soil_moisture", "soil_moisture_pct", "moisture", "vwc"):
         if key in data:
             try:

--- a/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
@@ -6,24 +6,12 @@ from datetime import datetime
 
 from custom_components.horticulture_assistant.utils.path_utils import plants_path
 
-from .helpers import append_json_log, iter_profiles
+from .helpers import append_json_log, iter_profiles, latest_env
 
 # Global override: disable automation if False
 ENABLE_AUTOMATION = False
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _latest_env(profile: dict) -> dict:
-    """Return most recent environment readings from ``profile``."""
-
-    data = {}
-    gen = profile.get("general")
-    if isinstance(gen, dict):
-        data = gen.get("latest_env", {}) or {}
-    if not data:
-        data = profile.get("latest_env", {})
-    return data if isinstance(data, dict) else {}
 
 def run_fertilizer_cycle(base_path: str | None = None) -> None:
     """
@@ -61,7 +49,7 @@ def run_fertilizer_cycle(base_path: str | None = None) -> None:
             continue
 
         # Get the latest sensor data for this plant (nutrient levels, EC, etc.)
-        sensor_data = _latest_env(profile_data)
+        sensor_data = latest_env(profile_data)
         if not sensor_data:
             _LOGGER.warning("No latest sensor data found for plant %s. Skipping.", plant_id)
             continue


### PR DESCRIPTION
## Summary
- refactor automation modules to share a common `latest_env` helper
- update irrigation and fertilizer cycles to use new helper

## Testing
- `pytest tests/test_automation_cycles.py::test_run_automation_cycle -q`
- `pytest tests/test_automation_cycles.py::test_run_fertilizer_cycle -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6887718084608330bbc9cc019722f6f4