### PR TITLE
Add pest damage thresholds and monitoring utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Important categories include:
 - **Pest and disease references** – thresholds, prevention tips and treatment options
 - **Fungicide recommendations** – suggested organic products for common diseases
 - **Pest scouting methods** – recommended techniques for monitoring common pests
+- **Pest damage thresholds** – percent leaf damage that warrants treatment
 - **Stage-specific pest thresholds** – economic thresholds for each growth stage
 - **Irrigation and water quality** – daily volume guidelines, quality thresholds and cost estimates
 - **Water usage guidelines** – typical daily irrigation volumes by stage

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -20,6 +20,7 @@
     "pest_monitoring_intervals.json": "Recommended days between scouting events.",
     "pest_risk_interval_modifiers.json": "Multipliers adjusting monitoring frequency based on risk level.",
     "pest_scouting_methods.json": "Recommended scouting techniques for common pests.",
+    "pest_damage_thresholds.json": "Percentage leaf damage thresholds for action.",
     "pest_lifecycle_durations.json": "Typical development duration for common pest life stages.",
     "ipm_guidelines.json": "Integrated pest management practices by crop.",
     "disease_guidelines.json": "Treatment guidance for common plant diseases.",

--- a/data/pest_damage_thresholds.json
+++ b/data/pest_damage_thresholds.json
@@ -1,0 +1,1 @@
+{"aphids": 20, "thrips": 10, "spider mites": 15}

--- a/tests/test_pest_damage.py
+++ b/tests/test_pest_damage.py
@@ -1,0 +1,23 @@
+import builtins
+
+from plant_engine import pest_monitor
+
+
+def test_get_damage_threshold():
+    assert pest_monitor.get_damage_threshold("aphids") == 20
+    assert pest_monitor.get_damage_threshold("unknown") is None
+
+
+def test_is_damage_severe():
+    assert pest_monitor.is_damage_severe("aphids", 25) is True
+    assert pest_monitor.is_damage_severe("aphids", 15) is False
+    assert pest_monitor.is_damage_severe("unknown", 10) is None
+
+
+def test_is_damage_severe_invalid():
+    try:
+        pest_monitor.is_damage_severe("aphids", -1)
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError"


### PR DESCRIPTION
## Summary
- introduce `pest_damage_thresholds.json` dataset for leaf damage limits
- register the dataset in `dataset_catalog.json`
- extend `pest_monitor` with damage threshold helpers
- document new dataset in README
- add unit tests for new functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888d397de2883309766a3cab7b17982