### PR TITLE
Enhance pest monitoring

### DIFF
--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -65,6 +65,7 @@ __all__ = [
     "get_scouting_method",
     "get_severity_action",
     "get_severity_thresholds",
+    "calculate_pest_management_index",
     "get_monitoring_interval",
     "risk_adjusted_monitor_interval",
     "next_monitor_date",
@@ -324,6 +325,25 @@ def estimate_adjusted_pest_risk(
     if not risk:
         return {}
     return adjust_risk_with_resistance(plant_type, risk)
+
+
+def calculate_pest_management_index(
+    plant_type: str,
+    observations: Mapping[str, int],
+    environment: Mapping[str, float] | None = None,
+) -> float:
+    """Return 0-100 index combining pressure and environmental risk."""
+
+    pressure = calculate_pest_pressure_index(plant_type, observations)
+    if environment is None:
+        return pressure
+
+    risk = estimate_adjusted_pest_risk(plant_type, environment)
+    if not risk:
+        return pressure
+    risk_score = calculate_risk_score(risk)
+    risk_index = (risk_score / 3.0) * 100 if risk_score else 0.0
+    return round((pressure + risk_index) / 2, 1)
 
 
 def classify_pest_severity(

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -19,6 +19,7 @@ from plant_engine.pest_monitor import (
     get_scouting_method,
     get_severity_thresholds,
     summarize_pest_management,
+    calculate_pest_management_index,
 )
 
 
@@ -201,4 +202,13 @@ def test_generate_detailed_monitoring_schedule():
     entry = plan[0]
     assert entry["date"] == date(2023, 1, 4)
     assert "aphids" in entry["methods"]
+
+
+def test_calculate_pest_management_index():
+    obs = {"aphids": 6}
+    env = {"temperature": 26, "humidity": 80}
+    idx = calculate_pest_management_index("citrus", obs, env)
+    assert 66 <= idx <= 67
+    base = calculate_pest_pressure_index("citrus", obs)
+    assert calculate_pest_management_index("citrus", obs) == base
 


### PR DESCRIPTION
## Summary
- add `calculate_pest_management_index` helper
- test pest management index calculation

## Testing
- `pytest -k pest_monitor -q`
- `pytest tests/test_pest_monitor.py::test_calculate_pest_management_index -q`


------
https://chatgpt.com/codex/tasks/task_e_68878d7d885c8330a0cf2aaea2bdfd3e