### PR TITLE
Enhance pest management data

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -18,6 +18,7 @@
     "pest_monitoring_intervals.json": "Recommended days between scouting events.",
     "pest_risk_interval_modifiers.json": "Multipliers adjusting monitoring frequency based on risk level.",
     "pest_scouting_methods.json": "Recommended scouting techniques for common pests.",
+    "pest_lifecycle_durations.json": "Typical development duration for common pest life stages.",
     "ipm_guidelines.json": "Integrated pest management practices by crop.",
     "disease_guidelines.json": "Treatment guidance for common plant diseases.",
     "disease_prevention.json": "Preventative measures to reduce disease incidence.",

--- a/data/pest_lifecycle_durations.json
+++ b/data/pest_lifecycle_durations.json
@@ -1,0 +1,5 @@
+{
+  "aphids": {"egg": 3, "nymph": 7, "adult": 10},
+  "thrips": {"egg": 2, "larva": 4, "pupa": 2, "adult": 30},
+  "whiteflies": {"egg": 4, "nymph": 7, "pupa": 3, "adult": 7}
+}

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -137,3 +137,17 @@ def test_build_pest_management_plan_includes_organic():
 def test_build_pest_management_plan_includes_scientific_name():
     plan = build_pest_management_plan("citrus", ["aphids"])
     assert plan["aphids"]["scientific_name"] == "Aphidoidea"
+
+
+def test_get_pest_lifecycle():
+    from plant_engine.pest_manager import get_pest_lifecycle
+
+    data = get_pest_lifecycle("aphids")
+    assert data["egg"] == 3
+    assert data["adult"] == 10
+
+
+def test_build_pest_management_plan_includes_lifecycle():
+    plan = build_pest_management_plan("citrus", ["aphids"])
+    assert "lifecycle" in plan["aphids"]
+    assert plan["aphids"]["lifecycle"]["egg"] == 3


### PR DESCRIPTION
## Summary
- add `pest_lifecycle_durations.json` dataset
- wire lifecycle dataset into `pest_manager`
- expose `get_pest_lifecycle` helper and include lifecycle info in pest plans
- document dataset in `dataset_catalog.json`
- test lifecycle helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_pest_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688771f3e560833089801852ee7fece8