### PR TITLE
Improve nutrient schedule performance

### DIFF
--- a/custom_components/horticulture_assistant/utils/nutrient_schedule.py
+++ b/custom_components/horticulture_assistant/utils/nutrient_schedule.py
@@ -1,8 +1,9 @@
-"""Generate nutrient schedules across growth stages."""
+"""Helpers to generate nutrient schedules across growth stages."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Dict, List
 
 from plant_engine import growth_stage
@@ -18,6 +19,7 @@ class StageNutrientTotals:
     totals: Dict[str, float]
 
 
+@lru_cache(maxsize=None)
 def generate_nutrient_schedule(plant_type: str) -> List[StageNutrientTotals]:
     """Return per-stage nutrient totals for ``plant_type``.
 
@@ -35,7 +37,7 @@ def generate_nutrient_schedule(plant_type: str) -> List[StageNutrientTotals]:
         daily = stage_nutrient_requirements.get_stage_requirements(
             plant_type, stage
         )
-        totals = {n: round(v * duration, 2) for n, v in daily.items()}
+        totals = {nut: round(val * duration, 2) for nut, val in daily.items()}
         schedule.append(StageNutrientTotals(stage, duration, totals))
     return schedule
 

--- a/tests/test_nutrient_schedule.py
+++ b/tests/test_nutrient_schedule.py
@@ -10,3 +10,9 @@ def test_generate_nutrient_schedule():
     assert first.stage == "seedling"
     assert first.duration_days == 60
     assert abs(first.totals["N"] - 75 * 60) < 0.01
+
+
+def test_generate_nutrient_schedule_cached():
+    first_call = generate_nutrient_schedule("citrus")
+    second_call = generate_nutrient_schedule("citrus")
+    assert first_call is second_call


### PR DESCRIPTION
## Summary
- cache nutrient schedule results for faster repeated calls
- tidy nutrient schedule implementation
- test caching behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f019f3548330875ce4250ee78036