### PR TITLE
Add growth rate utilities

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -30,6 +30,7 @@
     "germination_duration.json": "Typical days from sowing to germination by crop.",
     "stage_multipliers.json": "Scaling factors for nutrient targets by stage.",
     "stage_nutrient_requirements.json": "Daily nutrient needs per plant stage.",
+    "growth_rate_guidelines.json": "Average daily growth rate in grams per plant stage.",
     "light_dli_guidelines.json": "Daily Light Integral targets for growth stages.",
     "vpd_guidelines.json": "Vapor pressure deficit targets for growth stages.",
     "vpd_actions.json": "Recommended actions when VPD is outside the target range.",

--- a/data/growth_rate_guidelines.json
+++ b/data/growth_rate_guidelines.json
@@ -1,0 +1,11 @@
+{
+  "citrus": {
+    "vegetative": 1.2,
+    "flowering": 0.8,
+    "fruiting": 0.9
+  },
+  "lettuce": {
+    "seedling": 0.4,
+    "vegetative": 1.5
+  }
+}

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -30,6 +30,11 @@ from .precipitation_risk import (
     estimate_precipitation_risk,
 )
 from .fertigation_optimizer import generate_fertigation_plan
+from .growth_rate_manager import (
+    list_supported_plants as list_growth_rate_plants,
+    get_daily_growth_rate,
+    estimate_growth,
+)
 
 __all__ = sorted(
     set(utils.__all__)
@@ -50,6 +55,9 @@ __all__ = sorted(
         "list_precipitation_plants",
         "estimate_precipitation_risk",
         "generate_fertigation_plan",
+        "list_growth_rate_plants",
+        "get_daily_growth_rate",
+        "estimate_growth",
     }
 )
 

--- a/plant_engine/growth_rate_manager.py
+++ b/plant_engine/growth_rate_manager.py
@@ -1,0 +1,42 @@
+"""Simple growth rate utilities using the growth_rate_guidelines dataset."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .utils import load_dataset, list_dataset_entries, normalize_key
+
+DATA_FILE = "growth_rate_guidelines.json"
+
+# Load dataset once at import time using cached helper
+_DATA: Dict[str, Dict[str, float]] = load_dataset(DATA_FILE)
+
+__all__ = [
+    "list_supported_plants",
+    "get_daily_growth_rate",
+    "estimate_growth",
+]
+
+
+def list_supported_plants() -> list[str]:
+    """Return plant types with growth rate data available."""
+    return list_dataset_entries(_DATA)
+
+
+def get_daily_growth_rate(plant_type: str, stage: str) -> float | None:
+    """Return grams per day growth rate for ``plant_type`` at ``stage``."""
+    value = _DATA.get(normalize_key(plant_type), {}).get(normalize_key(stage))
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def estimate_growth(plant_type: str, stage: str, days: float) -> float:
+    """Return estimated grams gained over ``days`` at the stage growth rate."""
+    if days < 0:
+        raise ValueError("days must be non-negative")
+    rate = get_daily_growth_rate(plant_type, stage)
+    if rate is None:
+        return 0.0
+    return round(rate * days, 2)

--- a/tests/test_growth_rate_manager.py
+++ b/tests/test_growth_rate_manager.py
@@ -1,0 +1,32 @@
+from plant_engine.growth_rate_manager import (
+    list_supported_plants,
+    get_daily_growth_rate,
+    estimate_growth,
+)
+
+
+def test_list_supported_plants():
+    plants = list_supported_plants()
+    assert "citrus" in plants
+    assert "lettuce" in plants
+
+
+def test_get_daily_growth_rate():
+    rate = get_daily_growth_rate("citrus", "vegetative")
+    assert rate == 1.2
+    assert get_daily_growth_rate("unknown", "stage") is None
+
+
+def test_estimate_growth():
+    grams = estimate_growth("lettuce", "vegetative", 3)
+    assert grams == 4.5
+
+    grams_zero = estimate_growth("unknown", "stage", 2)
+    assert grams_zero == 0.0
+
+    try:
+        estimate_growth("lettuce", "vegetative", -1)
+    except ValueError:
+        pass
+    else:
+        assert False, "negative days should raise"


### PR DESCRIPTION
## Summary
- add growth_rate_guidelines dataset and hook it into dataset catalog
- provide new `growth_rate_manager` module for estimating daily growth
- expose growth rate helpers in `plant_engine`
- test new growth rate utilities

## Testing
- `pytest tests/test_growth_rate_manager.py -q`
- `pytest -k growth_rate_manager -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f00ccecc8330a85c3748d9d10966