### PR TITLE
Add nutrient synergy option in fertigation planner

### DIFF
--- a/custom_components/horticulture_assistant/utils/fertigation_planner.py
+++ b/custom_components/horticulture_assistant/utils/fertigation_planner.py
@@ -46,6 +46,7 @@ def plan_fertigation_from_profile(
     water_profile: Mapping[str, float] | None = None,
     include_micro: bool = False,
     fertilizers: Mapping[str, str] | None = None,
+    use_synergy: bool = False,
 ) -> FertigationPlan:
     """Return a fertigation plan using profile data and dataset guidelines."""
 
@@ -83,6 +84,7 @@ def plan_fertigation_from_profile(
         water_profile,
         fertilizers=fertilizers,
         include_micro=include_micro,
+        use_synergy=use_synergy,
     )
 
     return FertigationPlan(schedule, total, breakdown, warnings, diagnostics)

--- a/tests/test_fertigation_planner.py
+++ b/tests/test_fertigation_planner.py
@@ -42,3 +42,13 @@ def test_plan_fertigation_missing_profile(tmp_path):
     plan = plan_fertigation_from_profile("missing", 5.0, hass)
     assert plan.schedule == {}
     assert plan.cost_total == 0.0
+
+
+def test_plan_fertigation_synergy(tmp_path):
+    plant_dir = tmp_path / "plants"
+    plant_dir.mkdir()
+    (plant_dir / "lettuce.json").write_text('{"general": {"plant_type": "lettuce", "stage": "seedling"}}')
+    hass = _hass_for(tmp_path)
+    plan_basic = plan_fertigation_from_profile("lettuce", 1.0, hass)
+    plan_syn = plan_fertigation_from_profile("lettuce", 1.0, hass, use_synergy=True)
+    assert plan_syn.cost_total >= plan_basic.cost_total


### PR DESCRIPTION
## Summary
- support synergy-adjusted nutrient recommendations in `plan_fertigation_from_profile`
- refactor fertigation utilities to accept `use_synergy` flag
- test fertigation planner with synergy option

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_fertigation_planner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688771ad56ec8330a6e7444e033bcffd