### PR TITLE
Add DataFrame environment scoring helper

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -331,6 +331,7 @@ __all__ = [
     "recommend_environment_adjustments",
     "score_environment",
     "score_environment_series",
+    "score_environment_dataframe",
     "score_environment_components",
     "suggest_environment_setpoints",
     "suggest_environment_setpoints_advanced",
@@ -1064,6 +1065,60 @@ def score_environment_series(
         return 0.0
 
     return round(total / count, 1)
+
+
+def score_environment_dataframe(
+    df: "pd.DataFrame", plant_type: str, stage: str | None = None
+) -> "pd.Series":
+    """Return environment scores for each row in ``df``.
+
+    The calculation is vectorized for efficiency and mirrors
+    :func:`score_environment` semantics.
+    """
+
+    import pandas as pd
+    import numpy as np
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    targets = get_environmental_targets(plant_type, stage)
+    if not targets:
+        return pd.Series([0.0] * len(df), index=df.index)
+
+    scores = pd.DataFrame(index=df.index)
+    weights = []
+    for key, bounds in targets.items():
+        if (
+            key not in df
+            or not isinstance(bounds, (list, tuple))
+            or len(bounds) != 2
+        ):
+            continue
+        low, high = float(bounds[0]), float(bounds[1])
+        width = high - low
+        if width <= 0:
+            continue
+        values = df[key].astype(float)
+        comp = np.where(
+            values < low,
+            1 - (low - values) / width,
+            np.where(values > high, 1 - (values - high) / width, 1.0),
+        )
+        scores[key] = np.clip(comp, 0.0, 1.0) * 100
+        weights.append(get_score_weight(key))
+
+    if scores.empty:
+        return pd.Series([0.0] * len(df), index=df.index)
+
+    weight_arr = np.array(weights)
+    weighted = scores.mul(weight_arr, axis=1)
+    total_weight = (
+        (~scores.isna()).astype(float).mul(weight_arr, axis=1)
+    ).sum(axis=1)
+    total_weight = total_weight.replace(0, np.nan)
+    result = weighted.sum(axis=1) / total_weight
+    return result.fillna(0.0).round(1)
 
 
 def classify_environment_quality(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -56,6 +56,7 @@ from plant_engine.environment_manager import (
     evaluate_leaf_temperature_stress,
     score_environment,
     score_environment_series,
+    score_environment_dataframe,
     score_environment_components,
     optimize_environment,
     calculate_environment_metrics,
@@ -1148,3 +1149,18 @@ def test_get_frost_dates_and_is_frost_free():
 
     assert is_frost_free(datetime.date(2024, 5, 1), "zone_6")
     assert not is_frost_free(datetime.date(2024, 3, 1), "zone_6")
+
+
+def test_score_environment_dataframe():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {"temp_c": 22, "humidity_pct": 70, "light_ppfd": 250, "co2_ppm": 450},
+            {"temp_c": 18, "humidity_pct": 50, "light_ppfd": 100, "co2_ppm": 800},
+        ]
+    )
+    scores = score_environment_dataframe(df, "citrus", "seedling")
+    assert len(scores) == 2
+    assert scores.iloc[0] > scores.iloc[1]
+


### PR DESCRIPTION
## Summary
- handle environment scoring for pandas DataFrames via new helper
- test `score_environment_dataframe` in environment manager

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests/test_environment_manager.py::test_score_environment_dataframe`
- `pytest -q tests/test_environment_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6888df6f99048330a8ed012c8a76dd99