### PR TITLE
Add daily optimization planner

### DIFF
--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 
 from . import utils, environment_tips, media_manager, ingredients, reference_data
-from . import height_manager
+from . import height_manager, daily_optimizer
 from .reference_data import load_reference_data, refresh_reference_data
 from .utils import *  # noqa: F401,F403
 from .environment_tips import *  # noqa: F401,F403
@@ -29,6 +29,7 @@ from .precipitation_risk import (
     list_supported_plants as list_precipitation_plants,
     estimate_precipitation_risk,
 )
+from .daily_optimizer import DailyPlan, build_daily_plan
 
 __all__ = sorted(
     set(utils.__all__)
@@ -48,6 +49,8 @@ __all__ = sorted(
         "apply_absorption_rates",
         "list_precipitation_plants",
         "estimate_precipitation_risk",
+        "DailyPlan",
+        "build_daily_plan",
     }
 )
 

--- a/plant_engine/daily_optimizer.py
+++ b/plant_engine/daily_optimizer.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Generate consolidated daily management plans.
+
+This helper pulls together recommendations from the environment,
+fertigation and pest management modules so applications have a
+single entry point for actionable tasks.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Dict, Any
+
+from . import environment_manager as env
+from . import fertigation
+from . import pest_manager
+
+
+@dataclass(slots=True)
+class DailyPlan:
+    """Summary of recommended daily actions."""
+
+    environment_actions: Dict[str, str]
+    fertigation_schedule: Dict[str, float]
+    cost_total: float
+    cost_breakdown: Dict[str, float]
+    pest_plan: Dict[str, Any]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "environment_actions": self.environment_actions,
+            "fertigation_schedule": self.fertigation_schedule,
+            "cost_total": self.cost_total,
+            "cost_breakdown": self.cost_breakdown,
+            "pest_plan": self.pest_plan,
+        }
+
+
+def build_daily_plan(
+    plant_type: str,
+    stage: str,
+    *,
+    temp_c: float | None = None,
+    humidity_pct: float | None = None,
+    wind_m_s: float | None = None,
+    pests: Iterable[str] | None = None,
+    water_profile: Mapping[str, float] | None = None,
+    include_micro: bool = False,
+    fertilizers: Mapping[str, str] | None = None,
+    volume_l: float = 1.0,
+) -> DailyPlan:
+    """Return a :class:`DailyPlan` for the given crop conditions."""
+
+    env_actions: Dict[str, str] = {}
+
+    t_act = env.recommend_temperature_action(temp_c, humidity_pct, plant_type)
+    if t_act:
+        env_actions["temperature"] = t_act
+
+    h_act = env.recommend_humidity_action(humidity_pct, plant_type)
+    if h_act:
+        env_actions["humidity"] = h_act
+
+    w_act = env.recommend_wind_action(wind_m_s, plant_type)
+    if w_act:
+        env_actions["wind"] = w_act
+
+    sched, total, breakdown, _warn, _diag = fertigation.recommend_precise_fertigation(
+        plant_type,
+        stage,
+        volume_l,
+        water_profile,
+        include_micro=include_micro,
+        fertilizers=fertilizers,
+    )
+
+    pest_plan = (
+        pest_manager.build_pest_management_plan(plant_type, pests)
+        if pests
+        else {}
+    )
+
+    return DailyPlan(env_actions, sched, total, breakdown, pest_plan)
+
+
+__all__ = ["DailyPlan", "build_daily_plan"]

--- a/tests/test_daily_optimizer.py
+++ b/tests/test_daily_optimizer.py
@@ -1,0 +1,28 @@
+from plant_engine.daily_optimizer import build_daily_plan
+
+
+def test_build_daily_plan():
+    plan = build_daily_plan(
+        "citrus",
+        "vegetative",
+        temp_c=42,
+        humidity_pct=20,
+        wind_m_s=16,
+        pests=["aphids"],
+        volume_l=1.0,
+        include_micro=False,
+        water_profile=None,
+        fertilizers={
+            "N": "foxfarm_grow_big",
+            "P": "foxfarm_grow_big",
+            "K": "intrepid_granular_potash_0_0_60",
+        },
+    )
+
+    assert "temperature" in plan.environment_actions
+    assert "humidity" in plan.environment_actions
+    assert "wind" in plan.environment_actions
+    assert "foxfarm_grow_big" in plan.fertigation_schedule
+    assert "aphids" in plan.pest_plan
+    assert plan.cost_total >= 0
+    assert isinstance(plan.cost_breakdown, dict)


### PR DESCRIPTION
## Summary
- implement `daily_optimizer` module for consolidated crop guidance
- expose planner via plant_engine package
- test new daily plan helper

## Testing
- `pytest -q tests/test_daily_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_6888df82c4dc8330afca65440a4621e3