### PR TITLE
Enhance dataset utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Datasets can be overridden by setting environment variables:
 - `HORTICULTURE_DATA_DIR` to change the base data directory
 - `HORTICULTURE_OVERLAY_DIR` to merge in custom files
 - `HORTICULTURE_EXTRA_DATA_DIRS` to load additional datasets
-Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately.
+Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately. Use `plant_engine.utils.load_dataset_df()` to quickly load any dataset into a `pandas.DataFrame` for analysis.
 
 See [docs/custom_data_dirs.md](docs/custom_data_dirs.md) for examples of how to
 structure overlay and extra dataset directories.

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -135,6 +135,7 @@
     "fertigation_loss_factors.json": "Default nutrient loss percentages during fertigation.",
     "fertigation_volume.json": "Recommended nutrient solution volume in mL per plant per event.",
     "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
+    "fertigation_injectors.json": "Injection ratios (parts water to stock solution).",
     "companion_plants.json": "Companion planting recommendations.",
     "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
     "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -19,6 +19,7 @@ __all__ = [
     "load_dataset",
     "load_datasets",
     "lazy_dataset",
+    "load_dataset_df",
     "clear_dataset_cache",
     "dataset_paths",
     "dataset_search_paths",
@@ -282,6 +283,23 @@ def lazy_dataset(filename: str):
         return load_dataset(filename)
 
     return _loader
+
+
+def load_dataset_df(filename: str) -> "pd.DataFrame":
+    """Return dataset ``filename`` as a :class:`pandas.DataFrame`.
+
+    Dictionaries are treated as row mappings and lists as row sequences.
+    Unsupported data structures raise ``ValueError``.
+    """
+
+    import pandas as pd
+
+    data = load_dataset(filename)
+    if isinstance(data, Mapping):
+        return pd.DataFrame.from_dict(data, orient="index")
+    if isinstance(data, list):
+        return pd.DataFrame(data)
+    raise ValueError(f"Dataset {filename} is not tabular")
 
 
 @lru_cache(maxsize=None)

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -1,0 +1,27 @@
+import importlib
+import json
+import pandas as pd
+from pathlib import Path
+
+import plant_engine.utils as utils
+
+
+def test_load_dataset_df_dict(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "sample.json").write_text(json.dumps({"a": {"x": 1}, "b": {"x": 2}}))
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(utils)
+    df = utils.load_dataset_df("sample.json")
+    assert list(df.index) == ["a", "b"]
+    assert list(df.columns) == ["x"]
+
+
+def test_load_dataset_df_list(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "sample.json").write_text(json.dumps([{"a": 1}, {"a": 2}]))
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(utils)
+    df = utils.load_dataset_df("sample.json")
+    assert df.shape == (2, 1)


### PR DESCRIPTION
## Summary
- add `load_dataset_df` helper to quickly return pandas dataframes
- expose fertigation injector dataset in catalog
- document new loader usage
- test dataframe loading

## Testing
- `pytest tests/test_dataset_file.py tests/test_dataset_integrity.py tests/test_dataset_dataframe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ea6c5894833082b93c26ffc55d65