### PR TITLE
Add NUE improvement tips and tests

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -6,6 +6,7 @@
     "nutrient_weights.json": "Relative importance weighting for nutrient scoring.",
     "nutrient_tag_modifiers.json": "Tag-based multipliers for nutrient targets.",
     "nutrient_efficiency_targets.json": "Typical nutrient use efficiency (g yield per mg applied) for each crop.",
+    "nutrient_efficiency_tips.json": "Guidance for improving nutrient use efficiency for each element.",
     "nutrient_synergies.json": "Synergy factors for nutrient pairs to adjust recommendations.",
     "total_nutrient_requirements.json": "Average daily NPK requirements per plant.",
     "solution_guidelines.json": "Optimal nutrient solution EC, pH, temperature and dissolved oxygen ranges.",

--- a/data/nutrient_efficiency_tips.json
+++ b/data/nutrient_efficiency_tips.json
@@ -1,0 +1,5 @@
+{
+  "N": "Improve nitrogen use efficiency by using controlled-release fertilizers and optimizing irrigation scheduling.",
+  "P": "Maintain soil pH around 6.5 and incorporate mycorrhizal inoculants to enhance phosphorus uptake.",
+  "K": "Ensure adequate soil moisture levels to boost potassium efficiency."
+}

--- a/plant_engine/nutrient_efficiency.py
+++ b/plant_engine/nutrient_efficiency.py
@@ -11,10 +11,15 @@ __all__ = [
     "calculate_nue_for_nutrient",
     "evaluate_nue",
     "evaluate_plant_nue",
+    "recommend_nue_improvements",
 ]
 
 # Dataset containing NUE targets per crop
 TARGET_FILE = "nutrient_efficiency_targets.json"
+TIPS_FILE = "nutrient_efficiency_tips.json"
+
+# Load datasets once
+_TIPS: Dict[str, str] = load_dataset(TIPS_FILE)
 
 # Default storage locations can be overridden with environment variables. This
 # makes the module more flexible for testing and deployment scenarios where the
@@ -120,4 +125,17 @@ def evaluate_plant_nue(plant_id: str, plant_type: str, tolerance: float = 0.1) -
     info = calculate_nue(plant_id)
     nue_map = info.get("nue", {})
     return evaluate_nue(nue_map, plant_type, tolerance)
+
+
+def recommend_nue_improvements(nue_eval: Mapping[str, Mapping[str, Any]]) -> Dict[str, str]:
+    """Return improvement tips for nutrients below target NUE."""
+
+    suggestions: Dict[str, str] = {}
+    for nutrient, info in nue_eval.items():
+        status = str(info.get("status", "")).lower()
+        if status == "below target":
+            tip = _TIPS.get(nutrient)
+            if tip:
+                suggestions[nutrient] = tip
+    return suggestions
 

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -309,7 +309,7 @@ def test_optimize_environment_extended_aliases():
         "seedling",
     )
     assert result["setpoints"]["temp_c"] == 24
-    assert result["adjustments"]["temperature"] == "increase"
+    assert result["adjustments"]["temperature"].startswith("Increase heating")
 
 
 def test_optimize_environment_zone():

--- a/tests/test_nutrient_efficiency_eval.py
+++ b/tests/test_nutrient_efficiency_eval.py
@@ -22,3 +22,15 @@ def test_evaluate_plant_nue(tmp_path, monkeypatch):
     assert result["N"]["status"] == "above target"
     assert result["K"]["status"] == "above target"
 
+
+def test_recommend_nue_improvements(tmp_path, monkeypatch):
+    n_dir, y_dir = setup_data(tmp_path)
+    monkeypatch.setattr(ne, "NUTRIENT_DIR", str(n_dir))
+    monkeypatch.setattr(ne, "YIELD_DIR", str(y_dir))
+    monkeypatch.setattr(ne, "_TIPS", {"N": "tip"})
+    monkeypatch.setattr(ne, "load_dataset", lambda _: {"tomato": {"N": 10}})
+    eval_map = ne.evaluate_plant_nue("plant", "tomato")
+    eval_map["N"]["status"] = "below target"
+    tips = ne.recommend_nue_improvements(eval_map)
+    assert tips["N"] == "tip"
+


### PR DESCRIPTION
## Summary
- extend nutrient_efficiency with improvement recommendation helper
- add nutrient_efficiency_tips dataset and document in dataset catalog
- update environment manager tests for verbose messages
- test NUE improvement suggestions

## Testing
- `pytest tests/test_nutrient_efficiency_eval.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ea5f33d08330b214a0de947776ef