### PR TITLE
Improve growth planning utilities

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -426,6 +426,7 @@ __all__ = [
     "EnvironmentSummary",
     "calculate_environment_metrics_series",
     "generate_stage_environment_plan",
+    "generate_stage_growth_plan",
     "suggest_environment_setpoints_zone",
     "generate_zone_environment_plan",
 ]
@@ -1286,6 +1287,24 @@ def generate_zone_environment_plan(
     plan: Dict[str, Dict[str, float]] = {}
     for stage in list_growth_stages(plant_type):
         plan[stage] = suggest_environment_setpoints_zone(plant_type, stage, zone)
+    return plan
+
+
+def generate_stage_growth_plan(plant_type: str) -> Dict[str, Dict[str, Any]]:
+    """Return environment setpoints, nutrient needs and tasks per stage."""
+
+    from custom_components.horticulture_assistant.utils.stage_nutrient_requirements import (
+        get_stage_requirements,
+    )
+    from .stage_tasks import get_stage_tasks
+
+    plan: Dict[str, Dict[str, Any]] = {}
+    for stage in list_growth_stages(plant_type):
+        plan[stage] = {
+            "environment": suggest_environment_setpoints(plant_type, stage),
+            "nutrients": get_stage_requirements(plant_type, stage),
+            "tasks": get_stage_tasks(plant_type, stage),
+        }
     return plan
 
 

--- a/tests/test_stage_growth_plan.py
+++ b/tests/test_stage_growth_plan.py
@@ -1,0 +1,10 @@
+from plant_engine.environment_manager import generate_stage_growth_plan
+
+
+def test_generate_stage_growth_plan_tomato_seedling():
+    plan = generate_stage_growth_plan("tomato")
+    assert "seedling" in plan
+    seedling = plan["seedling"]
+    assert seedling["environment"]["temp_c"] == 24
+    assert seedling["nutrients"]["N"] == 90.0
+    assert "Transplant seedlings" in " ".join(seedling["tasks"])


### PR DESCRIPTION
## Summary
- extend environment manager with `generate_stage_growth_plan`
- test stage growth plan output

## Testing
- `pytest tests/test_stage_environment_plan.py tests/test_stage_growth_plan.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887efc882588330b49c1fccfc5d6226