### PR TITLE
Add crop profit estimation CLI

### DIFF
--- a/scripts/estimate_profit.py
+++ b/scripts/estimate_profit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Estimate crop profit using yield records and market prices."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.profit_estimator import estimate_profit, estimate_expected_profit
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Estimate crop profit")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    actual = sub.add_parser("actual", help="Profit from recorded yield")
+    actual.add_argument("plant_id", help="Plant identifier")
+    actual.add_argument("plant_type", help="Crop type")
+    actual.add_argument(
+        "--cost", action="append", type=float, default=[], help="Additional cost"
+    )
+
+    exp = sub.add_parser("expected", help="Profit from yield estimate")
+    exp.add_argument("plant_type", help="Crop type")
+    exp.add_argument(
+        "--extra-cost", action="append", type=float, default=[], help="Extra cost"
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "actual":
+        costs = {f"extra_{i+1}": c for i, c in enumerate(args.cost)}
+        profit = estimate_profit(args.plant_id, args.plant_type, costs)
+        print(profit)
+        return
+
+    if args.cmd == "expected":
+        extras = {f"extra_{i+1}": c for i, c in enumerate(args.extra_cost)}
+        profit = estimate_expected_profit(args.plant_type, extras)
+        print("unknown" if profit is None else profit)
+        return
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_estimate_profit_script.py
+++ b/tests/test_estimate_profit_script.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import subprocess
+import sys
+import json
+import os
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/estimate_profit.py"
+
+
+def test_expected_profit_cli(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "crop_market_prices.json").write_text('{"lettuce": 3}')
+    (data_dir / "crop_production_costs.json").write_text('{"lettuce": 1}')
+    (data_dir / "yield_estimates.json").write_text('{"lettuce": 1000}')
+
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "expected", "lettuce"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "2.0"
+
+
+def test_actual_profit_cli(tmp_path):
+    from plant_engine import yield_manager
+
+    yield_manager.YIELD_DIR = str(tmp_path)
+    yield_manager.record_harvest("profitplant", grams=1000)
+    env = os.environ.copy()
+    env["HORTICULTURE_YIELD_DIR"] = str(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "actual",
+            "profitplant",
+            "lettuce",
+            "--cost",
+            "0.5",
+            "--cost",
+            "0.3",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    assert result.stdout.strip() == "2.2"


### PR DESCRIPTION
## Summary
- add `estimate_profit.py` CLI for profit calculations
- test profit CLI for expected and actual yield cases

## Testing
- `pytest tests/test_estimate_profit_script.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7842a3c83308c5e83b4f35ce04f