### PR TITLE
Enhance fertilizer inventory stats

### DIFF
--- a/custom_components/horticulture_assistant/utils/fertilizer_inventory.py
+++ b/custom_components/horticulture_assistant/utils/fertilizer_inventory.py
@@ -78,6 +78,23 @@ class FertilizerProduct:
     def needs_temp_protection(self, current_temp: float) -> bool:
         return any(current_temp < 5 or current_temp > 30 for _ in self.temp_sensitive_ingredients)
 
+    def average_price_per_unit(self) -> float | None:
+        """Return the mean unit price from ``price_history`` if available."""
+
+        if not self.price_history:
+            return None
+        total = sum(p.unit_price for p in self.price_history)
+        return round(total / len(self.price_history), 2)
+
+    def total_usage(self, unit: str | None = None) -> float:
+        """Return cumulative amount used optionally filtered by ``unit``."""
+
+        total = 0.0
+        for record in self.usage_log:
+            if unit is None or record.unit == unit:
+                total += record.amount_used
+        return round(total, 3)
+
 
 @dataclass
 class FertilizerInventory:

--- a/tests/test_fertilizer_inventory.py
+++ b/tests/test_fertilizer_inventory.py
@@ -38,9 +38,12 @@ def test_product_price_and_usage():
     product.add_price_entry("B", 2.0, "1kg")
     latest = product.get_latest_price()
     assert latest.vendor == "B"
+    assert product.average_price_per_unit() == 1.5
 
     product.log_usage(100, "g", "GH1")
-    assert len(product.usage_log) == 1
+    product.log_usage(50, "g", "GH1")
+    assert len(product.usage_log) == 2
     assert not product.is_expired()
+    assert product.total_usage() == 150
 
 


### PR DESCRIPTION
## Summary
- add `average_price_per_unit` and `total_usage` helpers for fertilizer stats
- cover new helpers in `test_fertilizer_inventory`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c77c00208330adea8ea06efedab7