### PR TITLE
Improve dataset_info CLI

### DIFF
--- a/scripts/dataset_info.py
+++ b/scripts/dataset_info.py
@@ -20,6 +20,7 @@ from plant_engine.datasets import (
     list_datasets_by_category,
     list_dataset_info_by_category,
     search_datasets,
+    get_dataset_description,
 )
 
 
@@ -43,6 +44,11 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="include dataset descriptions in output",
     )
+
+    desc_parser = sub.add_parser(
+        "describe", help="show description for a specific dataset"
+    )
+    desc_parser.add_argument("name", help="dataset file name")
 
     args = parser.parse_args(argv)
 
@@ -77,6 +83,14 @@ def main(argv: list[str] | None = None) -> None:
                 print(f"[{cat}]")
                 for name in names:
                     print(f"  {name}")
+        return
+
+    if args.command == "describe":
+        desc = get_dataset_description(args.name)
+        if desc is None:
+            print("Dataset not found", file=sys.stderr)
+            sys.exit(1)
+        print(f"{args.name}: {desc}")
         return
 
 

--- a/tests/test_dataset_info_script.py
+++ b/tests/test_dataset_info_script.py
@@ -37,3 +37,14 @@ def test_categories_cli():
     out = result.stdout
     assert "[fertilizers]" in out
     assert "fertilizers/fertilizer_products.json" in out
+
+
+def test_describe_cli():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "describe", "nutrient_guidelines.json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = result.stdout.strip()
+    assert out.startswith("nutrient_guidelines.json:")


### PR DESCRIPTION
## Summary
- enhance dataset_info CLI with a `describe` subcommand
- cover the new command in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d3a594a08330b97856704aaf3cc2