### PR TITLE
Streamline utilities imports

### DIFF
--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -32,7 +32,7 @@ from .utils.entry_helpers import (
     remove_entry_data,
 )
 from .utils.plant_profile_loader import update_profile_sensors
-from .utils.path_utils import plants_path
+from .utils import plants_path
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/horticulture_assistant/analytics/growth_yield_exporter.py
+++ b/custom_components/horticulture_assistant/analytics/growth_yield_exporter.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from plant_engine.utils import load_json, save_json
-from custom_components.horticulture_assistant.utils.path_utils import data_path
+from custom_components.horticulture_assistant.utils import data_path
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/automation/actuator_utils.py
+++ b/custom_components/horticulture_assistant/automation/actuator_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from ..utils.json_io import load_json
+from ..utils import load_json
 
 try:
     from homeassistant.core import HomeAssistant

--- a/custom_components/horticulture_assistant/automation/fertilizer_trigger.py
+++ b/custom_components/horticulture_assistant/automation/fertilizer_trigger.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from custom_components.horticulture_assistant.utils import plants_path
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/automation/helpers.py
+++ b/custom_components/horticulture_assistant/automation/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
-from ..utils.json_io import load_json, save_json
+from ..utils import load_json, save_json
 
 
 def iter_profiles(base_path: str) -> Iterable[Tuple[str, Dict]]:

--- a/custom_components/horticulture_assistant/automation/irrigation_trigger.py
+++ b/custom_components/horticulture_assistant/automation/irrigation_trigger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from custom_components.horticulture_assistant.utils import plants_path
 from plant_engine.utils import load_json
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/horticulture_assistant/automation/run_automation_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_automation_cycle.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from datetime import datetime
 
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from custom_components.horticulture_assistant.utils import plants_path
 
 from .helpers import iter_profiles, append_json_log, latest_env
 

--- a/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from datetime import datetime
 
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from custom_components.horticulture_assistant.utils import plants_path
 
 from .helpers import append_json_log, iter_profiles, latest_env
 

--- a/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
+++ b/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from ..utils.json_io import load_json, save_json
+from ..utils import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
+++ b/custom_components/horticulture_assistant/engine/analyze_ai_recommendations.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime
 
-from ..utils.json_io import load_json, save_json
+from ..utils import load_json, save_json
 from plant_engine.utils import get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
+++ b/custom_components/horticulture_assistant/engine/approve_threshold_queue.py
@@ -17,8 +17,8 @@ try:
 except ImportError:
     HomeAssistant = None  # if Home Assistant not available, ignore for standalone use
 
-from ..utils.json_io import load_json, save_json
-from ..utils.path_utils import data_path, plants_path
+from ..utils import load_json, save_json
+from ..utils import data_path, plants_path
 from plant_engine.utils import get_pending_dir
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/horticulture_assistant/engine/load_ai_insight_context.py
+++ b/custom_components/horticulture_assistant/engine/load_ai_insight_context.py
@@ -1,12 +1,12 @@
 import logging
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     plants_path,
     data_path,
 )
 
-from ..utils.json_io import load_json
+from ..utils import load_json
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/engine/report_packager.py
+++ b/custom_components/horticulture_assistant/engine/report_packager.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from statistics import mean
 
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     plants_path,
     data_path,
 )
@@ -12,7 +12,7 @@ from custom_components.horticulture_assistant.utils.path_utils import (
 from custom_components.horticulture_assistant.utils.plant_profile_loader import (
     load_plant_profile,
 )
-from ..utils.json_io import load_json, save_json
+from ..utils import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/engine/run_daily_cycle.py
+++ b/custom_components/horticulture_assistant/engine/run_daily_cycle.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Mapping
 
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     plants_path,
     data_path,
 )

--- a/custom_components/horticulture_assistant/utils/__init__.py
+++ b/custom_components/horticulture_assistant/utils/__init__.py
@@ -1,0 +1,22 @@
+"""Utility helpers re-exported for convenience."""
+
+from .path_utils import (
+    config_path,
+    data_path,
+    plants_path,
+    ensure_dir,
+    ensure_data_dir,
+    ensure_plants_dir,
+)
+from .json_io import load_json, save_json
+
+__all__ = [
+    "config_path",
+    "data_path",
+    "plants_path",
+    "ensure_dir",
+    "ensure_data_dir",
+    "ensure_plants_dir",
+    "load_json",
+    "save_json",
+]

--- a/custom_components/horticulture_assistant/utils/ai_feedback_handler.py
+++ b/custom_components/horticulture_assistant/utils/ai_feedback_handler.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 
 from ..engine import ai_model
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     plants_path,
     data_path,
 )

--- a/custom_components/horticulture_assistant/utils/cec_model.py
+++ b/custom_components/horticulture_assistant/utils/cec_model.py
@@ -12,7 +12,7 @@ import logging
 from typing import Optional, Dict
 
 from . import media_inference  # use media_inference.infer_media_type for media-based CEC estimation
-from custom_components.horticulture_assistant.utils.path_utils import data_path
+from custom_components.horticulture_assistant.utils import data_path
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/utils/daily_report_builder.py
+++ b/custom_components/horticulture_assistant/utils/daily_report_builder.py
@@ -16,7 +16,7 @@ from .state_helpers import (
     aggregate_sensor_values,
 )
 from .json_io import load_json, save_json
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     config_path,
     plants_path,
     data_path,

--- a/custom_components/horticulture_assistant/utils/ec_trend_tracker.py
+++ b/custom_components/horticulture_assistant/utils/ec_trend_tracker.py
@@ -15,7 +15,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     data_path,
     plants_path,
 )

--- a/custom_components/horticulture_assistant/utils/growth_model.py
+++ b/custom_components/horticulture_assistant/utils/growth_model.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 # Reuse the central evapotranspiration formulas from plant_engine
 from plant_engine.et_model import calculate_et0, calculate_eta
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     plants_path,
     data_path,
 )

--- a/custom_components/horticulture_assistant/utils/media_inference.py
+++ b/custom_components/horticulture_assistant/utils/media_inference.py
@@ -10,7 +10,7 @@ import json
 import logging
 from typing import Optional, Dict
 
-from custom_components.horticulture_assistant.utils.path_utils import data_path
+from custom_components.horticulture_assistant.utils import data_path
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_scheduler.py
@@ -21,7 +21,7 @@ from plant_engine.nutrient_manager import (
     calculate_nutrient_adjustments,
 )
 from plant_engine.utils import load_json, save_json, load_dataset, normalize_key
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     config_path,
     plants_path,
     data_path,

--- a/custom_components/horticulture_assistant/utils/nutrient_use_efficiency.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_use_efficiency.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime, date
 from typing import Dict, List, Optional, Union, Mapping
 
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     data_path,
     config_path,
 )

--- a/custom_components/horticulture_assistant/utils/plant_registry.py
+++ b/custom_components/horticulture_assistant/utils/plant_registry.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover - tests run without HA
     HomeAssistant = None  # type: ignore
 
 from .json_io import load_json
-from custom_components.horticulture_assistant.utils.path_utils import config_path
+from custom_components.horticulture_assistant.utils import config_path
 
 PLANT_REGISTRY_FILE = "plant_registry.json"
 

--- a/custom_components/horticulture_assistant/utils/profile_generator.py
+++ b/custom_components/horticulture_assistant/utils/profile_generator.py
@@ -4,7 +4,7 @@ import json
 import logging
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from custom_components.horticulture_assistant.utils import plants_path
 
 try:
     from homeassistant.core import HomeAssistant

--- a/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
+++ b/custom_components/horticulture_assistant/utils/profile_nutrient_log_writer.py
@@ -6,7 +6,7 @@ except ImportError:  # pragma: no cover - outside Home Assistant
     HomeAssistant = None
 
 from .profile_helpers import write_profile_sections
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
+from custom_components.horticulture_assistant.utils import plants_path
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/utils/threshold_approval_manager.py
+++ b/custom_components/horticulture_assistant/utils/threshold_approval_manager.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import (
+from custom_components.horticulture_assistant.utils import (
     plants_path,
     data_path,
 )

--- a/custom_components/horticulture_assistant/utils/yield_tracker.py
+++ b/custom_components/horticulture_assistant/utils/yield_tracker.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, date
 from typing import List, Dict, Optional, Union
 
-from custom_components.horticulture_assistant.utils.path_utils import data_path
+from custom_components.horticulture_assistant.utils import data_path
 try:
     from homeassistant.core import HomeAssistant
 except ImportError:

--- a/scripts/generate_plant_sensors.py
+++ b/scripts/generate_plant_sensors.py
@@ -9,7 +9,7 @@ import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import data_path
+from custom_components.horticulture_assistant.utils import data_path
 from typing import Dict, Iterable, List
 
 try:
@@ -17,7 +17,7 @@ try:
 except Exception:  # pragma: no cover - fallback when PyYAML is missing
     yaml = None
 
-from custom_components.horticulture_assistant.utils.json_io import load_json
+from custom_components.horticulture_assistant.utils import load_json
 
 
 DEFAULT_OUTPUT_DIR = Path("templates/generated")

--- a/scripts/profile_manager.py
+++ b/scripts/profile_manager.py
@@ -13,7 +13,7 @@ ROOT = ensure_repo_root_on_path()
 from custom_components.horticulture_assistant.utils import (
     plant_profile_loader as loader,
 )
-from custom_components.horticulture_assistant.utils.json_io import load_json
+from custom_components.horticulture_assistant.utils import load_json
 
 DEFAULT_PLANTS_DIR = ROOT / "plants"
 DEFAULT_GLOBAL_DIR = ROOT / "data" / "global_profiles"


### PR DESCRIPTION
## Summary
- expose common helper functions via `utils/__init__.py`
- switch imports across the integration to use the consolidated utilities package

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889b3a7cc083308507abde64092aa0