### PR TITLE
Improve zone registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ from custom_components.horticulture_assistant.utils import zone_registry
 zone_registry.add_zone("3", ["switch.valve_3a", "switch.valve_3b"])
 zone_registry.attach_plants("3", ["plant_a", "plant_b"])
 zone_registry.attach_solenoids("3", ["switch.extra_valve"])
+print(zone_registry.zones_for_plant("plant_a"))  # ["3"]
 ```
 
 Irrigation settings are placed under `irrigation_schedule` with a `method`

--- a/custom_components/horticulture_assistant/utils/zone_registry.py
+++ b/custom_components/horticulture_assistant/utils/zone_registry.py
@@ -23,6 +23,7 @@ __all__ = [
     "attach_solenoids",
     "detach_solenoids",
     "remove_zone",
+    "zones_for_plant",
 ]
 
 
@@ -72,6 +73,15 @@ def list_zones(hass=None) -> List[str]:
     """Return all known zone IDs sorted alphabetically."""
 
     return sorted(load_zones(hass).keys())
+
+
+def zones_for_plant(plant_id: str, hass=None) -> List[str]:
+    """Return zone IDs containing ``plant_id`` sorted alphabetically."""
+
+    pid = str(plant_id)
+    return sorted(
+        zid for zid, zone in load_zones(hass).items() if pid in zone.plant_ids
+    )
 
 
 def save_zones(zones: Dict[str, ZoneConfig], hass=None) -> bool:

--- a/tests/test_zone_registry.py
+++ b/tests/test_zone_registry.py
@@ -10,6 +10,7 @@ from custom_components.horticulture_assistant.utils.zone_registry import (
     attach_solenoids,
     detach_solenoids,
     remove_zone,
+    zones_for_plant,
 )
 
 
@@ -82,4 +83,22 @@ def test_zone_registry_remove(tmp_path, monkeypatch):
     assert "10" in load_zones()
     assert remove_zone("10")
     assert "10" not in load_zones()
+
+
+def test_zones_for_plant(tmp_path, monkeypatch):
+    file_path = tmp_path / "zones.json"
+    file_path.write_text("{}")
+
+    def fake_config_path(hass, *parts):
+        return str(file_path)
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.utils.zone_registry.config_path",
+        fake_config_path,
+    )
+
+    assert add_zone("1", ["a"], ["p1"])
+    assert add_zone("2", ["b"], ["p2", "p1"])
+    zones = zones_for_plant("p1")
+    assert zones == ["1", "2"]
 


### PR DESCRIPTION
## Summary
- allow looking up zones that contain a plant
- document new helper in README
- test for `zones_for_plant`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d3b6dd9883309d9c8f156ca0f226