### PR TITLE
Enhance pest manager with beneficial release planning

### DIFF
--- a/data/beneficial_effective_days.json
+++ b/data/beneficial_effective_days.json
@@ -1,0 +1,8 @@
+{
+  "ladybugs": 14,
+  "lacewings": 10,
+  "encarsia formosa": 15,
+  "predatory mites": 7,
+  "parasitic wasps": 12,
+  "diglyphus isaea": 10
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -47,6 +47,7 @@
     "plant_density_guidelines.json": "Recommended plant spacing for common crops.",
     "beneficial_insects.json": "Natural predators for common greenhouse pests.",
     "beneficial_release_rates.json": "Recommended release rates of beneficial insects per m^2.",
+    "beneficial_effective_days.json": "Typical days beneficial insects remain effective after release.",
     "bioinoculant_guidelines.json": "Recommended microbial inoculants for improved nutrient uptake.",
     "bioinoculant_attributes.json": "Key attributes and usage notes for common microbial inoculants.",
     "crop_coefficients.json": "Crop coefficients for evapotranspiration models.",

--- a/tests/test_pest_manager.py
+++ b/tests/test_pest_manager.py
@@ -182,3 +182,20 @@ def test_build_monitoring_plan():
     assert plan["interval_days"] == 2
     assert plan["thresholds"]["aphids"] == 5
     assert "inspect" in plan["methods"]["aphids"].lower()
+
+
+def test_plan_beneficial_releases():
+    from datetime import date, timedelta
+    from plant_engine.pest_manager import (
+        plan_beneficial_releases,
+        get_beneficial_effective_days,
+    )
+
+    start = date(2024, 1, 1)
+    schedule = plan_beneficial_releases(["aphids"], start, cycles=2)
+    assert len(schedule) == 2
+    assert schedule[0]["date"] == start
+    insects = ["ladybugs", "lacewings"]
+    interval = min(get_beneficial_effective_days(i) for i in insects)
+    assert schedule[1]["date"] == start + timedelta(days=interval)
+    assert "ladybugs" in schedule[0]["releases"]


### PR DESCRIPTION
## Summary
- add `beneficial_effective_days.json` dataset
- document dataset in `dataset_catalog.json`
- provide `get_beneficial_effective_days` and `plan_beneficial_releases` helpers
- test new scheduling logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c76881c08330861e565484e37305