### PR TITLE
Add recovery factor helper

### DIFF
--- a/tests/test_nutrient_recovery.py
+++ b/tests/test_nutrient_recovery.py
@@ -1,5 +1,6 @@
 from plant_engine.nutrient_recovery import (
     get_recovery_factor,
+    get_recovery_factors,
     estimate_recovered_amounts,
     adjust_for_recovery,
 )
@@ -13,6 +14,12 @@ def test_get_recovery_factor_override():
     assert get_recovery_factor("N", "tomato") == 0.6
 
 
+def test_get_recovery_factors():
+    factors = get_recovery_factors("tomato")
+    assert factors["N"] == 0.6
+    assert factors["P"] == 0.35
+
+
 def test_estimate_recovered_amounts():
     recovered = estimate_recovered_amounts({"P": 100}, "lettuce")
     assert recovered == {"P": 30.0}
@@ -21,3 +28,4 @@ def test_estimate_recovered_amounts():
 def test_adjust_for_recovery():
     adjusted = adjust_for_recovery({"K": 100})
     assert adjusted == {"K": 40.0}
+


### PR DESCRIPTION
## Summary
- expose `get_recovery_factors` helper for nutrient recovery factors
- test recovery factor helper
- docs for nutrient recovery module

## Testing
- `pytest tests/test_nutrient_recovery.py -q`
- `pytest tests/test_drought_manager.py tests/test_ph_manager.py -q`
- `pytest tests/test_irrigation_manager.py tests/test_environment_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c76fad2c83308d24699f7d040e61