### PR TITLE
Add fertigation optimizer module with tests

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -29,6 +29,7 @@ from .precipitation_risk import (
     list_supported_plants as list_precipitation_plants,
     estimate_precipitation_risk,
 )
+from .fertigation_optimizer import generate_fertigation_plan
 
 __all__ = sorted(
     set(utils.__all__)
@@ -48,6 +49,7 @@ __all__ = sorted(
         "apply_absorption_rates",
         "list_precipitation_plants",
         "estimate_precipitation_risk",
+        "generate_fertigation_plan",
     }
 )
 

--- a/plant_engine/fertigation_optimizer.py
+++ b/plant_engine/fertigation_optimizer.py
@@ -1,0 +1,45 @@
+"""High level fertigation planning utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .fertigation import (
+    recommend_loss_adjusted_fertigation,
+    get_fertigation_interval,
+)
+
+__all__ = ["generate_fertigation_plan"]
+
+
+def generate_fertigation_plan(
+    plant_type: str, stage: str, volume_l: float
+) -> Dict[str, Any]:
+    """Return fertigation schedule and interval for a plant stage.
+
+    The schedule is loss-adjusted using dataset factors and includes an
+    estimated cost breakdown. Interval days are looked up via
+    :data:`fertigation_intervals.json`. The return dictionary contains:
+
+    ``schedule_g`` - grams of each fertilizer per batch
+    ``cost`` - estimated total cost
+    ``cost_breakdown`` - cost per fertilizer
+    ``warnings`` - warnings from formulation checks
+    ``diagnostics`` - nutrient ppm and toxicity diagnostics
+    ``interval_days`` - recommended days between fertigation events
+    """
+
+    schedule, cost, breakdown, warnings, diagnostics = (
+        recommend_loss_adjusted_fertigation(plant_type, stage, volume_l)
+    )
+
+    interval = get_fertigation_interval(plant_type, stage)
+
+    return {
+        "schedule_g": schedule,
+        "cost": cost,
+        "cost_breakdown": breakdown,
+        "warnings": warnings,
+        "diagnostics": diagnostics,
+        "interval_days": interval,
+    }

--- a/tests/test_fertigation_optimizer.py
+++ b/tests/test_fertigation_optimizer.py
@@ -1,0 +1,24 @@
+import pytest
+from plant_engine import fertigation_optimizer
+
+
+def test_generate_fertigation_plan_basic(monkeypatch):
+    def fake_recommend(pt, st, vol):
+        return {"urea": 3.15, "map": 1.545, "kcl": 2.04}, 0.0, {}, {}, {}
+
+    def fake_interval(pt, st):
+        return 1
+
+    monkeypatch.setattr(
+        fertigation_optimizer, "recommend_loss_adjusted_fertigation", fake_recommend
+    )
+    monkeypatch.setattr(
+        fertigation_optimizer, "get_fertigation_interval", fake_interval
+    )
+
+    plan = fertigation_optimizer.generate_fertigation_plan("lettuce", "seedling", 10)
+    assert plan["interval_days"] == 1
+    assert plan["schedule_g"]["urea"] == 3.15
+    assert plan["schedule_g"]["map"] == 1.545
+    assert plan["schedule_g"]["kcl"] == 2.04
+    assert plan["cost"] == 0.0


### PR DESCRIPTION
## Summary
- expose new fertigation planning helper through `plant_engine`
- implement `fertigation_optimizer.generate_fertigation_plan`
- unit test for fertigation plan generation

## Testing
- `pytest tests/test_fertigation_optimizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888df6baef8833085edaed05dbc94bd