### PR TITLE
Improve dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Datasets can be overridden by setting environment variables:
 - `HORTICULTURE_DATA_DIR` to change the base data directory
 - `HORTICULTURE_OVERLAY_DIR` to merge in custom files
 - `HORTICULTURE_EXTRA_DATA_DIRS` to load additional datasets
-Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately. Use `plant_engine.utils.load_dataset_df()` to quickly load any dataset into a `pandas.DataFrame` for analysis.
+Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately. Use `plant_engine.utils.load_dataset_df()` to quickly load any dataset into a `pandas.DataFrame` for analysis. JSON, YAML and now CSV/TSV files are supported.
 
 See [docs/custom_data_dirs.md](docs/custom_data_dirs.md) for examples of how to
 structure overlay and extra dataset directories.

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -288,11 +288,18 @@ def lazy_dataset(filename: str):
 def load_dataset_df(filename: str) -> "pd.DataFrame":
     """Return dataset ``filename`` as a :class:`pandas.DataFrame`.
 
+    JSON/YAML files are loaded via :func:`load_dataset`. CSV/TSV files are read
+    directly if located in one of the configured dataset directories.
     Dictionaries are treated as row mappings and lists as row sequences.
     Unsupported data structures raise ``ValueError``.
     """
 
     import pandas as pd
+
+    path = dataset_file(filename)
+    if path and path.suffix.lower() in {".csv", ".tsv"}:
+        sep = "\t" if path.suffix.lower() == ".tsv" else ","
+        return pd.read_csv(path, sep=sep)
 
     data = load_dataset(filename)
     if isinstance(data, Mapping):

--- a/tests/test_dataset_dataframe.py
+++ b/tests/test_dataset_dataframe.py
@@ -25,3 +25,15 @@ def test_load_dataset_df_list(tmp_path, monkeypatch):
     importlib.reload(utils)
     df = utils.load_dataset_df("sample.json")
     assert df.shape == (2, 1)
+
+
+def test_load_dataset_df_csv(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    csv_path = data_dir / "sample.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n")
+    monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    importlib.reload(utils)
+    df = utils.load_dataset_df("sample.csv")
+    assert list(df.columns) == ["a", "b"]
+    assert df.shape == (2, 2)


### PR DESCRIPTION
## Summary
- support CSV/TSV files when loading datasets as DataFrames
- document CSV/TSV dataset support
- test new CSV loading path

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ef73ca508330b2860cb0d64ba4b3