### PR TITLE
Improve deficiency manager with synergy support

### DIFF
--- a/plant_engine/deficiency_manager.py
+++ b/plant_engine/deficiency_manager.py
@@ -32,6 +32,8 @@ __all__ = [
     "summarize_deficiencies",
     "recommend_deficiency_treatments",
     "diagnose_deficiency_actions",
+    "assess_deficiency_severity_with_synergy",
+    "summarize_deficiencies_with_synergy",
 ]
 
 
@@ -165,6 +167,42 @@ def summarize_deficiencies(
         current_levels, plant_type, stage
     )
     index = calculate_deficiency_index(severity)
+    return {
+        "severity": severity,
+        "treatments": treatments,
+        "severity_index": index,
+    }
+
+
+def assess_deficiency_severity_with_synergy(
+    current_levels: Mapping[str, float], plant_type: str, stage: str
+) -> Dict[str, str]:
+    """Return severity levels using synergy-adjusted guidelines."""
+
+    from . import nutrient_manager
+
+    deficits = nutrient_manager.calculate_all_deficiencies_with_synergy(
+        current_levels, plant_type, stage
+    )
+    return classify_deficiency_levels(deficits)
+
+
+def summarize_deficiencies_with_synergy(
+    current_levels: Mapping[str, float], plant_type: str, stage: str
+) -> Dict[str, object]:
+    """Return deficiency summary using synergy-adjusted targets."""
+
+    from . import nutrient_manager
+
+    severity = assess_deficiency_severity_with_synergy(
+        current_levels, plant_type, stage
+    )
+    treatments = recommend_deficiency_treatments(
+        current_levels, plant_type, stage
+    )
+    index = nutrient_manager.calculate_deficiency_index_with_synergy(
+        current_levels, plant_type, stage
+    )
     return {
         "severity": severity,
         "treatments": treatments,

--- a/tests/test_deficiency_manager.py
+++ b/tests/test_deficiency_manager.py
@@ -10,6 +10,7 @@ from plant_engine.deficiency_manager import (
     diagnose_deficiency_actions,
     calculate_deficiency_index,
     summarize_deficiencies,
+    summarize_deficiencies_with_synergy,
 )
 from plant_engine.nutrient_manager import get_recommended_levels
 
@@ -98,4 +99,12 @@ def test_summarize_deficiencies():
     summary = summarize_deficiencies(current, "lettuce", "seedling")
     assert summary["severity_index"] == 3.0
     assert "N" in summary["treatments"]
+
+
+def test_summarize_deficiencies_with_synergy():
+    guidelines = get_recommended_levels("tomato", "fruiting")
+    current = {n: 0 for n in guidelines}
+    summary = summarize_deficiencies_with_synergy(current, "tomato", "fruiting")
+    assert summary["severity_index"] > 0
+    assert summary["severity"].get("P") == "severe"
 


### PR DESCRIPTION
## Summary
- extend `deficiency_manager` to offer synergy-aware summary functions
- add tests to cover new functionality

## Testing
- `pytest tests/test_deficiency_manager.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888df715a6c833088dfcc4fa5bb41c2