### PR TITLE
Add growth stage image dataset and accessor

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -168,5 +168,6 @@
     "species_cation_profiles.json": "Relative cation extraction multipliers by species.",
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
-    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone."
+    "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
+    "growth_stage_images.json": "Example images illustrating each growth stage."
 }

--- a/data/growth_stage_images.json
+++ b/data/growth_stage_images.json
@@ -1,0 +1,13 @@
+{
+  "tomato": {
+    "seedling": "https://example.com/tomato_seedling.jpg",
+    "vegetative": "https://example.com/tomato_vegetative.jpg",
+    "flowering": "https://example.com/tomato_flowering.jpg",
+    "fruiting": "https://example.com/tomato_fruiting.jpg"
+  },
+  "basil": {
+    "seedling": "https://example.com/basil_seedling.jpg",
+    "vegetative": "https://example.com/basil_vegetative.jpg",
+    "harvest": "https://example.com/basil_harvest.jpg"
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -29,13 +29,17 @@ from .precipitation_risk import (
     estimate_precipitation_risk,
 )
 
+_MODULE_ALL = (
+    utils.__all__
+    + environment_tips.__all__
+    + media_manager.__all__
+    + ingredients.__all__
+)
+
 __all__ = sorted(
-    set(utils.__all__)
-    | set(environment_tips.__all__)
-    | set(media_manager.__all__)
-    | set(ingredients.__all__)
-    | {"load_reference_data"}
+    set(_MODULE_ALL)
     | {
+        "load_reference_data",
         "NutrientManagementReport",
         "generate_nutrient_management_report",
         "list_synergy_pairs",
@@ -50,21 +54,16 @@ __all__ = sorted(
 )
 
 
+_LAZY_MODULES = {
+    "nutrient_diffusion",
+    "phenology",
+    "thermal_time",
+}
+
+
 def __getattr__(name: str):
-    if name == "nutrient_diffusion":
-        module = import_module(".nutrient_diffusion", __name__)
-        globals()[name] = module
-        __all__.append(name)
-        __all__.extend(getattr(module, "__all__", []))
-        return module
-    if name == "phenology":
-        module = import_module(".phenology", __name__)
-        globals()[name] = module
-        __all__.append(name)
-        __all__.extend(getattr(module, "__all__", []))
-        return module
-    if name == "thermal_time":
-        module = import_module(".thermal_time", __name__)
+    if name in _LAZY_MODULES:
+        module = import_module(f".{name}", __name__)
         globals()[name] = module
         __all__.append(name)
         __all__.extend(getattr(module, "__all__", []))

--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -15,6 +15,7 @@ GERMINATION_FILE = "germination_duration.json"
 # Load growth stage dataset once. ``load_dataset`` handles caching.
 _DATA: Dict[str, Dict[str, Any]] = load_dataset(DATA_FILE)
 _GERMINATION: Dict[str, int] = load_dataset(GERMINATION_FILE)
+_IMAGES: Dict[str, Dict[str, str]] = load_dataset("growth_stage_images.json")
 
 # Precompute cumulative stage end days for quick lookups
 _STAGE_BOUNDS: Dict[str, List[Tuple[str, int]]] = {}
@@ -50,6 +51,7 @@ __all__ = [
     "growth_stage_summary",
     "stage_bounds",
     "generate_stage_schedule",
+    "get_stage_image",
 ]
 
 
@@ -250,6 +252,14 @@ def get_germination_duration(plant_type: str) -> int | None:
     if isinstance(value, (int, float)):
         return int(value)
     return None
+
+
+def get_stage_image(plant_type: str, stage: str) -> str | None:
+    """Return example image URL for ``plant_type`` and ``stage`` if available."""
+
+    plant = _IMAGES.get(normalize_key(plant_type), {})
+    value = plant.get(normalize_key(stage))
+    return str(value) if isinstance(value, str) else None
 
 
 def growth_stage_summary(

--- a/tests/test_growth_stage_images.py
+++ b/tests/test_growth_stage_images.py
@@ -1,0 +1,10 @@
+from plant_engine.growth_stage import get_stage_image
+
+
+def test_get_stage_image_known():
+    url = get_stage_image("tomato", "seedling")
+    assert url.startswith("https://")
+
+
+def test_get_stage_image_unknown():
+    assert get_stage_image("unknown", "seedling") is None


### PR DESCRIPTION
## Summary
- add new `growth_stage_images.json` dataset
- expose `get_stage_image` helper in `growth_stage`
- register new dataset in `dataset_catalog.json`
- refactor lazy module loading in `plant_engine.__init__`
- test the new helper

## Testing
- `pytest tests/test_growth_stage_images.py -q`
- `pytest tests/test_dataset_info.py::test_list_dataset_info_contains_descriptions -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7864fdc8330aea702dfd979fb04