### PR TITLE
Add pest severity index calculation

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -93,6 +93,7 @@
     "disease_risk_factors.json": "Environmental factors increasing disease risk.",
     "pest_severity_actions.json": "Actions to take based on pest severity level.",
     "pest_severity_thresholds.json": "Population levels defining pest severity categories.",
+    "pest_severity_scores.json": "Numeric scores for pest severity levels.",
     "ph_adjustment_factors.json": "Acid/base amounts for pH corrections.",
     "ph_guidelines.json": "Optimal pH ranges for nutrient uptake.",
     "growth_medium_ph_ranges.json": "Recommended pH ranges for common growing media.",

--- a/data/pest_severity_scores.json
+++ b/data/pest_severity_scores.json
@@ -1,0 +1,5 @@
+{
+  "low": 1,
+  "moderate": 2,
+  "severe": 3
+}

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -20,6 +20,7 @@ from plant_engine.pest_monitor import (
     get_severity_thresholds,
     summarize_pest_management,
     calculate_pest_management_index,
+    calculate_severity_index,
     estimate_adjusted_pest_risk_series,
 )
 
@@ -189,6 +190,7 @@ def test_summarize_pest_management():
     assert summary["risk"]["aphids"] == "high"
     assert summary.get("risk_score") is not None
     assert "next_monitor_date" in summary
+    assert summary.get("severity_index") is not None
 
 
 def test_get_scouting_method():
@@ -222,4 +224,16 @@ def test_estimate_adjusted_pest_risk_series():
     risk = estimate_adjusted_pest_risk_series("citrus", series)
     assert risk.get("aphids") == "high"
     assert risk.get("mites") == "moderate"
+
+
+def test_calculate_severity_index():
+    severity = {"aphids": "moderate", "scale": "severe"}
+    idx = calculate_severity_index(severity)
+    assert idx == 2.5
+
+
+def test_report_includes_severity_index():
+    obs = {"aphids": 6}
+    report = generate_pest_report("citrus", obs)
+    assert report["severity_index"] > 0
 


### PR DESCRIPTION
## Summary
- add `pest_severity_scores.json` dataset and catalog entry
- implement `calculate_severity_index` and integrate into pest reports
- expose severity index in pest monitoring results
- test severity index calculations and reporting

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d3a1df3083309abf0ad9720284c0