### PR TITLE
Add growth stage targets script

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Helper scripts live in the `scripts/` directory.
 - `precision_fertigation.py` generates a detailed fertigation plan with stock
   solution injection volumes. Use `--use-synergy` to apply nutrient synergy
   adjustments.
+- `growth_stage_targets.py` prints stage durations with environment and nutrient
+  targets plus an optional harvest prediction.
 - `environment_optimize.py` prints recommended environment adjustments for
   current readings.
 - `monitor_schedule.py` outputs an integrated pest and disease monitoring

--- a/scripts/growth_stage_targets.py
+++ b/scripts/growth_stage_targets.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Output growth stage guidelines with environment and nutrient targets."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.growth_stage import growth_stage_summary
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Display growth stage durations with target guidelines"
+    )
+    parser.add_argument("plant_type", help="Plant type to summarize")
+    parser.add_argument(
+        "--start-date",
+        help="Optional planting start date (YYYY-MM-DD) to include harvest prediction",
+    )
+    parser.add_argument("--yaml", action="store_true", help="Output YAML format")
+    args = parser.parse_args(argv)
+
+    start = date.fromisoformat(args.start_date) if args.start_date else None
+    summary = growth_stage_summary(
+        args.plant_type, start_date=start, include_guidelines=True
+    )
+
+    if args.yaml:
+        import yaml
+
+        print(yaml.safe_dump(summary, sort_keys=False))
+    else:
+        print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add growth_stage_targets.py script for summarizing stage guidelines
- document script in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887efb3afd4833099297ff76e191bed