### PR TITLE
Add cycle monitoring schedule utility

### DIFF
--- a/tests/test_pest_manager_schedule.py
+++ b/tests/test_pest_manager_schedule.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+from plant_engine.pest_manager import generate_cycle_monitoring_schedule
+
+
+def test_generate_cycle_monitoring_schedule():
+    start = date(2023, 1, 1)
+    sched = generate_cycle_monitoring_schedule("tomato", start, ["aphids"])
+    assert sched[0]["date"] == date(2023, 1, 8)
+    assert sched[0]["stage"] == "seedling"
+    assert sched[-1]["date"] == date(2023, 5, 1)
+    assert sched[-1]["stage"] == "fruiting"
+    assert len(sched) >= 20


### PR DESCRIPTION
## Summary
- extend `pest_manager` with `generate_cycle_monitoring_schedule` for full-cycle monitoring tasks
- expose new utility through module exports
- test cycle monitoring schedule generation

## Testing
- `pytest -q tests/test_pest_manager_schedule.py`
- `pytest -q tests/test_utils.py tests/test_pest_manager_schedule.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f008c6208330bf3947aec1ad19fe