### PR TITLE
Enhance toxicity analysis

### DIFF
--- a/tests/test_toxicity_manager.py
+++ b/tests/test_toxicity_manager.py
@@ -7,6 +7,7 @@ from plant_engine.toxicity_manager import (
     diagnose_toxicities,
     get_toxicity_treatment,
     recommend_toxicity_treatments,
+    calculate_toxicity_index,
 )
 
 
@@ -47,3 +48,9 @@ def test_diagnose_and_recommend_treatments():
     actions = recommend_toxicity_treatments(current, "tomato")
     assert "N" in symptoms and "burn" in symptoms["N"].lower()
     assert "K" in actions and actions["K"]
+
+
+def test_calculate_toxicity_index():
+    levels = {"N": 300, "K": 400}
+    index = calculate_toxicity_index(levels, "tomato")
+    assert index == 17.1


### PR DESCRIPTION
## Summary
- add `calculate_toxicity_index` helper to score nutrient excess
- test toxicity index calculation

## Testing
- `pytest tests/test_toxicity_manager.py::test_calculate_toxicity_index -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f0014c088330b5b36f753cb79801