### PR TITLE
Improve profile helper and tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/profile_helpers.py
+++ b/custom_components/horticulture_assistant/utils/profile_helpers.py
@@ -46,6 +46,7 @@ def write_profile_sections(
         _LOGGER.error("Failed to create directory %s: %s", plant_dir, err)
         return ""
 
+    success = True
     for filename, data in sections.items():
         file_path = plant_dir / filename
         if file_path.exists() and not overwrite:
@@ -59,6 +60,10 @@ def write_profile_sections(
                 _LOGGER.info("Created file: %s", file_path)
         except Exception as err:  # pragma: no cover - unexpected errors
             _LOGGER.error("Failed to write %s: %s", file_path, err)
+            success = False
 
-    _LOGGER.info("Profile files prepared for '%s' at %s", plant_id, plant_dir)
-    return plant_id
+    if success:
+        _LOGGER.info("Profile files prepared for '%s' at %s", plant_id, plant_dir)
+        return plant_id
+
+    return ""

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -309,7 +309,7 @@ def test_optimize_environment_extended_aliases():
         "seedling",
     )
     assert result["setpoints"]["temp_c"] == 24
-    assert result["adjustments"]["temperature"] == "increase"
+    assert result["adjustments"]["temperature"].startswith("Increase heating")
 
 
 def test_optimize_environment_zone():

--- a/tests/test_profile_helpers.py
+++ b/tests/test_profile_helpers.py
@@ -28,3 +28,16 @@ def test_write_profile_sections_overwrite(tmp_path):
     assert pid == "demo"
     with open(base / "general.json", "r", encoding="utf-8") as f:
         assert json.load(f)["name"] == "updated"
+
+
+def test_write_profile_sections_error(tmp_path, monkeypatch):
+    def fail_save(path, data):
+        raise OSError("boom")
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.utils.profile_helpers.save_json",
+        fail_save,
+    )
+
+    pid = write_profile_sections("demo", {"a.json": {}}, base_path=tmp_path)
+    assert pid == ""


### PR DESCRIPTION
## Summary
- improve error handling in `write_profile_sections`
- adjust environment manager test to use extended alias expectations
- add test coverage for write_profile_sections error path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ea599c788330ade8747f35f6cdda