### PR TITLE
Improve pesticide toxicity analysis

### DIFF
--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -52,6 +52,7 @@ __all__ = [
     "list_active_ingredients",
     "get_pesticide_efficacy",
     "list_effective_pesticides",
+    "estimate_mix_toxicity",
 ]
 
 
@@ -365,3 +366,21 @@ def list_effective_pesticides(pest: str) -> List[tuple[str, float]]:
         results.append((product, val))
     results.sort(key=lambda x: x[1], reverse=True)
     return results
+
+
+def estimate_mix_toxicity(products: Iterable[str]) -> str:
+    """Return overall toxicity level for a mix of pesticides."""
+
+    levels = ["low", "moderate", "high"]
+    highest = -1
+    data = _ACTIVE()
+    for product in products:
+        info = data.get(product.lower())
+        if not isinstance(info, Mapping):
+            continue
+        tox = str(info.get("toxicity", "")).lower()
+        if tox in levels:
+            idx = levels.index(tox)
+            if idx > highest:
+                highest = idx
+    return levels[highest] if highest >= 0 else "unknown"

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -208,4 +208,13 @@ def test_pesticide_efficacy_helpers():
     assert ranking[0][1] >= ranking[-1][1]
 
 
+def test_estimate_mix_toxicity():
+    from plant_engine.pesticide_manager import estimate_mix_toxicity
+
+    assert estimate_mix_toxicity(["neem_oil", "spinosad"]) == "low"
+    assert estimate_mix_toxicity(["neem_oil", "imidacloprid"]) == "moderate"
+    assert estimate_mix_toxicity(["copper_sulfate", "neem_oil"]) == "high"
+    assert estimate_mix_toxicity(["unknown"]) == "unknown"
+
+
 


### PR DESCRIPTION
## Summary
- expose `estimate_mix_toxicity` in `pesticide_manager` for evaluating pesticide combinations
- test mix toxicity helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c75ce960833097e68cf9369ebbd9