### PR TITLE
Add async AI model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 ### Automation & AI
 - Dynamic thresholds based on growth stage history
 - Optional OpenAI or offline models for nutrient planning
+- Async API helpers for non-blocking AI analysis
 - Irrigation and fertigation switches with approval queues
 - Configurable irrigation zones with shared solenoids
 - Watering interval defaults to drought tolerance when stage data is missing

--- a/tests/test_ai_model.py
+++ b/tests/test_ai_model.py
@@ -1,3 +1,4 @@
+import pytest
 from plant_engine import ai_model
 
 
@@ -9,6 +10,13 @@ def test_get_model_defaults_to_mock():
 def test_analyze_uses_mock_model():
     data = {"thresholds": {"leaf_temp": 20}, "lifecycle_stage": "vegetative"}
     updated = ai_model.analyze(data)
+    assert updated["leaf_temp"] == 19.0
+
+
+@pytest.mark.asyncio
+async def test_analyze_async_uses_mock_model():
+    data = {"thresholds": {"leaf_temp": 20}, "lifecycle_stage": "vegetative"}
+    updated = await ai_model.analyze_async(data)
     assert updated["leaf_temp"] == 19.0
 
 


### PR DESCRIPTION
## Summary
- add async interface to `ai_model` so OpenAI calls can run without blocking
- update docs for async API usage
- test async analysis helper

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f004f20c8330a3ab9f8adc6b4d1f