### PR TITLE
Improve nutrient tracking utilities

### DIFF
--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -163,7 +163,7 @@ def apply_loss_factors(schedule: Mapping[str, float], plant_type: str) -> Dict[s
     adjusted: Dict[str, float] = {}
     for fert, grams in schedule.items():
         factor = factors.get(fert, 0.0)
-    adjusted[fert] = round(grams * (1.0 + factor), 3)
+        adjusted[fert] = round(grams * (1.0 + factor), 3)
     return adjusted
 
 
@@ -226,6 +226,7 @@ def recommend_loss_adjusted_fertigation(
     purity_overrides: Mapping[str, float] | None = None,
     include_micro: bool = False,
     micro_fertilizers: Mapping[str, str] | None = None,
+    use_synergy: bool = False,
 ) -> tuple[
     Dict[str, float],
     float,


### PR DESCRIPTION
## Summary
- add fertilizer dataset loader and daily totals to nutrient tracker
- fix fertigation loss calculation indent and expose use_synergy
- test nutrient tracker integration with fertilizer dataset

## Testing
- `pytest tests/test_nutrient_tracker.py -k test_summarize_daily_totals_and_dataset_registration -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878d6bb7848330a53cd36183dbb1a1