### PR TITLE
Improve soil pH handling

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -105,6 +105,7 @@
     "solution_temperature_guidelines.json": "Recommended nutrient solution temperature ranges.",
     "dissolved_oxygen_guidelines.json": "Recommended dissolved oxygen ppm for nutrient solutions.",
     "soil_ec_guidelines.json": "Recommended soil salinity EC ranges for common crops.",
+    "soil_ph_guidelines.json": "Recommended soil pH ranges by crop.",
     "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
     "wind_actions.json": "Recommended actions for high wind speeds.",
     "yield_estimates.json": "Expected total yields for common cultivars.",

--- a/plant_engine/ph_manager.py
+++ b/plant_engine/ph_manager.py
@@ -31,6 +31,7 @@ __all__ = [
     "recommended_ph_for_medium",
     "get_soil_ph_range",
     "recommend_soil_ph_adjustment",
+    "classify_soil_ph",
 ]
 
 
@@ -243,3 +244,19 @@ def recommend_soil_ph_adjustment(current_ph: float, plant_type: str) -> str | No
     if current_ph > high:
         return "decrease"
     return None
+
+
+def classify_soil_ph(current_ph: float, plant_type: str) -> str | None:
+    """Return 'low', 'optimal' or 'high' classification for soil pH."""
+
+    if current_ph <= 0:
+        raise ValueError("current_ph must be positive")
+    rng = get_soil_ph_range(plant_type)
+    if not rng:
+        return None
+    low, high = rng
+    if current_ph < low:
+        return "low"
+    if current_ph > high:
+        return "high"
+    return "optimal"

--- a/tests/test_ph_manager.py
+++ b/tests/test_ph_manager.py
@@ -80,3 +80,10 @@ def test_soil_ph_functions():
     assert ph_manager.recommend_soil_ph_adjustment(7.2, "citrus") == "decrease"
     assert ph_manager.recommend_soil_ph_adjustment(6.5, "citrus") is None
     assert ph_manager.get_soil_ph_range("unknown") == []
+
+
+def test_classify_soil_ph():
+    assert ph_manager.classify_soil_ph(5.5, "citrus") == "low"
+    assert ph_manager.classify_soil_ph(7.2, "citrus") == "high"
+    assert ph_manager.classify_soil_ph(6.5, "citrus") == "optimal"
+    assert ph_manager.classify_soil_ph(6.5, "unknown") is None


### PR DESCRIPTION
## Summary
- document soil_pH_guidelines dataset
- add `classify_soil_ph` helper
- test soil pH classification logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c77fd6208330806395da5e941669