### PR TITLE
Improve dataset cache handling

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -164,5 +164,5 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,4 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -194,9 +194,27 @@ def dataset_paths() -> tuple[Path, ...]:
     return _PATH_CACHE
 
 
-@lru_cache(maxsize=None)
+_DS_SEARCH_CACHE: dict[tuple[bool, tuple[str | None, str | None, str | None]], tuple[Path, ...]] = {}
+
+
 def dataset_search_paths(include_overlay: bool = False) -> tuple[Path, ...]:
-    """Return dataset search paths optionally including overlay first."""
+    """Return dataset search paths optionally including overlay first.
+
+    The result is cached per current environment variables so updates to
+    ``HORTICULTURE_DATA_DIR``, ``HORTICULTURE_EXTRA_DATA_DIRS`` or
+    ``HORTICULTURE_OVERLAY_DIR`` automatically refresh when calling
+    :func:`clear_dataset_cache` or when variables change between calls.
+    """
+
+    env_state = (
+        os.getenv("HORTICULTURE_DATA_DIR"),
+        os.getenv(EXTRA_ENV),
+        os.getenv(OVERLAY_ENV),
+    )
+    key = (include_overlay, env_state)
+    cached = _DS_SEARCH_CACHE.get(key)
+    if cached is not None:
+        return cached
 
     paths = []
     if include_overlay:
@@ -204,7 +222,10 @@ def dataset_search_paths(include_overlay: bool = False) -> tuple[Path, ...]:
         if ov:
             paths.append(ov)
     paths.extend(dataset_paths())
-    return tuple(paths)
+
+    result = tuple(paths)
+    _DS_SEARCH_CACHE[key] = result
+    return result
 
 
 @lru_cache(maxsize=None)
@@ -280,10 +301,10 @@ def load_datasets(*filenames: str) -> Dict[str, Dict[str, Any]]:
 def clear_dataset_cache() -> None:
     """Clear cached dataset results loaded via :func:`load_dataset`."""
 
-    global _PATH_CACHE, _ENV_STATE, _OVERLAY_CACHE, _OVERLAY_ENV_VALUE
+    global _PATH_CACHE, _ENV_STATE, _OVERLAY_CACHE, _OVERLAY_ENV_VALUE, _DS_SEARCH_CACHE
     load_dataset.cache_clear()
     dataset_file.cache_clear()
-    dataset_search_paths.cache_clear()
+    _DS_SEARCH_CACHE.clear()
     _PATH_CACHE = None
     _ENV_STATE = None
     _OVERLAY_CACHE = None

--- a/tests/test_dataset_paths.py
+++ b/tests/test_dataset_paths.py
@@ -52,3 +52,20 @@ def test_dataset_search_paths_includes_overlay(monkeypatch, tmp_path):
     assert paths[0] == overlay
     assert base in paths
     utils.clear_dataset_cache()
+
+def test_dataset_search_paths_env_change(monkeypatch, tmp_path):
+    base1 = tmp_path / "d1"
+    base2 = tmp_path / "d2"
+    base1.mkdir()
+    base2.mkdir()
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base1))
+    import importlib
+    importlib.reload(utils)
+    paths1 = utils.dataset_search_paths()
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(base2))
+    # calling again without clearing cache should reflect new env
+    paths2 = utils.dataset_search_paths()
+    assert paths2[0] == base2
+    assert paths1 != paths2
+    utils.clear_dataset_cache()
+


### PR DESCRIPTION
## Summary
- fix JSON trailing commas in two data files
- improve dataset search path caching
- cover dataset search path environment change behavior

## Testing
- `pytest -q`
- `pytest tests/test_dataset_paths.py::test_dataset_search_paths_env_change -q`

------
https://chatgpt.com/codex/tasks/task_e_688771859134833091d7155f08e80cff