### PR TITLE
Enhance nutrient synergy data and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Important categories include:
 - **Environment guidelines** – optimal temperature, humidity, light and CO₂ ranges
 - **Environment actions** – recommended steps when temperature or humidity are out of range
 - **Nutrient guidelines** – macronutrient and micronutrient targets by stage
+- **Nutrient synergies** – factors adjusting uptake when specific elements are present together
 - **Total nutrient requirements** – daily NPK needs for common crops
 - **Stage nutrient requirements** – daily needs for each growth stage
 - **Pest and disease references** – thresholds, prevention tips and treatment options

--- a/data/nutrient_synergies.json
+++ b/data/nutrient_synergies.json
@@ -1,5 +1,7 @@
 {
   "n_p": {"factor": 1.1, "message": "Nitrogen improves phosphorus uptake"},
   "ca_b": {"factor": 1.05, "message": "Calcium transport aided by boron"},
-  "k_mg": {"factor": 0.95, "message": "High potassium reduces magnesium uptake"}
+  "k_mg": {"factor": 0.95, "message": "High potassium reduces magnesium uptake"},
+  "n_ca": {"factor": 1.05, "message": "Nitrogen boosts calcium uptake"},
+  "fe_mn": {"factor": 0.85, "message": "High manganese suppresses iron uptake"}
 }

--- a/plant_engine/nutrient_synergy.py
+++ b/plant_engine/nutrient_synergy.py
@@ -32,6 +32,7 @@ __all__ = [
     "list_synergy_pairs",
     "get_synergy_info",
     "get_synergy_factor",
+    "has_synergy_pair",
     "apply_synergy_adjustments",
     "apply_synergy_adjustments_verbose",
 ]
@@ -53,6 +54,13 @@ def get_synergy_factor(n1: str, n2: str) -> float | None:
     n2_key = n2.casefold()
     info = _SYNERGY_MAP.get((n1_key, n2_key)) or _SYNERGY_MAP.get((n2_key, n1_key))
     return info.factor if info else None
+
+
+def has_synergy_pair(n1: str, n2: str) -> bool:
+    """Return ``True`` if synergy data exists for the nutrient pair."""
+    n1_key = n1.casefold()
+    n2_key = n2.casefold()
+    return (n1_key, n2_key) in _SYNERGY_MAP or (n2_key, n1_key) in _SYNERGY_MAP
 
 
 def apply_synergy_adjustments(levels: Mapping[str, float]) -> Dict[str, float]:

--- a/tests/test_nutrient_synergy.py
+++ b/tests/test_nutrient_synergy.py
@@ -1,6 +1,7 @@
 from plant_engine.nutrient_synergy import (
     list_synergy_pairs,
     get_synergy_factor,
+    has_synergy_pair,
     apply_synergy_adjustments,
     apply_synergy_adjustments_verbose,
 )
@@ -34,4 +35,11 @@ def test_apply_synergy_adjustments_verbose():
     adjusted, notes = apply_synergy_adjustments_verbose(levels)
     assert adjusted["mg"] == 9.5
     assert "k/mg" in notes
+
+
+def test_has_synergy_pair():
+    assert has_synergy_pair("N", "Ca")
+    assert has_synergy_pair("Fe", "Mn")
+    assert not has_synergy_pair("Cu", "Zn")
+
 


### PR DESCRIPTION
## Summary
- expand `nutrient_synergies.json` with Ca/N and Fe/Mn pairs
- expose a new `has_synergy_pair` helper
- document nutrient synergy dataset in README
- test new helper and synergy pairs

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_nutrient_synergy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f011a7788330a9e05d683ce7b642