### PR TITLE
Add ET0-based water use estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 - Automated fertigation planning with cost estimates
 - Yield-based revenue and profit projections
 - Expected profit forecasts based on estimated production costs
+- ET₀-based daily water usage estimates using crop coefficients
 
 ---
 

--- a/tests/test_water_usage_et0.py
+++ b/tests/test_water_usage_et0.py
@@ -1,0 +1,13 @@
+import plant_engine.water_usage as water_usage
+
+
+def test_estimate_daily_use_from_et0():
+    # lettuce vegetative stage kc=1.0, spacing 25 cm => area 0.0625 m2
+    use = water_usage.estimate_daily_use_from_et0(
+        "lettuce", "vegetative", et0_mm_day=5.0
+    )
+    assert use > 0
+    assert round(use, 1) == round(5.0 * 1.0 * 0.0625 * 1000, 1)
+
+    # unknown plant => 0
+    assert water_usage.estimate_daily_use_from_et0("unknown", "stage", 5.0) == 0.0


### PR DESCRIPTION
## Summary
- allow estimating daily water use from ET0 and crop coefficients
- document new ET0 water usage feature
- test water usage ET0 calculations

## Testing
- `pytest tests/test_water_usage_et0.py tests/test_water_usage.py tests/test_water_usage_totals.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f0135aac83308f81930e30315bae