### PR TITLE
Improve transpiration helper

### DIFF
--- a/tests/test_compute_transpiration.py
+++ b/tests/test_compute_transpiration.py
@@ -105,3 +105,10 @@ def test_compute_transpiration_dataframe():
     ]
     assert len(result) == 2
     assert result.iloc[0]["transpiration_ml_day"] > 0
+
+
+def test_compute_transpiration_alias_support():
+    profile = {"plant_type": "lettuce", "stage": "vegetative", "canopy_m2": 0.25}
+    env = {"temperature": 25, "humidity": 50, "par": 400}
+    result = compute_transpiration(profile, env)
+    assert result["transpiration_ml_day"] > 0


### PR DESCRIPTION
## Summary
- normalize aliases in `compute_transpiration`
- test that alias names are supported

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c7762c608330a1bf3c0f3bd1f342