### PR TITLE
Add OpenAI temperature configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The bundled datasets are not exhaustive and may contain inaccuracies. Always cro
 5. Open the entry's **Options** anytime to update the zone, enable auto‑approve or link sensors.
 6. Copy `blueprints/automation/plant_monitoring.yaml` into `<config>/blueprints/automation/>` and create an automation from it.
 7. Enable `input_boolean.auto_approve_all` if you want AI recommendations applied automatically.
-8. From the integration page, choose **Settings** to configure global AI options such as OpenAI usage or the default threshold mode. These settings are stored in `<config>/data/horticulture_global_config.json`.
+8. From the integration page, choose **Settings** to configure global AI options such as OpenAI usage, model and temperature. These settings are stored in `<config>/data/horticulture_global_config.json`.
 9. Ensure all numeric sensors use `state_class: measurement` so statistics are recorded.
 
 Plant profiles are stored in the `plants/` directory and can be created through the config flow or edited manually.
@@ -300,6 +300,7 @@ Datasets can be overridden by setting environment variables:
 - `HORTICULTURE_DATA_DIR` to change the base data directory
 - `HORTICULTURE_OVERLAY_DIR` to merge in custom files
 - `HORTICULTURE_EXTRA_DATA_DIRS` to load additional datasets
+- `OPENAI_API_KEY` and `OPENAI_TEMPERATURE` configure the AI integration if you prefer not to store these values in the config file
 Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately. Use `plant_engine.utils.load_dataset_df()` to quickly load any dataset into a `pandas.DataFrame` for analysis. JSON, YAML and now CSV/TSV files are supported.
 
 See [docs/custom_data_dirs.md](docs/custom_data_dirs.md) for examples of how to

--- a/custom_components/horticulture_assistant/config_flow.py
+++ b/custom_components/horticulture_assistant/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_USE_OPENAI,
     CONF_OPENAI_API_KEY,
     CONF_OPENAI_MODEL,
+    CONF_OPENAI_TEMPERATURE,
     THRESHOLD_MODE_MANUAL,
     THRESHOLD_MODE_PROFILE,
 )
@@ -93,6 +94,10 @@ class HorticultureAssistantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_OPENAI_API_KEY, default=cfg.get(CONF_OPENAI_API_KEY, "")
                 ): TextSelector(),
+                vol.Optional(
+                    CONF_OPENAI_TEMPERATURE,
+                    default=cfg.get(CONF_OPENAI_TEMPERATURE, 0.3),
+                ): vol.Coerce(float),
                 vol.Optional(
                     CONF_DEFAULT_THRESHOLD_MODE,
                     default=cfg.get(

--- a/custom_components/horticulture_assistant/const.py
+++ b/custom_components/horticulture_assistant/const.py
@@ -17,6 +17,7 @@ CONF_DEFAULT_THRESHOLD_MODE = "default_threshold_mode"
 CONF_USE_OPENAI = "use_openai"
 CONF_OPENAI_MODEL = "openai_model"
 CONF_OPENAI_API_KEY = "openai_api_key"
+CONF_OPENAI_TEMPERATURE = "openai_temperature"
 
 # Threshold modes
 THRESHOLD_MODE_MANUAL = "manual"

--- a/custom_components/horticulture_assistant/utils/ai_feedback_handler.py
+++ b/custom_components/horticulture_assistant/utils/ai_feedback_handler.py
@@ -8,6 +8,7 @@ from ..const import (
     CONF_OPENAI_API_KEY,
     CONF_OPENAI_MODEL,
     CONF_USE_OPENAI,
+    CONF_OPENAI_TEMPERATURE,
 )
 from . import global_config
 from custom_components.horticulture_assistant.utils.path_utils import (
@@ -46,6 +47,7 @@ def process_ai_feedback(plant_id: str, daily_report: dict) -> str:
         use_openai=cfg.get(CONF_USE_OPENAI, ai_model.USE_OPENAI),
         model=cfg.get(CONF_OPENAI_MODEL, ai_model.OPENAI_MODEL),
         api_key=cfg.get(CONF_OPENAI_API_KEY) or ai_model.OPENAI_API_KEY,
+        temperature=cfg.get(CONF_OPENAI_TEMPERATURE, ai_model.OPENAI_TEMPERATURE),
     )
     try:
         result = ai_model.analyze(daily_report, model_cfg)

--- a/custom_components/horticulture_assistant/utils/global_config.py
+++ b/custom_components/horticulture_assistant/utils/global_config.py
@@ -13,6 +13,7 @@ DEFAULTS: Dict[str, Any] = {
     "use_openai": False,
     "openai_api_key": "",
     "openai_model": "gpt-4o",
+    "openai_temperature": 0.3,
     "default_threshold_mode": "profile",
 }
 

--- a/plant_engine/ai_model.py
+++ b/plant_engine/ai_model.py
@@ -17,6 +17,10 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 USE_OPENAI = False  # Toggle between mock mode and API
 OPENAI_MODEL = "gpt-4o"
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", None)  # Stored in environment variable
+try:
+    OPENAI_TEMPERATURE = float(os.getenv("OPENAI_TEMPERATURE", "0.3"))
+except (TypeError, ValueError):
+    OPENAI_TEMPERATURE = 0.3
 
 
 @dataclass(slots=True)
@@ -26,6 +30,7 @@ class AIModelConfig:
     use_openai: bool = USE_OPENAI
     model: str = OPENAI_MODEL
     api_key: str | None = OPENAI_API_KEY
+    temperature: float = OPENAI_TEMPERATURE
 
 
 class BaseAIModel(Protocol):
@@ -90,7 +95,7 @@ class OpenAIModel:
                     "content": f"Input data:\n{json.dumps(data, indent=2)}",
                 },
             ],
-            temperature=0.3,
+            temperature=self.config.temperature,
         )
 
         text = response["choices"][0]["message"]["content"]

--- a/tests/test_ai_feedback_handler.py
+++ b/tests/test_ai_feedback_handler.py
@@ -13,6 +13,7 @@ def test_process_ai_feedback_uses_global_settings(tmp_path, monkeypatch):
         "use_openai": True,
         "openai_api_key": "abc",
         "openai_model": "model-x",
+        "openai_temperature": 0.4,
         "default_threshold_mode": "profile",
     }
     (data_dir / "horticulture_global_config.json").write_text(json.dumps(cfg))
@@ -32,3 +33,4 @@ def test_process_ai_feedback_uses_global_settings(tmp_path, monkeypatch):
     assert model_cfg.use_openai is True
     assert model_cfg.api_key == "abc"
     assert model_cfg.model == "model-x"
+    assert model_cfg.temperature == 0.4

--- a/tests/test_ai_model.py
+++ b/tests/test_ai_model.py
@@ -16,3 +16,11 @@ def test_get_model_openai():
     cfg = ai_model.AIModelConfig(use_openai=True, api_key="key")
     model = ai_model.get_model(cfg)
     assert isinstance(model, ai_model.OpenAIModel)
+
+
+def test_temperature_env_var_parsing(monkeypatch):
+    monkeypatch.setenv("OPENAI_TEMPERATURE", "bad")
+    import importlib
+
+    mod = importlib.reload(ai_model)
+    assert mod.OPENAI_TEMPERATURE == 0.3

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -189,6 +189,7 @@ def test_settings_flow(tmp_path):
                 "use_openai": True,
                 "openai_api_key": "key",
                 "openai_model": "model",
+                "openai_temperature": 0.7,
                 "default_threshold_mode": config_flow.THRESHOLD_MODE_MANUAL,
             }
         )
@@ -198,6 +199,7 @@ def test_settings_flow(tmp_path):
     assert cfg["use_openai"] is True
     assert cfg["openai_api_key"] == "key"
     assert cfg["openai_model"] == "model"
+    assert cfg["openai_temperature"] == 0.7
     assert cfg["default_threshold_mode"] == config_flow.THRESHOLD_MODE_MANUAL
 
 

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -30,4 +30,5 @@ def test_save_and_merge(tmp_path):
     assert cfg["use_openai"] is True
     assert cfg["openai_api_key"] == ""
     assert cfg["openai_model"] == "gpt-4o"
+    assert cfg["openai_temperature"] == 0.3
     assert cfg["default_threshold_mode"] == "profile"


### PR DESCRIPTION
## Summary
- support configurable temperature for OpenAI models
- pass temperature through config flow and AI feedback handler
- handle invalid OPENAI_TEMPERATURE environment variable
- document OpenAI temperature setting and env vars

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888d17f7d1483308939e11c36871bcf