### PR TITLE
Enable profile caching and upload utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The bundled datasets are not exhaustive and may contain inaccuracies. Always cro
 8. Ensure all numeric sensors use `state_class: measurement` so statistics are recorded.
 
 Plant profiles are stored in the `plants/` directory and can be created through the config flow or edited manually.
+Each newly generated profile is also cached under `data/profile_cache/` so it can be uploaded to a public database in a future release. When you're ready to share new profiles, run the `upload_profile_cache.py` script to send them to the external service.
 
 Once you have at least one plant configured, open **Settings → Devices & Services → Horticulture Assistant**. Here you can edit existing plant profiles and use the **Add Plant** button to create new ones without returning to the integrations list.
 
@@ -330,6 +331,7 @@ Helper scripts live in the `scripts/` directory.
 - `dataset_info.py` lists available datasets and categories.
 - `validate_datasets.py` verifies that all dataset files can be parsed.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
+- `upload_profile_cache.py` sends cached profiles in `data/profile_cache/` to a remote service for training future models. Add `--delete` to remove files after upload.
 - `profile_manager.py` manages sensors, preferences, templates and history files. `attach-sensor` appends new sensors, while `detach-sensor` removes them. Other subcommands include `list-sensors`, `show-prefs`, `list-logs`, `set-pref`, `load-default`, `show-history`, `show-global`, and `list-globals`. `--plants-dir` and `--global-dir` operate on alternate directories.
 
 Example usage:

--- a/custom_components/horticulture_assistant/utils/profile_upload_cache.py
+++ b/custom_components/horticulture_assistant/utils/profile_upload_cache.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+try:
+    from homeassistant.core import HomeAssistant
+except ImportError:  # pragma: no cover - allow tests without HA installed
+    HomeAssistant = None  # type: ignore
+
+from .path_utils import plants_path, ensure_data_dir
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["cache_profile_for_upload"]
+
+
+def _load_section(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:  # pragma: no cover - unexpected I/O errors
+        _LOGGER.error("Failed reading %s: %s", path, exc)
+        return None
+
+
+def cache_profile_for_upload(plant_id: str, hass: HomeAssistant | None = None) -> None:
+    """Cache a combined profile JSON for later upload."""
+    plant_dir = Path(plants_path(hass, plant_id))
+    cache_dir = Path(ensure_data_dir(hass, "profile_cache"))
+
+    profile = {}
+    for fname in (
+        "general.json",
+        "environment.json",
+        "nutrition.json",
+        "irrigation.json",
+        "stages.json",
+    ):
+        section = _load_section(plant_dir / fname)
+        if section is not None:
+            profile[fname[:-5]] = section
+
+    if not profile:
+        _LOGGER.warning("No profile data found for %s; nothing cached", plant_id)
+        return
+
+    out = cache_dir / f"{plant_id}.json"
+    try:
+        with open(out, "w", encoding="utf-8") as f:
+            json.dump(profile, f, indent=2)
+        _LOGGER.info("Cached profile for %s at %s", plant_id, out)
+    except Exception as exc:  # pragma: no cover - unexpected I/O errors
+        _LOGGER.error("Failed to cache profile %s: %s", plant_id, exc)

--- a/scripts/upload_profile_cache.py
+++ b/scripts/upload_profile_cache.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Upload cached plant profiles to a remote server."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+import urllib.request as urlreq
+
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+DEFAULT_CACHE_DIR = ROOT / "data" / "profile_cache"
+
+__all__ = ["list_cached_profiles", "upload_cached_profiles", "main"]
+
+
+def list_cached_profiles(dir_path: Path = DEFAULT_CACHE_DIR) -> list[Path]:
+    """Return sorted list of cached profile JSON files."""
+    if not dir_path.exists():
+        return []
+    return sorted(dir_path.glob("*.json"))
+
+
+def upload_cached_profiles(
+    url: str,
+    dir_path: Path = DEFAULT_CACHE_DIR,
+    delete: bool = False,
+) -> None:
+    """Upload each cached profile to ``url`` via HTTP POST.
+
+    If ``delete`` is True, remove each file after a successful upload.
+    """
+    for path in list_cached_profiles(dir_path):
+        with open(path, "rb") as f:
+            data = f.read()
+        req = urlreq.Request(url, data=data, headers={"Content-Type": "application/json"})
+        try:
+            urlreq.urlopen(req)
+            print(f"Uploaded {path.name}")
+            if delete:
+                try:
+                    path.unlink()
+                except Exception as exc:  # pragma: no cover - fs errors
+                    print(f"Failed deleting {path.name}: {exc}", file=sys.stderr)
+        except Exception as exc:  # pragma: no cover - network errors
+            print(f"Failed uploading {path.name}: {exc}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Upload cached plant profiles")
+    parser.add_argument("url", help="API endpoint accepting profile JSON")
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete cached profiles after successful upload",
+    )
+    args = parser.parse_args(argv)
+
+    upload_cached_profiles(args.url, args.cache_dir, delete=args.delete)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    main()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -170,3 +170,25 @@ def test_init_menu(monkeypatch):
     flow.hass = hass
     result = asyncio.run(flow.async_step_init())
     assert result["type"] == "menu"
+
+
+def test_subentry_flow(monkeypatch):
+    recorded = {}
+
+    def fake_generate(data, hass=None):
+        recorded.update(data)
+        return "sub123"
+
+    monkeypatch.setattr(config_flow, "generate_profile", fake_generate)
+    flow = config_flow.PlantProfileSubEntryFlow()
+    flow.hass = object()
+    result = asyncio.run(flow.async_step_user({"plant_name": "Mint"}))
+    assert result["type"] == "create_entry"
+    assert flow.created_entry["data"]["plant_name"] == "Mint"
+    assert flow.created_entry["unique_id"] == "sub123"
+    assert recorded["plant_name"] == "Mint"
+
+
+def test_get_supported_subentry_types():
+    mapping = config_flow.async_get_supported_subentry_types(None)
+    assert mapping["plant"] is config_flow.PlantProfileSubEntryFlow

--- a/tests/test_profile_generator.py
+++ b/tests/test_profile_generator.py
@@ -1,0 +1,30 @@
+import types
+from custom_components.horticulture_assistant.utils import (
+    profile_generator,
+    profile_upload_cache,
+)
+
+
+def _make_hass(tmp_path):
+    return types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            path=lambda *parts: str(tmp_path.joinpath(*parts))
+        )
+    )
+
+
+def test_generate_profile_caches(tmp_path, monkeypatch):
+    hass = _make_hass(tmp_path)
+    calls = []
+
+    def fake_cache(pid, hass_arg=None):
+        calls.append((pid, hass_arg))
+
+    monkeypatch.setattr(profile_upload_cache, "cache_profile_for_upload", fake_cache)
+
+    plant_id = profile_generator.generate_profile({"plant_name": "Mint"}, hass)
+
+    assert plant_id == "mint"
+    assert calls[0][0] == "mint"
+    assert calls[0][1] is hass
+

--- a/tests/test_profile_upload_cache.py
+++ b/tests/test_profile_upload_cache.py
@@ -1,0 +1,35 @@
+import json
+import types
+
+from custom_components.horticulture_assistant.utils.profile_upload_cache import (
+    cache_profile_for_upload,
+)
+
+
+def _make_hass(tmp_path):
+    return types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            path=lambda *parts: str(tmp_path.joinpath(*parts))
+        )
+    )
+
+
+def test_cache_profile_for_upload(tmp_path):
+    plant_dir = tmp_path / "plants" / "demo"
+    plant_dir.mkdir(parents=True)
+    for name in [
+        "general.json",
+        "environment.json",
+        "nutrition.json",
+        "irrigation.json",
+        "stages.json",
+    ]:
+        (plant_dir / name).write_text("{}")
+
+    hass = _make_hass(tmp_path)
+    cache_profile_for_upload("demo", hass)
+
+    out = tmp_path / "data" / "profile_cache" / "demo.json"
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert "general" in data

--- a/tests/test_upload_profile_cache_script.py
+++ b/tests/test_upload_profile_cache_script.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import scripts.upload_profile_cache as upc
+
+
+def test_list_cached_profiles(tmp_path: Path):
+    cache_dir = tmp_path / "profile_cache"
+    cache_dir.mkdir()
+    p = cache_dir / "a.json"
+    p.write_text("{}")
+    files = upc.list_cached_profiles(cache_dir)
+    assert files == [p]
+
+
+def test_upload_cached_profiles(tmp_path: Path, monkeypatch):
+    cache_dir = tmp_path / "profile_cache"
+    cache_dir.mkdir()
+    p = cache_dir / "a.json"
+    p.write_text("{\"k\":1}")
+
+    calls = []
+
+    class FakeResponse:
+        pass
+
+    def fake_urlopen(req):
+        calls.append((req.full_url, req.data))
+        return FakeResponse()
+
+    monkeypatch.setattr(upc.urlreq, "urlopen", fake_urlopen)
+
+    upc.upload_cached_profiles("http://example.com/upload", cache_dir)
+
+    assert calls
+    assert calls[0][0] == "http://example.com/upload"
+    assert json.loads(calls[0][1].decode()) == {"k": 1}
+    assert p.exists()
+
+
+def test_upload_cached_profiles_delete(tmp_path: Path, monkeypatch):
+    cache_dir = tmp_path / "profile_cache"
+    cache_dir.mkdir()
+    p = cache_dir / "a.json"
+    p.write_text("{\"k\":2}")
+
+    monkeypatch.setattr(upc.urlreq, "urlopen", lambda req: object())
+
+    upc.upload_cached_profiles("http://example.com/upload", cache_dir, delete=True)
+
+    assert not p.exists()
+


### PR DESCRIPTION
## Summary
- document that generated profiles are cached under `data/profile_cache`
- implement profile caching via `cache_profile_for_upload`
- add subentry flow so profiles can be created from the integration page
- provide an `upload_profile_cache.py` helper to post cached profiles
- clean up imports in the upload script and tests
- clarify that `upload_profile_cache.py` can send cached profiles to the remote service

## Testing
- `pytest tests/test_config_flow.py tests/test_profile_upload_cache.py tests/test_profile_generator.py tests/test_upload_profile_cache_script.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68881173a82083308e49cdc888539373