### PR TITLE
Refactor engine helpers and add coverage

### DIFF
--- a/tests/test_engine_helpers.py
+++ b/tests/test_engine_helpers.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from plant_engine import engine
+
+
+def test_generate_environment_actions(tmp_path, monkeypatch):
+    profile = {"plant_type": "citrus", "stage": "vegetative", "observed_pests": ["aphids"], "observed_diseases": ["root rot"]}
+    env = {"temp_c": 24, "rh_pct": 60, "par_w_m2": 300}
+    # Use real dataset; function should work without patching
+    actions = engine._generate_environment_actions(profile, env)
+    env_actions, pest_actions, disease_actions = actions
+    assert isinstance(env_actions, dict)
+    assert pest_actions.get("aphids")
+    assert disease_actions.get("root rot")
+
+
+def test_get_nutrient_targets():
+    profile = {"plant_type": "citrus", "stage": "vegetative"}
+    guidelines, targets = engine._get_nutrient_targets(profile)
+    assert guidelines
+    assert targets
+
+
+def test_write_report(tmp_path, monkeypatch):
+    monkeypatch.setattr(engine, "OUTPUT_DIR", str(tmp_path))
+    data = {"a": 1}
+    engine._write_report("demo", data)
+    out_file = Path(tmp_path) / "demo.json"
+    assert out_file.exists()
+    assert json.loads(out_file.read_text()) == data


### PR DESCRIPTION
## Summary
- refactor plant_engine.engine for clarity
- add helper functions for environment actions, nutrient targets and report writing
- include unit tests for new helpers

## Testing
- `pytest -q tests/test_engine.py tests/test_engine_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6888df80c89083308249da26df715a7d