### PR TITLE
Improve root temperature modeling

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -162,6 +162,8 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
+    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
     "disease_resistance_ratings.json": "Relative disease resistance ratings by crop.",

--- a/data/root_temperature_optima.json
+++ b/data/root_temperature_optima.json
@@ -1,0 +1,5 @@
+{
+  "citrus": 21,
+  "tomato": 24,
+  "lettuce": 18
+}

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -460,7 +460,7 @@ def get_temperature_adjusted_levels(
         return {}
     from .root_temperature import adjust_uptake
 
-    return adjust_uptake(base, root_temp_c)
+    return adjust_uptake(base, root_temp_c, plant_type)
 
 
 def calculate_deficiency_index_with_temperature(
@@ -693,7 +693,7 @@ def get_environment_adjusted_levels(
     if root_temp_c is not None:
         from .root_temperature import adjust_uptake
 
-        levels = adjust_uptake(levels, root_temp_c)
+        levels = adjust_uptake(levels, root_temp_c, plant_type)
 
     return levels
 

--- a/plant_engine/root_temperature.py
+++ b/plant_engine/root_temperature.py
@@ -7,10 +7,13 @@ from typing import Mapping, Dict, Sequence
 from .utils import load_dataset
 
 DATA_FILE = "root_temperature_uptake.json"
+OPTIMA_FILE = "root_temperature_optima.json"
 
 _DATA = load_dataset(DATA_FILE)
+_OPTIMA = load_dataset(OPTIMA_FILE)
 _TEMPS: Sequence[float] = [float(t) for t in _DATA.get("temperature_c", [])]
 _FACTORS: Sequence[float] = [float(f) for f in _DATA.get("factor", [])]
+_DEFAULT_OPTIMUM = next((t for t, f in zip(_TEMPS, _FACTORS) if f == 1.0), 21.0)
 
 __all__ = [
     "get_uptake_factor",
@@ -18,10 +21,21 @@ __all__ = [
 ]
 
 
-def get_uptake_factor(temp_c: float) -> float:
-    """Return uptake efficiency factor for ``temp_c`` in Celsius."""
+def get_uptake_factor(temp_c: float, plant_type: str | None = None) -> float:
+    """Return uptake efficiency factor for ``temp_c`` in Celsius.
+
+    When ``plant_type`` is provided and an optimum temperature is defined in
+    :data:`root_temperature_optima.json`, the lookup adjusts the curve so that
+    the optimum factor of ``1.0`` occurs at the crop specific temperature.
+    """
     if not _TEMPS or len(_TEMPS) != len(_FACTORS):
         return 1.0
+
+    if plant_type:
+        opt = _OPTIMA.get(plant_type.lower())
+        if isinstance(opt, (int, float)):
+            temp_c = temp_c + (_DEFAULT_OPTIMUM - float(opt))
+
     idx = bisect_left(_TEMPS, temp_c)
     if idx <= 0:
         return float(_FACTORS[0])
@@ -33,7 +47,9 @@ def get_uptake_factor(temp_c: float) -> float:
     return round(lo_f + fraction * (hi_f - lo_f), 3)
 
 
-def adjust_uptake(uptake: Mapping[str, float], temp_c: float) -> Dict[str, float]:
+def adjust_uptake(
+    uptake: Mapping[str, float], temp_c: float, plant_type: str | None = None
+) -> Dict[str, float]:
     """Return ``uptake`` scaled by the temperature factor."""
-    factor = get_uptake_factor(temp_c)
+    factor = get_uptake_factor(temp_c, plant_type)
     return {nutrient: round(value * factor, 2) for nutrient, value in uptake.items()}

--- a/tests/test_root_temperature.py
+++ b/tests/test_root_temperature.py
@@ -13,8 +13,18 @@ def test_adjust_uptake():
     adjusted = adjust_uptake(uptake, 15)
     assert adjusted == {"N": 70.0, "P": 35.0}
 
+    tomato_adjusted = adjust_uptake(uptake, 21, "tomato")
+    assert tomato_adjusted == {"N": 85.0, "P": 42.5}
+
+
+def test_plant_specific_optimum():
+    tomato_factor = get_uptake_factor(21, "tomato")
+    base_factor = get_uptake_factor(18)
+    assert tomato_factor == base_factor
+
 
 def test_temperature_adjusted_levels():
     levels = get_temperature_adjusted_levels("lettuce", "seedling", 15)
-    assert levels["N"] == 56.0  # 80 * 0.7
+    assert levels["N"] == 68.0  # 80 * 0.85 (lettuce optimum 18C)
+
 


### PR DESCRIPTION
## Summary
- add dataset of optimal root temperature for nutrient uptake
- adjust `root_temperature` helpers to consider crop-specific optima
- update nutrient manager to pass plant type for temperature adjustments
- cover new behaviour with expanded unit tests

## Testing
- `pytest tests/test_root_temperature.py tests/test_environment_guidelines.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f01ed9c88330becc80327ad93765