### PR TITLE
Add integrated management summary helper

### DIFF
--- a/plant_engine/integrated_monitor.py
+++ b/plant_engine/integrated_monitor.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 """Utilities for combined pest and disease monitoring schedules."""
 
 from datetime import date
-from typing import List
+from typing import List, Mapping, Dict, Any
 
 from . import pest_monitor, disease_monitor
 
-__all__ = ["generate_integrated_monitoring_schedule"]
+__all__ = [
+    "generate_integrated_monitoring_schedule",
+    "summarize_integrated_management",
+]
 
 
 def generate_integrated_monitoring_schedule(
@@ -28,3 +31,31 @@ def generate_integrated_monitoring_schedule(
     disease = disease_monitor.generate_monitoring_schedule(plant_type, stage, start, events)
     combined = sorted(set(pest + disease))
     return combined[:events]
+
+
+def summarize_integrated_management(
+    plant_type: str,
+    stage: str | None,
+    pests: Mapping[str, int],
+    diseases: Mapping[str, int],
+    environment: Mapping[str, float] | None = None,
+    last_date: date | None = None,
+) -> Dict[str, Any]:
+    """Return combined pest and disease management summary."""
+
+    pest_summary = pest_monitor.summarize_pest_management(
+        plant_type,
+        stage,
+        pests,
+        environment=environment,
+        last_date=last_date,
+    )
+    disease_summary = disease_monitor.summarize_disease_management(
+        plant_type,
+        stage,
+        diseases,
+        environment=environment,
+        last_date=last_date,
+    )
+
+    return {"pests": pest_summary, "diseases": disease_summary}

--- a/tests/test_integrated_monitor.py
+++ b/tests/test_integrated_monitor.py
@@ -1,6 +1,9 @@
 from datetime import date
 
-from plant_engine.integrated_monitor import generate_integrated_monitoring_schedule
+from plant_engine.integrated_monitor import (
+    generate_integrated_monitoring_schedule,
+    summarize_integrated_management,
+)
 
 
 def test_generate_integrated_monitoring_schedule():
@@ -17,3 +20,19 @@ def test_generate_integrated_monitoring_schedule():
 def test_generate_integrated_monitoring_schedule_unknown():
     start = date(2023, 1, 1)
     assert generate_integrated_monitoring_schedule("unknown", None, start, 3) == []
+
+
+def test_summarize_integrated_management():
+    pests = {"aphids": 3}
+    diseases = {"citrus greening": 2}
+    env = {"humidity_pct": 80, "temp_c": 25}
+    summary = summarize_integrated_management(
+        "citrus",
+        "fruiting",
+        pests,
+        diseases,
+        environment=env,
+        last_date=date(2023, 1, 1),
+    )
+    assert "pests" in summary and "diseases" in summary
+    assert summary["pests"]["risk"]


### PR DESCRIPTION
## Summary
- extend `integrated_monitor` with `summarize_integrated_management`
- test new helper in `tests/test_integrated_monitor.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888df7751c083308aac14abff8694cb