### PR TITLE
Improve daily cycle helpers and tests

### DIFF
--- a/tests/test_run_daily_cycle_helpers.py
+++ b/tests/test_run_daily_cycle_helpers.py
@@ -5,6 +5,8 @@ from custom_components.horticulture_assistant.engine.run_daily_cycle import (
     _aggregate_nutrients,
     _average_sensor_data,
     _compute_expected_uptake,
+    _load_logs,
+    _build_root_zone_info,
 )
 
 
@@ -44,3 +46,26 @@ def test_compute_expected_uptake():
     expected, gap = _compute_expected_uptake("lettuce", "vegetative", totals)
     if expected:
         assert gap["N"] == round(expected["N"] - 30, 2)
+
+
+def test_load_logs(tmp_path):
+    pdir = tmp_path / "plant"
+    pdir.mkdir()
+    for name in (
+        "irrigation_log.json",
+        "nutrient_application_log.json",
+        "sensor_reading_log.json",
+        "water_quality_log.json",
+        "yield_tracking_log.json",
+    ):
+        (pdir / name).write_text("[]")
+
+    logs = _load_logs(pdir)
+    assert all(isinstance(v, list) for v in logs.values())
+
+
+def test_build_root_zone_info():
+    general = {"max_root_depth_cm": 40}
+    info = _build_root_zone_info(general, {"soil_moisture_pct": 50})
+    assert info["taw_ml"] > 0
+    assert info["current_moisture_pct"] == 50


### PR DESCRIPTION
## Summary
- refactor run_daily_cycle helpers into standalone functions
- expose helper methods for loading logs and root zone calculations
- cover new helpers in tests

## Testing
- `pytest tests/test_run_daily_cycle_helpers.py -q`
- `pytest tests/test_run_daily_cycle_transpiration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6887ea8ee6148330b25ccc94d3435e01