### PR TITLE
Add global config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The bundled datasets are not exhaustive and may contain inaccuracies. Always cro
 5. Open the entry's **Options** anytime to update the zone, enable auto‑approve or link sensors.
 6. Copy `blueprints/automation/plant_monitoring.yaml` into `<config>/blueprints/automation/>` and create an automation from it.
 7. Enable `input_boolean.auto_approve_all` if you want AI recommendations applied automatically.
-8. Ensure all numeric sensors use `state_class: measurement` so statistics are recorded.
+8. From the integration page, choose **Settings** to configure global AI options such as OpenAI usage or the default threshold mode. These settings are stored in `<config>/data/horticulture_global_config.json`.
+9. Ensure all numeric sensors use `state_class: measurement` so statistics are recorded.
 
 Plant profiles are stored in the `plants/` directory and can be created through the config flow or edited manually.
 Each newly generated profile is also cached under `data/profile_cache/` so it can be uploaded to a public database in a future release. When you're ready to share new profiles, run the `upload_profile_cache.py` script to send them to the external service.

--- a/custom_components/horticulture_assistant/const.py
+++ b/custom_components/horticulture_assistant/const.py
@@ -14,6 +14,9 @@ PLATFORMS = ["sensor", "binary_sensor", "switch"]
 # Configuration
 CONF_ENABLE_AUTO_APPROVE = "enable_auto_approve"
 CONF_DEFAULT_THRESHOLD_MODE = "default_threshold_mode"
+CONF_USE_OPENAI = "use_openai"
+CONF_OPENAI_MODEL = "openai_model"
+CONF_OPENAI_API_KEY = "openai_api_key"
 
 # Threshold modes
 THRESHOLD_MODE_MANUAL = "manual"

--- a/custom_components/horticulture_assistant/utils/global_config.py
+++ b/custom_components/horticulture_assistant/utils/global_config.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Helpers for loading and saving global integration settings."""
+
+from typing import Any, Dict
+
+from .path_utils import data_path
+from .json_io import load_json, save_json
+
+CONFIG_FILE = "horticulture_global_config.json"
+
+DEFAULTS: Dict[str, Any] = {
+    "use_openai": False,
+    "openai_api_key": "",
+    "openai_model": "gpt-4o",
+    "default_threshold_mode": "profile",
+}
+
+
+def load_config(hass=None) -> Dict[str, Any]:
+    """Return the stored global configuration merged with defaults."""
+    path = data_path(hass, CONFIG_FILE)
+    try:
+        cfg = load_json(path)
+    except FileNotFoundError:
+        return dict(DEFAULTS)
+    except Exception:
+        return dict(DEFAULTS)
+    if not isinstance(cfg, dict):
+        return dict(DEFAULTS)
+    merged = dict(DEFAULTS)
+    merged.update(cfg)
+    return merged
+
+
+def save_config(cfg: Dict[str, Any], hass=None) -> None:
+    """Persist ``cfg`` to the global config file."""
+    path = data_path(hass, CONFIG_FILE)
+    save_json(path, cfg)

--- a/tests/test_ai_feedback_handler.py
+++ b/tests/test_ai_feedback_handler.py
@@ -1,0 +1,34 @@
+import json
+
+from custom_components.horticulture_assistant.utils import ai_feedback_handler
+
+
+def test_process_ai_feedback_uses_global_settings(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    plants_dir = tmp_path / "plants"
+    data_dir.mkdir()
+    plants_dir.mkdir()
+    cfg = {
+        "use_openai": True,
+        "openai_api_key": "abc",
+        "openai_model": "model-x",
+        "default_threshold_mode": "profile",
+    }
+    (data_dir / "horticulture_global_config.json").write_text(json.dumps(cfg))
+    (plants_dir / "plant1.json").write_text(json.dumps({"thresholds": {}, "auto_approve_all": False}))
+
+    captured = {}
+
+    def fake_analyze(data, config=None):
+        captured["config"] = config
+        return {"thresholds": {}}
+
+    monkeypatch.setattr(ai_feedback_handler.ai_model, "analyze", fake_analyze)
+
+    ai_feedback_handler.process_ai_feedback("plant1", {"thresholds": {}})
+
+    model_cfg = captured["config"]
+    assert model_cfg.use_openai is True
+    assert model_cfg.api_key == "abc"
+    assert model_cfg.model == "model-x"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -172,6 +172,35 @@ def test_init_menu(monkeypatch):
     assert result["type"] == "menu"
 
 
+def test_settings_flow(tmp_path):
+    hass = types.SimpleNamespace(
+        config_entries=types.SimpleNamespace(async_entries=lambda domain: []),
+        config=types.SimpleNamespace(path=lambda *parts: str(tmp_path.joinpath(*parts))),
+    )
+    flow = Flow()
+    flow.hass = hass
+
+    form = asyncio.run(flow.async_step_settings())
+    assert form["type"] == "form"
+
+    result = asyncio.run(
+        flow.async_step_settings(
+            {
+                "use_openai": True,
+                "openai_api_key": "key",
+                "openai_model": "model",
+                "default_threshold_mode": config_flow.THRESHOLD_MODE_MANUAL,
+            }
+        )
+    )
+    assert result["type"] == "menu"
+    cfg = config_flow.global_config.load_config(hass)
+    assert cfg["use_openai"] is True
+    assert cfg["openai_api_key"] == "key"
+    assert cfg["openai_model"] == "model"
+    assert cfg["default_threshold_mode"] == config_flow.THRESHOLD_MODE_MANUAL
+
+
 def test_subentry_flow(monkeypatch):
     recorded = {}
 

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from custom_components.horticulture_assistant.utils import global_config
+
+
+class DummyConfig:
+    def __init__(self, base):
+        self._base = Path(base)
+
+    def path(self, *parts):
+        return str(self._base.joinpath(*parts))
+
+
+class DummyHass:
+    def __init__(self, base):
+        self.config = DummyConfig(base)
+        self.data = {}
+
+
+def test_load_config_defaults(tmp_path):
+    hass = DummyHass(tmp_path)
+    cfg = global_config.load_config(hass)
+    assert cfg == global_config.DEFAULTS
+
+
+def test_save_and_merge(tmp_path):
+    hass = DummyHass(tmp_path)
+    global_config.save_config({"use_openai": True}, hass)
+    cfg = global_config.load_config(hass)
+    assert cfg["use_openai"] is True
+    assert cfg["openai_api_key"] == ""
+    assert cfg["openai_model"] == "gpt-4o"
+    assert cfg["default_threshold_mode"] == "profile"


### PR DESCRIPTION
## Summary
- allow configuration of AI options from integration page
- store global settings in `horticulture_global_config.json`
- document new Settings step in the Quick Start
- test new config flow branch
- add tests and docs for global settings
- use global settings for AI feedback
- clean up README wording and test import

## Testing
- `pytest tests/test_global_config.py tests/test_config_flow.py::test_settings_flow tests/test_ai_feedback_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68889b1c05988330bfe14ad7c991d8a8