### PR TITLE
Add cycle progress utilities

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -42,10 +42,12 @@ __all__ = [
     "predict_harvest_date",
     "get_total_cycle_duration",
     "stage_progress",
+    "cycle_progress",
     "days_until_harvest",
     "predict_next_stage_date",
     "predict_stage_end_date",
     "stage_progress_from_dates",
+    "cycle_progress_from_dates",
     "get_germination_duration",
     "growth_stage_summary",
     "stage_bounds",
@@ -149,6 +151,18 @@ def stage_progress(plant_type: str, stage: str, days_elapsed: int) -> float | No
     return round(progress * 100, 1)
 
 
+def cycle_progress(plant_type: str, days_since_start: int) -> float | None:
+    """Return percent completion of the entire growth cycle."""
+
+    total = get_total_cycle_duration(plant_type)
+    if total is None:
+        return None
+    if days_since_start < 0:
+        raise ValueError("days_since_start must be non-negative")
+    progress = min(max(days_since_start / total, 0.0), 1.0)
+    return round(progress * 100, 1)
+
+
 def days_until_harvest(
     plant_type: str, start_date: date, current_date: date
 ) -> int | None:
@@ -210,6 +224,17 @@ def stage_progress_from_dates(
         raise ValueError("current_date cannot be before start_date")
     days = (current_date - start_date).days
     return stage_progress(plant_type, stage, days)
+
+
+def cycle_progress_from_dates(
+    plant_type: str, start_date: date, current_date: date
+) -> float | None:
+    """Return completion percent of the entire growth cycle based on dates."""
+
+    if current_date < start_date:
+        raise ValueError("current_date cannot be before start_date")
+    days = (current_date - start_date).days
+    return cycle_progress(plant_type, days)
 
 
 def days_until_next_stage(

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -14,6 +14,8 @@ from plant_engine.growth_stage import (
     predict_next_stage_date,
     predict_stage_end_date,
     stage_progress_from_dates,
+    cycle_progress,
+    cycle_progress_from_dates,
     get_germination_duration,
     days_until_next_stage,
     growth_stage_summary,
@@ -169,5 +171,21 @@ def test_generate_stage_schedule():
     assert schedule[0]["end_date"] == date(2025, 1, 31)
     assert schedule[-1]["stage"] == "fruiting"
     assert schedule[-1]["end_date"] == date(2025, 5, 1)
+
+
+def test_cycle_progress():
+    assert cycle_progress("tomato", 60) == 50.0
+    assert cycle_progress("tomato", 200) == 100.0
+    assert cycle_progress("unknown", 10) is None
+    with pytest.raises(ValueError):
+        cycle_progress("tomato", -1)
+
+
+def test_cycle_progress_from_dates():
+    start = date(2025, 1, 1)
+    current = date(2025, 3, 2)  # 60 days later
+    assert cycle_progress_from_dates("tomato", start, current) == 50.0
+    with pytest.raises(ValueError):
+        cycle_progress_from_dates("tomato", current, start)
 
 


### PR DESCRIPTION
## Summary
- expose new `cycle_progress` helpers in growth stage module
- track overall cycle progress percentages
- test new helpers in growth stage tests

## Testing
- `pytest -q tests/test_growth_stage.py::test_cycle_progress tests/test_growth_stage.py::test_cycle_progress_from_dates`
- `pytest -q tests/test_growth_stage.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c781db2c8330aec8d40aaaacf13d