### PR TITLE
Improve dataset utilities caching

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -164,5 +164,5 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,4 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -288,6 +288,7 @@ def clear_dataset_cache() -> None:
     _ENV_STATE = None
     _OVERLAY_CACHE = None
     _OVERLAY_ENV_VALUE = None
+    list_dataset_files.cache_clear()
 
 
 def normalize_key(key: str) -> str:
@@ -365,8 +366,14 @@ def load_stage_dataset_value(
     return stage_value(data, plant_type, stage, default_key)
 
 
+@lru_cache(maxsize=None)
 def list_dataset_files() -> list[str]:
-    """Return alphabetically sorted dataset files available in search paths."""
+    """Return alphabetically sorted dataset files available in search paths.
+
+    Results are cached to avoid repeated directory scans which can be
+    expensive on slower storage. Call :func:`clear_dataset_cache` when the
+    underlying files may have changed so the cache is refreshed.
+    """
 
     files: set[str] = set()
     for base in dataset_search_paths(include_overlay=True):


### PR DESCRIPTION
## Summary
- fix trailing commas in dataset JSON files
- cache dataset listings for faster repeated access

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688771a4aaa483308c09f0d7653a35b1