### PR TITLE
Add airflow guidelines support

### DIFF
--- a/data/airflow_guidelines.json
+++ b/data/airflow_guidelines.json
@@ -1,0 +1,13 @@
+{
+  "citrus": {
+    "seedling": [0.5, 1.0],
+    "vegetative": [1.0, 1.5]
+  },
+  "tomato": {
+    "vegetative": [0.6, 1.2],
+    "fruiting": [0.8, 1.4]
+  },
+  "lettuce": {
+    "optimal": [0.4, 0.9]
+  }
+}

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -113,6 +113,7 @@
     "soil_ph_guidelines.json": "Recommended soil pH ranges by crop.",
     "wind_stress_thresholds.json": "Wind speeds that cause physical damage.",
     "wind_actions.json": "Recommended actions for high wind speeds.",
+    "airflow_guidelines.json": "Recommended airflow rates (CFM per m²) for each plant stage.",
     "yield_estimates.json": "Expected total yields for common cultivars.",
     "co2_prices.json": "Cost per kg of CO₂ for enrichment.",
     "co2_method_efficiency.json": "Relative CO₂ delivery efficiency by enrichment method.",

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -48,6 +48,7 @@ SOIL_EC_DATA_FILE = "soil_ec_guidelines.json"
 LEAF_TEMP_DATA_FILE = "leaf_temperature_guidelines.json"
 SOIL_PH_DATA_FILE = "soil_ph_guidelines.json"
 FROST_DATES_FILE = "frost_dates.json"
+AIRFLOW_DATA_FILE = "airflow_guidelines.json"
 ALIAS_DATA_FILE = "environment_aliases.json"
 
 # map of dataset keys to human readable labels used when recommending
@@ -355,6 +356,7 @@ __all__ = [
     "get_target_co2",
     "get_target_light_intensity",
     "get_target_light_ratio",
+    "get_target_airflow",
     "get_target_soil_moisture",
     "get_target_soil_temperature",
     "get_target_soil_ec",
@@ -460,6 +462,7 @@ _SOIL_EC_DATA: Dict[str, Any] = load_dataset(SOIL_EC_DATA_FILE)
 _LEAF_TEMP_DATA: Dict[str, Any] = load_dataset(LEAF_TEMP_DATA_FILE)
 _FROST_DATES: Dict[str, Any] = load_dataset(FROST_DATES_FILE)
 _SOIL_PH_DATA: Dict[str, Any] = load_dataset(SOIL_PH_DATA_FILE)
+_AIRFLOW_DATA: Dict[str, Any] = load_dataset(AIRFLOW_DATA_FILE)
 
 
 def get_score_weight(metric: str) -> float:
@@ -2072,6 +2075,14 @@ def get_target_light_ratio(plant_type: str, stage: str | None = None) -> float |
     if stage is None:
         return None
     return get_red_blue_ratio(plant_type, stage)
+
+
+def get_target_airflow(
+    plant_type: str, stage: str | None = None
+) -> RangeTuple | None:
+    """Return recommended airflow range (CFM per m²) for a plant stage."""
+
+    return _lookup_range(_AIRFLOW_DATA, plant_type, stage)
 
 
 # Approximate mass of CO₂ in milligrams required per m³ to raise

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -26,6 +26,7 @@ from plant_engine.environment_manager import (
     get_target_co2,
     get_target_light_intensity,
     get_target_light_ratio,
+    get_target_airflow,
     calculate_co2_injection,
     recommend_co2_injection,
     get_co2_price,
@@ -532,6 +533,11 @@ def test_get_target_light_ratio():
 def test_get_target_light_intensity():
     assert get_target_light_intensity("citrus", "seedling") == (150, 300)
     assert get_target_light_intensity("unknown") is None
+
+
+def test_get_target_airflow():
+    assert get_target_airflow("citrus", "seedling") == (0.5, 1.0)
+    assert get_target_airflow("unknown") is None
 
 
 def test_calculate_co2_injection():


### PR DESCRIPTION
## Summary
- add a new `airflow_guidelines.json` dataset
- document dataset in `dataset_catalog.json`
- support airflow targets in `environment_manager`
- test new airflow helper

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888df6d8e1c8330ba79691eb8a22193