### PR TITLE
Add stage nutrient requirement utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Important categories include:
 - **Environment actions** – recommended steps when temperature or humidity are out of range
 - **Nutrient guidelines** – macronutrient and micronutrient targets by stage
 - **Total nutrient requirements** – daily NPK needs for common crops
+- **Stage nutrient requirements** – daily needs for each growth stage
 - **Pest and disease references** – thresholds, prevention tips and treatment options
 - **Fungicide recommendations** – suggested organic products for common diseases
 - **Pest scouting methods** – recommended techniques for monitoring common pests

--- a/custom_components/horticulture_assistant/utils/stage_nutrient_requirements.py
+++ b/custom_components/horticulture_assistant/utils/stage_nutrient_requirements.py
@@ -1,0 +1,63 @@
+"""Stage-based daily nutrient requirements for crops."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Mapping, Dict
+
+from plant_engine.constants import get_stage_multiplier
+from plant_engine.utils import load_dataset, normalize_key
+
+from .nutrient_requirements import get_requirements
+
+DATA_FILE = "stage_nutrient_requirements.json"
+
+
+@lru_cache(maxsize=None)
+def get_stage_requirements(plant_type: str, stage: str) -> Dict[str, float]:
+    """Return daily nutrient needs for ``plant_type`` at ``stage``.
+
+    Values are taken from :data:`DATA_FILE` when available. If a stage is
+    missing, totals from :func:`get_requirements` are scaled by the stage
+    multiplier from :func:`plant_engine.constants.get_stage_multiplier`.
+    """
+
+    data = load_dataset(DATA_FILE)
+    plant = data.get(normalize_key(plant_type))
+    if isinstance(plant, Mapping):
+        stage_data = plant.get(normalize_key(stage))
+        if isinstance(stage_data, Mapping):
+            result: Dict[str, float] = {}
+            for nutrient, value in stage_data.items():
+                try:
+                    result[nutrient] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            return result
+
+    totals = get_requirements(plant_type)
+    if not totals:
+        return {}
+
+    mult = get_stage_multiplier(stage)
+    return {n: round(v * mult, 2) for n, v in totals.items()}
+
+
+def calculate_stage_deficit(
+    current_totals: Mapping[str, float], plant_type: str, stage: str
+) -> Dict[str, float]:
+    """Return remaining nutrient amounts needed for ``stage``."""
+
+    required = get_stage_requirements(plant_type, stage)
+    deficit: Dict[str, float] = {}
+    for nutrient, target in required.items():
+        try:
+            current = float(current_totals.get(nutrient, 0.0))
+        except (TypeError, ValueError):
+            current = 0.0
+        diff = round(target - current, 2)
+        if diff > 0:
+            deficit[nutrient] = diff
+    return deficit
+
+
+__all__ = ["get_stage_requirements", "calculate_stage_deficit"]

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -29,6 +29,7 @@
     "stage_tasks.json": "Common tasks to perform during each growth stage.",
     "germination_duration.json": "Typical days from sowing to germination by crop.",
     "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",
+    "stage_nutrient_requirements.json": "Daily nutrient needs per plant stage.",
     "light_dli_guidelines.json": "Daily Light Integral targets for growth stages.",
     "vpd_guidelines.json": "Vapor pressure deficit targets for growth stages.",
     "vpd_actions.json": "Recommended actions when VPD is outside the target range.",

--- a/data/stage_nutrient_requirements.json
+++ b/data/stage_nutrient_requirements.json
@@ -1,0 +1,12 @@
+{
+  "citrus": {
+    "vegetative": {"N": 1.5, "P": 0.5, "K": 1.5},
+    "flowering": {"N": 1.2, "P": 0.4, "K": 1.4},
+    "fruiting": {"N": 1.0, "P": 0.4, "K": 1.6}
+  },
+  "tomato": {
+    "vegetative": {"N": 1.8, "P": 0.6, "K": 2.0},
+    "flowering": {"N": 1.6, "P": 0.7, "K": 2.2},
+    "fruiting": {"N": 1.4, "P": 0.6, "K": 2.4}
+  }
+}

--- a/tests/test_stage_nutrient_requirements.py
+++ b/tests/test_stage_nutrient_requirements.py
@@ -1,0 +1,22 @@
+from custom_components.horticulture_assistant.utils.stage_nutrient_requirements import (
+    get_stage_requirements,
+    calculate_stage_deficit,
+)
+
+
+def test_get_stage_requirements_fallback():
+    # stage data missing -> use totals scaled by multiplier
+    req = get_stage_requirements("citrus", "nonexistent")
+    assert req["N"] == 150 * 1.0  # multiplier defaults to 1.0
+
+
+def test_get_stage_requirements_defined():
+    req = get_stage_requirements("citrus", "vegetative")
+    assert req == {"N": 1.5, "P": 0.5, "K": 1.5}
+
+
+def test_calculate_stage_deficit():
+    deficits = calculate_stage_deficit({"N": 0.5}, "citrus", "vegetative")
+    assert deficits["N"] == 1.0
+    assert deficits["P"] == 0.5
+    assert deficits["K"] == 1.5


### PR DESCRIPTION
## Summary
- add stage nutrient requirement dataset and dataset catalog entry
- implement `stage_nutrient_requirements` helper
- test stage nutrient requirement utilities
- mention new dataset in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_nutrient_requirements.py tests/test_stage_nutrient_requirements.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ea7929ac83309ffd81feea3567ff