### PR TITLE
Improve lighting recommendations

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -58,6 +58,7 @@
     "fertilizer_solubility.json": "Solubility limits for common fertilizers.",
     "light_spectrum_guidelines.json": "Recommended red/blue light ratios for growth stages.",
     "light_efficiency.json": "Photon efficiency (μmol/J) for common lighting types.",
+    "light_saturation_ppfd.json": "Recommended PPFD where additional light no longer boosts growth.",
     "foliar_feed_guidelines.json": "Target ppm for foliar nutrient applications.",
     "foliar_feed_intervals.json": "Recommended days between foliar feed applications.",
     "foliar_spray_volume.json": "Recommended foliar spray volume per plant in mL.",

--- a/data/light_saturation_ppfd.json
+++ b/data/light_saturation_ppfd.json
@@ -1,0 +1,5 @@
+{
+  "tomato": 900,
+  "lettuce": 600,
+  "citrus": 1000
+}

--- a/plant_engine/light_saturation.py
+++ b/plant_engine/light_saturation.py
@@ -1,0 +1,55 @@
+"""Light saturation utilities."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, list_dataset_entries, normalize_key
+from .environment_manager import calculate_dli, photoperiod_for_target_dli
+
+DATA_FILE = "light_saturation_ppfd.json"
+
+_DATA: Dict[str, float] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_saturation_ppfd", "recommend_supplemental_hours"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with saturation data available."""
+    return list_dataset_entries(_DATA)
+
+
+def get_saturation_ppfd(plant_type: str) -> float | None:
+    """Return saturation PPFD for ``plant_type`` if defined."""
+    val = _DATA.get(normalize_key(plant_type))
+    try:
+        return float(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def recommend_supplemental_hours(
+    plant_type: str,
+    current_ppfd: float,
+    photoperiod_hours: float,
+) -> float | None:
+    """Return additional hours at saturation intensity to reach the target DLI.
+
+    ``current_ppfd`` is the average intensity currently provided over
+    ``photoperiod_hours`` hours. If the existing DLI meets or exceeds the
+    saturation DLI, ``0.0`` is returned. ``None`` is returned when saturation
+    data is missing or inputs are invalid.
+    """
+    if current_ppfd < 0 or photoperiod_hours <= 0:
+        return None
+
+    sat = get_saturation_ppfd(plant_type)
+    if sat is None or sat <= 0:
+        return None
+
+    target_dli = calculate_dli(sat, photoperiod_hours)
+    current_dli = calculate_dli(current_ppfd, photoperiod_hours)
+    if current_dli >= target_dli:
+        return 0.0
+
+    remaining_dli = target_dli - current_dli
+    return photoperiod_for_target_dli(remaining_dli, sat)

--- a/tests/test_light_saturation.py
+++ b/tests/test_light_saturation.py
@@ -1,0 +1,34 @@
+from plant_engine.light_saturation import (
+    list_supported_plants,
+    get_saturation_ppfd,
+    recommend_supplemental_hours,
+)
+from plant_engine.environment_manager import calculate_dli
+
+
+def test_get_saturation_ppfd():
+    plants = list_supported_plants()
+    assert "tomato" in plants
+    assert get_saturation_ppfd("tomato") == 900
+    assert get_saturation_ppfd("unknown") is None
+
+
+def test_recommend_supplemental_hours():
+    # Tomato saturation 900 ppfd with 12h photoperiod
+    current_ppfd = 500
+    photoperiod = 12
+    hours = recommend_supplemental_hours("tomato", current_ppfd, photoperiod)
+    target_dli = calculate_dli(900, photoperiod)
+    current_dli = calculate_dli(current_ppfd, photoperiod)
+    remaining = target_dli - current_dli
+    expected = round(remaining * 1_000_000 / (900 * 3600), 2)
+    assert hours == expected
+
+    # Already at saturation
+    assert recommend_supplemental_hours("tomato", 900, 12) == 0.0
+
+    # Invalid input returns None
+    assert recommend_supplemental_hours("unknown", 500, 12) is None
+    assert recommend_supplemental_hours("tomato", -1, 12) is None
+    assert recommend_supplemental_hours("tomato", 500, 0) is None
+


### PR DESCRIPTION
## Summary
- add `light_saturation_ppfd.json` dataset and catalog entry
- implement `plant_engine.light_saturation` utilities
- provide unit tests covering new functionality

## Testing
- `pytest tests/test_light_saturation.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c7714d8083309bcc6df0241ce9bf