### PR TITLE
Improve alias utilities and tests

### DIFF
--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -117,6 +117,12 @@ def get_environment_aliases() -> Dict[str, list[str]]:
     return {k: list(v) for k, v in ENV_ALIASES.items()}
 
 
+def resolve_environment_alias(key: str) -> str | None:
+    """Return canonical environment key for ``key`` when known."""
+
+    return _ALIAS_MAP.get(key)
+
+
 @dataclass(slots=True, frozen=True)
 class EnvironmentGuidelines:
     """Environmental target ranges for a plant stage."""
@@ -408,6 +414,7 @@ __all__ = [
     "StressFlags",
     "WaterQualityInfo",
     "get_environment_aliases",
+    "resolve_environment_alias",
     "normalize_environment_readings",
     "classify_value_range",
     "compare_environment",

--- a/tests/test_dataset_catalog.py
+++ b/tests/test_dataset_catalog.py
@@ -151,3 +151,7 @@ def test_get_dataset_path_and_load():
     assert path and path.exists()
     data = datasets.load_dataset_file("nutrient_guidelines.json")
     assert isinstance(data, dict)
+
+def test_dataset_exists():
+    assert datasets.dataset_exists("nutrient_guidelines.json")
+    assert not datasets.dataset_exists("missing_dataset.json")

--- a/tests/test_environment_aliases.py
+++ b/tests/test_environment_aliases.py
@@ -1,0 +1,12 @@
+import plant_engine.environment_manager as em
+
+
+def test_get_environment_aliases_contains_temperature():
+    aliases = em.get_environment_aliases()
+    assert "temp_c" in aliases
+    assert "temperature" in aliases["temp_c"]
+
+
+def test_resolve_environment_alias():
+    assert em.resolve_environment_alias("temperature") == "temp_c"
+    assert em.resolve_environment_alias("unknown") is None


### PR DESCRIPTION
## Summary
- add `resolve_environment_alias` helper for mapping environment key aliases
- expose the helper via `__all__`
- test dataset existence
- test environment alias utilities

## Testing
- `pytest tests/test_environment_aliases.py tests/test_dataset_catalog.py::test_dataset_exists -q`


------
https://chatgpt.com/codex/tasks/task_e_6888df75e2dc83309f4add577ad7d3f0