### PR TITLE
Add nutrient schedule helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 - Combined nutrient management reports with correction schedules
 - Automatic fertigation mix recommendations using priced fertilizer data
 - Daily report files summarizing environment and nutrient targets
+- Growth stage nutrient schedules for precise fertilization planning
 - Environment score and quality rating for sensor data
 - Infiltration-aware irrigation burst scheduling
 - Cost-optimized fertigation plans with injection volumes

--- a/tests/test_nutrient_schedule.py
+++ b/tests/test_nutrient_schedule.py
@@ -1,12 +1,12 @@
-from plant_engine.nutrient_schedule import generate_daily_uptake_plan
+from custom_components.horticulture_assistant.utils.nutrient_schedule import (
+    generate_nutrient_schedule,
+)
 
 
-def test_generate_daily_uptake_plan_strawberry():
-    plan = generate_daily_uptake_plan("strawberry")
-    assert "vegetative" in plan
-    veg = plan["vegetative"]
-    assert len(veg) == 60
-    first_day = veg[1]
-    assert first_day["N"] == 14.0
-    assert first_day["P"] == 6.0
-    assert first_day["K"] == 16.0
+def test_generate_nutrient_schedule():
+    schedule = generate_nutrient_schedule("citrus")
+    assert schedule
+    first = schedule[0]
+    assert first.stage == "seedling"
+    assert first.duration_days == 60
+    assert abs(first.totals["N"] - 75 * 60) < 0.01


### PR DESCRIPTION
## Summary
- implement `generate_nutrient_schedule` utility to compute per-stage totals
- document the new feature in the README
- test nutrient schedule generation

## Testing
- `pytest tests/test_nutrient_requirements.py tests/test_stage_nutrient_requirements.py tests/test_nutrient_schedule.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d3aebef48330952e2f4afcbbd9fe