### PR TITLE
Add stage-specific environment tips

### DIFF
--- a/data/environment_tips.yaml
+++ b/data/environment_tips.yaml
@@ -1,6 +1,11 @@
 citrus:
-  high_temp: "Provide shade cloth to reduce temperature"
-  low_humidity: "Use misting system to increase humidity"
+  default:
+    high_temp: "Provide shade cloth to reduce temperature"
+    low_humidity: "Use misting system to increase humidity"
+  fruiting:
+    low_temp: "Use heaters during cool nights"
+
 tomato:
-  high_temp: "Increase ventilation and shading"
-  low_nutrients: "Apply balanced fertilizer" 
+  default:
+    high_temp: "Increase ventilation and shading"
+    low_nutrients: "Apply balanced fertilizer"

--- a/plant_engine/environment_tips.py
+++ b/plant_engine/environment_tips.py
@@ -30,9 +30,40 @@ def list_supported_plants() -> list[str]:
 
 
 @lru_cache(maxsize=None)
-def get_environment_tips(plant_type: str) -> Dict[str, str]:
-    """Return environment management tips for ``plant_type``."""
-    return _DATA().get(normalize_key(plant_type), {})
+def get_environment_tips(plant_type: str, stage: str | None = None) -> Dict[str, str]:
+    """Return environment management tips for ``plant_type`` and ``stage``.
+
+    The dataset may include a ``default`` section with general tips and optional
+    stage-specific mappings. Stage entries override any defaults. If no tips are
+    defined for the plant or stage an empty dictionary is returned.
+    """
+
+    plant = _DATA().get(normalize_key(plant_type))
+    if not isinstance(plant, dict):
+        return {}
+
+    tips: Dict[str, str] = {}
+
+    default = plant.get("default")
+    if isinstance(default, dict):
+        for k, v in default.items():
+            if isinstance(v, str):
+                tips[k] = v
+    else:
+        # backward compatibility with old dataset structure where tips were
+        # stored directly under the plant mapping
+        for k, v in plant.items():
+            if isinstance(v, str):
+                tips[k] = v
+
+    if stage:
+        stage_tips = plant.get(normalize_key(stage))
+        if isinstance(stage_tips, dict):
+            for k, v in stage_tips.items():
+                if isinstance(v, str):
+                    tips[k] = v
+
+    return tips
 
 
 def refresh_cache() -> None:

--- a/tests/test_environment_tips.py
+++ b/tests/test_environment_tips.py
@@ -7,6 +7,11 @@ def test_environment_tips_basic():
     assert "citrus" in list_supported_plants()
 
 
+def test_environment_tips_stage_specific():
+    tips = get_environment_tips("citrus", "fruiting")
+    assert tips["low_temp"].startswith("Use heaters")
+
+
 def test_environment_tips_unknown():
     assert get_environment_tips("unknown") == {}
 


### PR DESCRIPTION
## Summary
- support stage-specific environment tips
- document new tips in `environment_tips.yaml`
- test stage retrieval logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ef82350c833090af5fc16b0b83a9