### PR TITLE
Refine dataset catalog & fix JSON

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -164,5 +164,5 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,4 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -49,12 +49,17 @@ class DatasetCatalog:
         default_factory=lambda: get_data_dir() / "dataset_catalog.json"
     )
 
-    def _iter_paths(self) -> List[Path]:
-        """Return search paths honoring init parameters."""
+    @lru_cache(maxsize=None)
+    def paths(self) -> tuple[Path, ...]:
+        """Return dataset search paths including overlay when set."""
         paths = [self.base_dir, *self.extra_dirs]
         if self.overlay_dir:
             paths.insert(0, self.overlay_dir)
-        return paths
+        return tuple(paths)
+
+    def _iter_paths(self) -> List[Path]:
+        """Return search paths as a list for backward compatibility."""
+        return list(self.paths())
 
     @lru_cache(maxsize=None)
     def list_datasets(self) -> List[str]:
@@ -154,6 +159,7 @@ class DatasetCatalog:
         self.list_info.cache_clear()
         self.list_by_category.cache_clear()
         self.load.cache_clear()
+        self.paths.cache_clear()
 
 
 DEFAULT_CATALOG = DatasetCatalog()

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -127,6 +127,25 @@ def test_catalog_overlay_priority(monkeypatch, tmp_path):
     assert cat.find_path("a.json") == overlay / "a.json"
 
 
+def test_catalog_paths_cached(tmp_path):
+    base = tmp_path / "data"
+    extra = tmp_path / "extra"
+    overlay = tmp_path / "overlay"
+    base.mkdir()
+    extra.mkdir()
+    overlay.mkdir()
+
+    cat = datasets.DatasetCatalog(
+        base_dir=base, extra_dirs=(extra,), overlay_dir=overlay
+    )
+
+    first = cat.paths()
+    second = cat.paths()
+    assert first is second
+    assert first[0] == overlay
+    assert base in first and extra in first
+
+
 def test_get_dataset_path_and_load():
     path = datasets.get_dataset_path("nutrient_guidelines.json")
     assert path and path.exists()


### PR DESCRIPTION
## Summary
- cache dataset search paths in `DatasetCatalog`
- refresh cached paths when clearing catalog
- ensure vpd_actions and dataset_catalog JSON are valid
- test the new `paths` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688772345eb083309d2efaa7673f9b73