### PR TITLE
Improve reference data access

### DIFF
--- a/plant_engine/reference_data.py
+++ b/plant_engine/reference_data.py
@@ -5,22 +5,31 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Any, Dict
 
-from .utils import load_dataset
+from .utils import load_dataset, normalize_key
 
 # Mapping of logical keys to dataset file names used across the project.
 # Additional datasets can be appended here without altering code that
 # consumes :func:`load_reference_data` or :func:`get_reference_dataset`.
 REFERENCE_FILES: dict[str, str] = {
     "nutrient_guidelines": "nutrient_guidelines.json",
+    "micronutrient_guidelines": "micronutrient_guidelines.json",
+    "nutrient_ratio_guidelines": "nutrient_ratio_guidelines.json",
     "environment_guidelines": "environment_guidelines.json",
     "pest_guidelines": "pest_guidelines.json",
+    "pest_monitoring_intervals": "pest_monitoring_intervals.json",
     "growth_stages": "growth_stages.json",
+    "stage_tasks": "stage_tasks.json",
     # newly exposed reference datasets
     "nutrient_synergies": "nutrient_synergies.json",
     "disease_guidelines": "disease_guidelines.json",
 }
 
-__all__ = ["load_reference_data", "get_reference_dataset", "REFERENCE_FILES"]
+__all__ = [
+    "load_reference_data",
+    "get_reference_dataset",
+    "get_plant_overview",
+    "REFERENCE_FILES",
+]
 
 
 @lru_cache(maxsize=None)
@@ -44,3 +53,32 @@ def get_reference_dataset(name: str) -> Dict[str, Any]:
     """Return a specific reference dataset by ``name``."""
 
     return load_reference_data().get(name, {})
+
+
+def get_plant_overview(plant_type: str) -> Dict[str, Any]:
+    """Return consolidated reference info for ``plant_type``.
+
+    The overview includes nutrient, environment and pest guidelines along with
+    growth stage details and common tasks. Missing datasets return empty
+    mappings so callers don't need to handle ``KeyError``.
+    """
+
+    key = normalize_key(plant_type)
+    data = load_reference_data()
+
+    def entry(name: str) -> Dict[str, Any]:
+        dataset = data.get(name, {})
+        if isinstance(dataset, dict):
+            return dataset.get(key, {}) if dataset else {}
+        return {}
+
+    return {
+        "nutrients": entry("nutrient_guidelines"),
+        "micronutrients": entry("micronutrient_guidelines"),
+        "ratios": entry("nutrient_ratio_guidelines"),
+        "environment": entry("environment_guidelines"),
+        "pests": entry("pest_guidelines"),
+        "monitoring_intervals": entry("pest_monitoring_intervals"),
+        "stages": entry("growth_stages"),
+        "tasks": entry("stage_tasks"),
+    }

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -12,3 +12,10 @@ def test_get_reference_dataset():
     synergy = ref.get_reference_dataset("nutrient_synergies")
     assert isinstance(synergy, dict)
     assert "n_p" in synergy
+
+
+def test_get_plant_overview():
+    overview = ref.get_plant_overview("tomato")
+    assert "environment" in overview
+    assert "nutrients" in overview
+    assert isinstance(overview["environment"], dict)


### PR DESCRIPTION
## Summary
- expand reference datasets for richer horticulture guidance
- provide `get_plant_overview` helper to return consolidated info for a plant
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c755d36c8330a2e16e3819411781