### PR TITLE
Enhance pesticide rotation features

### DIFF
--- a/data/pest_rotation_moas.json
+++ b/data/pest_rotation_moas.json
@@ -1,0 +1,6 @@
+{
+  "aphids": ["neonicotinoid", "pyrethroid", "spinosyn"],
+  "thrips": ["spinosyn", "pyrethroid"],
+  "caterpillars": ["spinosyn", "pyrethroid"],
+  "whiteflies": ["neonicotinoid", "pyrethroid"]
+}

--- a/tests/test_pesticide_rotation.py
+++ b/tests/test_pesticide_rotation.py
@@ -1,0 +1,14 @@
+from plant_engine.pesticide_manager import recommend_rotation_products
+
+
+def test_rotation_for_known_pest():
+    assert recommend_rotation_products("aphids") == ["imidacloprid", "pyrethrin"]
+
+
+def test_rotation_unknown_pest():
+    assert recommend_rotation_products("unknown") == []
+
+
+def test_rotation_count_limit():
+    res = recommend_rotation_products("aphids", count=1)
+    assert res == ["imidacloprid"]


### PR DESCRIPTION
## Summary
- add new `pest_rotation_moas.json` dataset
- support pest-specific pesticide rotation recommendations
- exercise new helper with unit tests

## Testing
- `pytest -q`
- `pytest tests/test_pesticide_rotation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6887c75b8654833084ba76d56aaf3147