### PR TITLE
Add nutrient analyzer utility and tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/nutrient_analyzer.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_analyzer.py
@@ -1,0 +1,47 @@
+"""Simple helpers for nutrient adjustment calculations."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+from plant_engine.nutrient_manager import calculate_nutrient_adjustments
+
+__all__ = ["recommend_adjustments", "ppm_to_mg"]
+
+
+def recommend_adjustments(
+    current_levels: Mapping[str, float],
+    plant_type: str,
+    stage: str,
+    volume_l: float | None = None,
+) -> Dict[str, float]:
+    """Return nutrient ppm adjustments and optional milligram totals.
+
+    Parameters
+    ----------
+    current_levels: Mapping[str, float]
+        Current measured nutrient values in ppm.
+    plant_type: str
+        Crop identifier for guideline lookup.
+    stage: str
+        Growth stage for guideline lookup.
+    volume_l: float | None
+        Optional solution volume. If provided the returned dictionary
+        includes additional ``*_mg`` keys with the milligram amounts to
+        add to that volume.
+    """
+
+    ppm_adjust = calculate_nutrient_adjustments(current_levels, plant_type, stage)
+    if volume_l is None or not ppm_adjust:
+        return ppm_adjust
+
+    mg_adjust: Dict[str, float] = {}
+    for nutrient, ppm in ppm_adjust.items():
+        mg_adjust[f"{nutrient}_mg"] = ppm * volume_l
+    ppm_adjust.update(mg_adjust)
+    return ppm_adjust
+
+
+def ppm_to_mg(ppm: float, volume_l: float) -> float:
+    """Return milligrams represented by ``ppm`` in ``volume_l`` liters."""
+    return round(ppm * volume_l, 3)

--- a/tests/test_nutrient_analyzer.py
+++ b/tests/test_nutrient_analyzer.py
@@ -1,0 +1,34 @@
+import pytest
+
+from custom_components.horticulture_assistant.utils.nutrient_analyzer import (
+    recommend_adjustments,
+    ppm_to_mg,
+)
+
+
+@pytest.mark.parametrize(
+    "current,expected",
+    [
+        ({"N": 50, "P": 25, "K": 40}, {"N": 70, "P": 15, "K": 60}),
+        ({"N": 120, "P": 40, "K": 110}, {"N": 0, "P": 0, "K": -10}),
+    ],
+)
+def test_recommend_adjustments_basic(current, expected):
+    result = recommend_adjustments(current, "citrus", "fruiting")
+    for nutrient, value in expected.items():
+        if value == 0:
+            assert nutrient not in result
+        else:
+            assert pytest.approx(result[nutrient]) == value
+
+
+def test_recommend_adjustments_with_volume():
+    current = {"N": 50, "P": 25, "K": 40}
+    result = recommend_adjustments(current, "citrus", "fruiting", volume_l=2)
+    assert result["N"] == 70
+    assert result["N_mg"] == 140
+    assert result["K_mg"] == 120
+
+
+def test_ppm_to_mg():
+    assert ppm_to_mg(50, 1.5) == 75.0


### PR DESCRIPTION
## Summary
- implement simple nutrient analyzer helper
- test nutrient analyzer calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888df7351cc8330b453a72820c6efd6