### PR TITLE
Enhance guidelines with plant height data

### DIFF
--- a/data/plant_height_ranges.json
+++ b/data/plant_height_ranges.json
@@ -1,0 +1,13 @@
+{
+  "tomato": {
+    "seedling": [5, 15],
+    "vegetative": [20, 60],
+    "flowering": [60, 120],
+    "fruiting": [80, 150]
+  },
+  "lettuce": {
+    "seedling": [2, 5],
+    "vegetative": [10, 25],
+    "harvest": [20, 30]
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 
 from . import utils, environment_tips, media_manager, ingredients, reference_data
+from . import height_manager
 from .reference_data import load_reference_data
 from .utils import *  # noqa: F401,F403
 from .environment_tips import *  # noqa: F401,F403
@@ -34,6 +35,7 @@ __all__ = sorted(
     | set(environment_tips.__all__)
     | set(media_manager.__all__)
     | set(ingredients.__all__)
+    | set(height_manager.__all__)
     | {"load_reference_data"}
     | {
         "NutrientManagementReport",

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -20,6 +20,7 @@ from . import (
     irrigation_manager,
     growth_stage,
     stage_tasks,
+    height_manager,
 )
 
 __all__ = ["GuidelineSummary", "get_guideline_summary"]
@@ -50,6 +51,7 @@ class GuidelineSummary:
     stage_info: Optional[Dict[str, Any]] = None
     stages: Optional[List[str]] = None
     stage_tasks: Dict[str, List[str]] = dataclass_field(default_factory=dict)
+    height_range: List[float] | None = None
 
     def as_dict(self) -> Dict[str, Any]:
         """Return guidelines as a regular dictionary."""
@@ -78,6 +80,8 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
 
     inoculants = bioinoculant_manager.get_recommended_inoculants(plant_type)
     details = {name: bioinoculant_info.get_inoculant_info(name) for name in inoculants}
+
+    height_rng = height_manager.get_height_range(plant_type, stage) if stage else None
 
     summary = GuidelineSummary(
         environment=environment_manager.get_environmental_targets(plant_type, stage),
@@ -111,6 +115,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
         stage_info=growth_stage.get_stage_info(plant_type, stage) if stage else None,
         stages=None if stage else growth_stage.list_growth_stages(plant_type),
         stage_tasks=tasks,
+        height_range=list(height_rng) if height_rng else None,
     )
 
     return summary.as_dict()

--- a/plant_engine/height_manager.py
+++ b/plant_engine/height_manager.py
@@ -1,0 +1,52 @@
+"""Helpers for plant height estimation based on growth stage."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, Tuple
+
+from .utils import load_dataset, normalize_key, list_dataset_entries
+
+DATA_FILE = "plant_height_ranges.json"
+
+_DATA: Dict[str, Dict[str, Tuple[float, float]]] = load_dataset(DATA_FILE)
+
+__all__ = ["list_supported_plants", "get_height_range", "estimate_height"]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with height range data."""
+    return list_dataset_entries(_DATA)
+
+
+@lru_cache(maxsize=None)
+def get_height_range(plant_type: str, stage: str) -> Tuple[float, float] | None:
+    """Return (min_cm, max_cm) height for ``plant_type`` at ``stage``."""
+    plant = _DATA.get(normalize_key(plant_type))
+    if not plant:
+        return None
+    values = plant.get(normalize_key(stage))
+    if (
+        isinstance(values, (list, tuple))
+        and len(values) == 2
+    ):
+        try:
+            low, high = float(values[0]), float(values[1])
+            return low, high
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def estimate_height(
+    plant_type: str,
+    stage: str,
+    progress_pct: float,
+) -> float | None:
+    """Return estimated plant height in centimeters."""
+    if not 0 <= progress_pct <= 100:
+        raise ValueError("progress_pct must be between 0 and 100")
+    rng = get_height_range(plant_type, stage)
+    if not rng:
+        return None
+    low, high = rng
+    return round(low + (high - low) * (progress_pct / 100.0), 1)

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -21,6 +21,7 @@ def test_get_guideline_summary():
     assert "irrigation_interval_days" in data
     # citrus has no task entries so all lists should be empty
     assert all(len(t) == 0 for t in data["stage_tasks"].values())
+    assert data["height_range"] is None
 
 
 def test_guideline_summary_no_stage():
@@ -40,3 +41,4 @@ def test_guideline_summary_bioinoculants():
     # stage tasks should include entries for the requested stage
     assert "fruiting" in data["stage_tasks"]
     assert "Maintain high potassium" in data["stage_tasks"]["fruiting"][1]
+    assert data["height_range"] == [80.0, 150.0]

--- a/tests/test_height_manager.py
+++ b/tests/test_height_manager.py
@@ -1,0 +1,21 @@
+from plant_engine.height_manager import (
+    list_supported_plants,
+    get_height_range,
+    estimate_height,
+)
+
+
+def test_get_height_range():
+    rng = get_height_range("tomato", "vegetative")
+    assert rng == (20.0, 60.0)
+
+
+def test_estimate_height():
+    assert estimate_height("tomato", "vegetative", 0) == 20.0
+    assert estimate_height("tomato", "vegetative", 50) == 40.0
+    assert estimate_height("tomato", "vegetative", 100) == 60.0
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "tomato" in plants and "lettuce" in plants


### PR DESCRIPTION
## Summary
- add dataset for height ranges by plant stage
- provide new `height_manager` utilities for estimating plant height
- expose height info through `get_guideline_summary`
- cover new code with unit tests

## Testing
- `pytest -q tests/test_height_manager.py tests/test_guidelines.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c766d0288330b14517f55398c90e