### PR TITLE
Improve pest monitoring data integration

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -20,6 +20,7 @@
     "pest_monitoring_intervals.json": "Recommended days between scouting events.",
     "pest_risk_interval_modifiers.json": "Multipliers adjusting monitoring frequency based on risk level.",
     "pest_scouting_methods.json": "Recommended scouting techniques for common pests.",
+    "pest_sample_sizes.json": "Recommended number of plants to inspect during pest monitoring.",
     "pest_lifecycle_durations.json": "Typical development duration for common pest life stages.",
     "ipm_guidelines.json": "Integrated pest management practices by crop.",
     "disease_guidelines.json": "Treatment guidance for common plant diseases.",

--- a/data/pest_sample_sizes.json
+++ b/data/pest_sample_sizes.json
@@ -1,0 +1,6 @@
+{
+  "citrus": 25,
+  "tomato": 20,
+  "lettuce": 15,
+  "spinach": 15
+}

--- a/plant_engine/guidelines.py
+++ b/plant_engine/guidelines.py
@@ -52,6 +52,7 @@ class GuidelineSummary:
     irrigation_volume_ml: float | None = None
     irrigation_interval_days: float | None = None
     pest_monitor_interval_days: int | None = None
+    pest_sample_size: int | None = None
     disease_monitor_interval_days: int | None = None
     water_daily_ml: float | None = None
     stage_info: Optional[Dict[str, Any]] = None
@@ -123,6 +124,7 @@ def get_guideline_summary(plant_type: str, stage: str | None = None) -> Dict[str
             else None
         ),
         pest_monitor_interval_days=pest_interval,
+        pest_sample_size=pest_monitor.get_sample_size(plant_type),
         disease_monitor_interval_days=disease_interval,
         water_daily_ml=(
             water_usage.get_daily_use(plant_type, stage) if stage else None

--- a/plant_engine/pest_monitor.py
+++ b/plant_engine/pest_monitor.py
@@ -32,6 +32,7 @@ RISK_INTERVAL_MOD_FILE = "pest_risk_interval_modifiers.json"
 SCOUTING_METHOD_FILE = "pest_scouting_methods.json"
 SEVERITY_THRESHOLD_FILE = "pest_severity_thresholds.json"
 SEVERITY_SCORE_FILE = "pest_severity_scores.json"
+SAMPLE_SIZE_FILE = "pest_sample_sizes.json"
 
 # Load once with caching
 _THRESHOLDS = lazy_dataset(DATA_FILE)
@@ -42,6 +43,7 @@ _SEVERITY_THRESHOLDS = lazy_dataset(SEVERITY_THRESHOLD_FILE)
 _SEVERITY_SCORES = lazy_dataset(SEVERITY_SCORE_FILE)
 PRESSURE_WEIGHT_FILE = "pest_pressure_weights.json"
 _PRESSURE_WEIGHTS = lazy_dataset(PRESSURE_WEIGHT_FILE)
+_SAMPLE_SIZES = lazy_dataset(SAMPLE_SIZE_FILE)
 
 
 def _resolve(data):
@@ -77,6 +79,7 @@ __all__ = [
     "next_monitor_date",
     "generate_monitoring_schedule",
     "generate_detailed_monitoring_schedule",
+    "get_sample_size",
     "PestReport",
     "summarize_pest_management",
 ]
@@ -218,6 +221,17 @@ def get_severity_thresholds(pest: str) -> Dict[str, float]:
 
     thresholds = _resolve(_SEVERITY_THRESHOLDS)
     return thresholds.get(normalize_key(pest), {})
+
+
+def get_sample_size(plant_type: str) -> int | None:
+    """Return recommended sample size for ``plant_type`` pest scouting."""
+
+    sizes = _resolve(_SAMPLE_SIZES)
+    value = sizes.get(normalize_key(plant_type)) if isinstance(sizes, Mapping) else None
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def assess_pest_pressure(plant_type: str, observations: Mapping[str, int]) -> Dict[str, bool]:

--- a/tests/test_guidelines.py
+++ b/tests/test_guidelines.py
@@ -22,6 +22,7 @@ def test_get_guideline_summary():
     assert data["water_daily_ml"] == 0.0
     assert data["disease_thresholds"]["citrus_greening"] == 1
     assert data["pest_monitor_interval_days"] == 3
+    assert data["pest_sample_size"] == 25
     assert data["disease_monitor_interval_days"] == 4
     # citrus has no task entries so all lists should be empty
     assert all(len(t) == 0 for t in data["stage_tasks"].values())

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -22,6 +22,7 @@ from plant_engine.pest_monitor import (
     calculate_pest_management_index,
     calculate_severity_index,
     estimate_adjusted_pest_risk_series,
+    get_sample_size,
 )
 
 
@@ -236,4 +237,9 @@ def test_report_includes_severity_index():
     obs = {"aphids": 6}
     report = generate_pest_report("citrus", obs)
     assert report["severity_index"] > 0
+
+
+def test_get_sample_size():
+    assert get_sample_size("citrus") == 25
+    assert get_sample_size("unknown") is None
 


### PR DESCRIPTION
## Summary
- add `pest_sample_sizes.json` dataset and reference it in catalog
- expose sample size via `pest_monitor.get_sample_size`
- include recommended sample size in `GuidelineSummary`
- test new dataset loader and guideline integration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f006f19483308792dea107e77417