### PR TITLE
Improve dataset handling and CLI

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -164,5 +164,5 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
 }

--- a/data/vpd_actions.json
+++ b/data/vpd_actions.json
@@ -1,4 +1,5 @@
 {
     "low": "Decrease humidity or increase temperature to raise VPD.",
-    "high": "Increase humidity or decrease temperature to lower VPD.",
+    "high": "Increase humidity or decrease temperature to lower VPD."
 }
+

--- a/plant_engine/datasets.py
+++ b/plant_engine/datasets.py
@@ -33,6 +33,7 @@ __all__ = [
     "list_dataset_info_by_category",
     "get_dataset_path",
     "load_dataset_file",
+    "dataset_exists",
 ]
 
 
@@ -75,8 +76,12 @@ class DatasetCatalog:
             path = base / "dataset_catalog.json"
             if not path.exists():
                 continue
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except json.JSONDecodeError:
+                # Skip malformed catalog files instead of failing on import
+                continue
             if isinstance(data, dict):
                 catalogs.update({str(k): str(v) for k, v in data.items()})
         return catalogs
@@ -204,6 +209,12 @@ def get_dataset_path(name: str) -> Path | None:
     """Return absolute path to ``name`` if found in the catalog."""
 
     return DEFAULT_CATALOG.find_path(name)
+
+
+def dataset_exists(name: str) -> bool:
+    """Return ``True`` if the dataset ``name`` is available."""
+
+    return get_dataset_path(name) is not None
 
 
 def load_dataset_file(name: str) -> object | None:

--- a/scripts/dataset_info.py
+++ b/scripts/dataset_info.py
@@ -20,6 +20,8 @@ from plant_engine.datasets import (
     list_datasets_by_category,
     list_dataset_info_by_category,
     search_datasets,
+    get_dataset_description,
+    dataset_exists,
 )
 
 
@@ -43,6 +45,9 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="include dataset descriptions in output",
     )
+
+    desc_parser = sub.add_parser("describe", help="show dataset description")
+    desc_parser.add_argument("name", help="dataset name")
 
     args = parser.parse_args(argv)
 
@@ -77,6 +82,14 @@ def main(argv: list[str] | None = None) -> None:
                 print(f"[{cat}]")
                 for name in names:
                     print(f"  {name}")
+        return
+
+    if args.command == "describe":
+        if not dataset_exists(args.name):
+            print("Dataset not found", file=sys.stderr)
+            raise SystemExit(1)
+        desc = get_dataset_description(args.name) or ""
+        print(desc)
         return
 
 

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -132,3 +132,8 @@ def test_get_dataset_path_and_load():
     assert path and path.exists()
     data = datasets.load_dataset_file("nutrient_guidelines.json")
     assert isinstance(data, dict)
+
+
+def test_dataset_exists():
+    assert datasets.dataset_exists("nutrient_guidelines.json")
+    assert not datasets.dataset_exists("does_not_exist.json")

--- a/tests/test_dataset_info_script.py
+++ b/tests/test_dataset_info_script.py
@@ -37,3 +37,22 @@ def test_categories_cli():
     out = result.stdout
     assert "[fertilizers]" in out
     assert "fertilizers/fertilizer_products.json" in out
+
+
+def test_describe_cli():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "describe", "nutrient_guidelines.json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "macronutrient" in result.stdout.lower()
+
+
+def test_describe_cli_missing():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "describe", "missing.json"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- clean up trailing commas in `data/` JSON files
- handle malformed JSON in `DatasetCatalog`
- expose `dataset_exists()` helper
- add `describe` subcommand to `dataset_info` script
- test CLI and dataset helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688771d2be508330bfd145837b886a67