### PR TITLE
Add light intensity helper

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -330,6 +330,7 @@ __all__ = [
     "get_target_vpd",
     "get_target_photoperiod",
     "get_target_co2",
+    "get_target_light_intensity",
     "get_target_light_ratio",
     "get_target_soil_moisture",
     "get_target_soil_temperature",
@@ -1926,6 +1927,23 @@ def get_target_photoperiod(
 ) -> tuple[float, float] | None:
     """Return recommended photoperiod range for a plant stage."""
     return _lookup_range(_PHOTOPERIOD_DATA, plant_type, stage)
+
+
+def get_target_light_intensity(
+    plant_type: str, stage: str | None = None
+) -> tuple[float, float] | None:
+    """Return recommended light intensity (PPFD) for a plant stage."""
+
+    data = _lookup_stage_data(_DATA, plant_type, stage)
+    if not isinstance(data, Mapping):
+        return None
+    vals = data.get("light_ppfd")
+    if isinstance(vals, (list, tuple)) and len(vals) == 2:
+        try:
+            return float(vals[0]), float(vals[1])
+        except (TypeError, ValueError):
+            return None
+    return None
 
 
 def get_target_co2(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -24,6 +24,7 @@ from plant_engine.environment_manager import (
     get_target_vpd,
     get_target_photoperiod,
     get_target_co2,
+    get_target_light_intensity,
     get_target_light_ratio,
     calculate_co2_injection,
     recommend_co2_injection,
@@ -469,6 +470,11 @@ def test_get_target_co2():
 def test_get_target_light_ratio():
     assert get_target_light_ratio("lettuce", "seedling") == 0.67
     assert get_target_light_ratio("unknown", "seedling") is None
+
+
+def test_get_target_light_intensity():
+    assert get_target_light_intensity("citrus", "seedling") == (150, 300)
+    assert get_target_light_intensity("unknown") is None
 
 
 def test_calculate_co2_injection():


### PR DESCRIPTION
## Summary
- expose plant-specific light intensity ranges via `get_target_light_intensity`
- cover new helper in `tests/test_environment_manager.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7b5e32883309b40663d88444a98