### PR TITLE
Improve environment optimization with light ratio

### DIFF
--- a/data/light_spectrum_guidelines.json
+++ b/data/light_spectrum_guidelines.json
@@ -10,5 +10,10 @@
   "citrus": {
     "vegetative": {"red": 0.5, "blue": 0.5},
     "fruiting": {"red": 0.55, "blue": 0.45}
+  },
+  "tomato": {
+    "seedling": {"red": 0.55, "blue": 0.45},
+    "vegetative": {"red": 0.6, "blue": 0.4},
+    "fruiting": {"red": 0.65, "blue": 0.35}
   }
 }

--- a/plant_engine/fertigation.py
+++ b/plant_engine/fertigation.py
@@ -163,7 +163,7 @@ def apply_loss_factors(schedule: Mapping[str, float], plant_type: str) -> Dict[s
     adjusted: Dict[str, float] = {}
     for fert, grams in schedule.items():
         factor = factors.get(fert, 0.0)
-    adjusted[fert] = round(grams * (1.0 + factor), 3)
+        adjusted[fert] = round(grams * (1.0 + factor), 3)
     return adjusted
 
 
@@ -226,6 +226,7 @@ def recommend_loss_adjusted_fertigation(
     purity_overrides: Mapping[str, float] | None = None,
     include_micro: bool = False,
     micro_fertilizers: Mapping[str, str] | None = None,
+    use_synergy: bool = False,
 ) -> tuple[
     Dict[str, float],
     float,

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -24,6 +24,7 @@ from plant_engine.environment_manager import (
     get_target_vpd,
     get_target_photoperiod,
     get_target_co2,
+    get_target_light_ratio,
     calculate_co2_injection,
     recommend_co2_injection,
     get_co2_price,
@@ -259,6 +260,7 @@ def test_optimize_environment():
     assert result["photoperiod_hours"] is None
     assert result["target_photoperiod"] == (16, 18)
     assert result["target_co2"] == (400, 600)
+    assert result["target_light_ratio"] is None
 
     result2 = optimize_environment(
         {"temp_c": 18, "humidity_pct": 90, "ph": 7.2},
@@ -271,6 +273,7 @@ def test_optimize_environment():
     assert result2["photoperiod_hours"] is None
     assert result2["target_vpd"] == (0.6, 0.8)
     assert result2["target_co2"] == (400, 600)
+    assert result2["target_light_ratio"] is None
 
 
 def test_optimize_environment_with_dli():
@@ -285,6 +288,7 @@ def test_optimize_environment_with_dli():
     assert result["photoperiod_hours"] == expected_hours
     assert result["target_photoperiod"] == (18, 20)
     assert result["target_co2"] == (400, 600)
+    assert result["target_light_ratio"] == 1.22
 
 
 def test_optimize_environment_aliases():
@@ -460,6 +464,11 @@ def test_get_target_photoperiod():
 def test_get_target_co2():
     assert get_target_co2("citrus", "seedling") == (400, 600)
     assert get_target_co2("unknown") is None
+
+
+def test_get_target_light_ratio():
+    assert get_target_light_ratio("lettuce", "seedling") == 0.67
+    assert get_target_light_ratio("unknown", "seedling") is None
 
 
 def test_calculate_co2_injection():


### PR DESCRIPTION
## Summary
- integrate light spectrum ratios into environment optimization
- add tomato spectrum data
- fix fertigation loss factor function
- test new light ratio helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878d798c988330807c028d08908e21