### PR TITLE
Add stage-specific pest thresholds and fix dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Important categories include:
 - **Pest and disease references** – thresholds, prevention tips and treatment options
 - **Fungicide recommendations** – suggested organic products for common diseases
 - **Pest scouting methods** – recommended techniques for monitoring common pests
+- **Stage-specific pest thresholds** – economic thresholds for each growth stage
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -15,6 +15,7 @@
     "default_environment.json": "Fallback environment readings used when sensor data is missing.",
     "pest_guidelines.json": "Common pest control recommendations per crop.",
     "pest_thresholds.json": "Economic threshold counts for triggering actions.",
+    "pest_thresholds_by_stage.json": "Stage-specific pest count thresholds for scouting decisions.",
     "pest_monitoring_intervals.json": "Recommended days between scouting events.",
     "pest_risk_interval_modifiers.json": "Multipliers adjusting monitoring frequency based on risk level.",
     "pest_scouting_methods.json": "Recommended scouting techniques for common pests.",
@@ -164,5 +165,5 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/pest_thresholds_by_stage.json
+++ b/data/pest_thresholds_by_stage.json
@@ -1,0 +1,14 @@
+{
+  "citrus": {
+    "vegetative": {"aphids": 5, "scale": 2},
+    "fruiting": {"aphids": 5, "scale": 2}
+  },
+  "tomato": {
+    "seedling": {"aphids": 5, "blight": 0},
+    "vegetative": {"aphids": 10, "blight": 1},
+    "fruiting": {"aphids": 12, "blight": 1}
+  },
+  "lettuce": {
+    "vegetative": {"aphids": 8, "leafminers": 4}
+  }
+}

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,4 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -65,7 +65,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
     richer automation data.
     """
 
-    thresholds = pest_monitor.get_pest_thresholds(plant_type)
+    thresholds = pest_monitor.get_pest_thresholds(plant_type, stage)
     beneficial = {p: pest_manager.get_beneficial_insects(p) for p in thresholds}
 
     if stage:

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -27,6 +27,10 @@ def test_guideline_summary_no_stage():
     data = get_guideline_summary("citrus")
     assert "stages" in data and "vegetative" in data["stages"]
 
+    # ensure stage thresholds fallback correctly
+    thresh = get_guideline_summary("tomato", "seedling")["pest_thresholds"]
+    assert thresh["aphids"] == 5
+
 
 def test_guideline_summary_bioinoculants():
     data = get_guideline_summary("tomato", "fruiting")

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -28,6 +28,9 @@ def test_get_pest_thresholds():
     thresh2 = get_pest_thresholds("CiTrUs")
     assert thresh2 == thresh
 
+    stage_thresh = get_pest_thresholds("tomato", "seedling")
+    assert stage_thresh["aphids"] == 5
+
 
 def test_assess_pest_pressure():
     obs = {"aphids": 6, "scale": 1}


### PR DESCRIPTION
## Summary
- update `vpd_actions.json` to use valid JSON
- provide new dataset `pest_thresholds_by_stage.json`
- describe new dataset in `dataset_catalog.json` and README
- extend `pest_monitor.get_pest_thresholds` to support stages
- surface stage-aware thresholds in `get_guideline_summary`
- cover new behaviour in tests
- fix trailing comma in `dataset_catalog.json`

## Testing
- `pytest tests/test_pest_monitor.py::test_get_pest_thresholds tests/test_guidelines.py::test_guideline_summary_no_stage tests/test_dataset_catalog.py::test_list_dataset_info_by_category tests/test_environment_guidelines.py::test_get_environment_guidelines_dataclass -q`

------
https://chatgpt.com/codex/tasks/task_e_6887721716e0833085b10fb0a9f3db29