### PR TITLE
Enhance environment alias support

### DIFF
--- a/data/environment_aliases.json
+++ b/data/environment_aliases.json
@@ -1,8 +1,8 @@
 {
-  "temp_c": ["temp_c", "temperature", "temp", "temperature_c", "temp_custom"],
+  "temp_c": ["temp_c", "temperature", "temp", "temperature_c", "temp_custom", "air_temperature", "air_temp_c"],
   "temp_f": ["temp_f", "temperature_f", "temp_fahrenheit"],
   "temp_k": ["temp_k", "temperature_k", "temp_kelvin"],
-  "humidity_pct": ["humidity_pct", "humidity", "rh", "rh_pct"],
+  "humidity_pct": ["humidity_pct", "humidity", "rh", "rh_pct", "humidity_percent", "relative_humidity"],
   "light_ppfd": ["light_ppfd", "light", "par", "par_w_m2"],
   "co2_ppm": ["co2_ppm", "co2"],
   "ec": ["ec", "EC"],

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -301,6 +301,16 @@ def test_optimize_environment_aliases():
     assert result["adjustments"]["temperature"] == "increase"
 
 
+def test_optimize_environment_extended_aliases():
+    result = optimize_environment(
+        {"air_temperature": 18, "relative_humidity": 90},
+        "citrus",
+        "seedling",
+    )
+    assert result["setpoints"]["temp_c"] == 24
+    assert result["adjustments"]["temperature"] == "increase"
+
+
 def test_optimize_environment_zone():
     result = optimize_environment(
         {"temp_c": 20, "humidity_pct": 70},


### PR DESCRIPTION
## Summary
- extend alias list for temperature and humidity metrics
- add tests for new environment aliases

## Testing
- `pytest tests/test_environment_manager.py::test_optimize_environment_extended_aliases -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c764c6a48330aa75ae35fa969cd6