### PR TITLE
Enhance environment metrics with root temperature factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 - Cost-optimized fertigation plans with injection volumes
 - Risk-adjusted pest monitoring summaries and scheduling
 - Automatic pesticide rotation planning
+- Root uptake factor calculation from soil temperature
 - Summaries of reentry and harvest restrictions for applied pesticides
 - Automated fertigation planning with cost estimates
 - Yield-based revenue and profit projections

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -347,6 +347,24 @@ def test_environment_metrics_with_transpiration():
     assert metrics.transpiration_ml_day == 2242.5
 
 
+def test_environment_metrics_root_uptake_factor():
+    env = {
+        "temp_c": 25,
+        "humidity_pct": 50,
+        "soil_temp_c": 15,
+        "par_w_m2": 400,
+        "wind_speed_m_s": 1.0,
+    }
+    metrics = calculate_environment_metrics(
+        25,
+        50,
+        env=env,
+        plant_type="tomato",
+        stage="vegetative",
+    )
+    assert metrics.root_uptake_factor == 0.7
+
+
 def test_calculate_dli():
     dli = calculate_dli(500, 16)
     assert round(dli, 1) == 28.8


### PR DESCRIPTION
## Summary
- add root uptake factor to EnvironmentMetrics
- compute soil temperature-based uptake factor in calculate_environment_metrics
- document new capability in README
- test root temperature integration

## Testing
- `pytest tests/test_environment_manager.py::test_calculate_environment_metrics tests/test_environment_manager.py::test_environment_metrics_with_transpiration tests/test_environment_manager.py::test_environment_metrics_root_uptake_factor -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c76c29848330ada4b45e2c848a92