### PR TITLE
Enhance fertigation injector calculations

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -140,6 +140,7 @@
     "fertigation_volume.json": "Recommended nutrient solution volume in mL per plant per event.",
     "emitter_flow_rates.json": "Typical emitter flow rates in L/h.",
     "fertigation_injectors.json": "Injection ratios (parts water to stock solution).",
+    "fertigation_injector_flow_rates.json": "Approximate injector flow rates in L/min.",
     "companion_plants.json": "Companion planting recommendations.",
     "rotation_guidance.json": "Crop rotation families and recommended years between replanting.",
     "pesticide_withdrawal_days.json": "Mandatory days to wait after pesticide application before harvest.",

--- a/data/fertigation_injector_flow_rates.json
+++ b/data/fertigation_injector_flow_rates.json
@@ -1,0 +1,4 @@
+{
+  "dosatron_1pct": 1.0,
+  "dosatron_2pct": 1.0
+}

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -535,3 +535,20 @@ def test_calculate_injection_volumes():
     with pytest.raises(KeyError):
         calculate_injection_volumes({"unknown": 1.0}, 10.0, "dosatron_1pct")
 
+
+def test_get_injector_flow_rate():
+    from plant_engine.fertigation import get_injector_flow_rate
+
+    assert get_injector_flow_rate("dosatron_1pct") == 1.0
+    assert get_injector_flow_rate("unknown") is None
+
+
+def test_estimate_injection_duration():
+    from plant_engine.fertigation import estimate_injection_duration
+
+    schedule = {"foxfarm_grow_big": 20.0}
+    expected_volume = round(20.0 / (0.96 * 1000) * 1000 / 100, 3)
+    expected_time = round(expected_volume / (1.0 * 1000), 3)
+    duration = estimate_injection_duration(schedule, 10.0, "dosatron_1pct")
+    assert duration == expected_time
+


### PR DESCRIPTION
## Summary
- support injector flow rates for fertigation scheduling
- estimate injection duration based on flow rate
- document new dataset entry
- test new helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f01b838083309f6fe560b621d1ef