### PR TITLE
Expand reference datasets and tests

### DIFF
--- a/plant_engine/reference_data.py
+++ b/plant_engine/reference_data.py
@@ -19,6 +19,8 @@ REFERENCE_FILES: dict[str, str] = {
     "pest_monitoring_intervals": "pest_monitoring_intervals.json",
     "growth_stages": "growth_stages.json",
     "stage_tasks": "stage_tasks.json",
+    "total_nutrient_requirements": "total_nutrient_requirements.json",
+    "stage_nutrient_requirements": "stage_nutrient_requirements.json",
     # newly exposed reference datasets
     "nutrient_synergies": "nutrient_synergies.json",
     "disease_guidelines": "disease_guidelines.json",
@@ -84,6 +86,8 @@ def get_plant_overview(plant_type: str) -> Dict[str, Any]:
         "monitoring_intervals": entry("pest_monitoring_intervals"),
         "stages": entry("growth_stages"),
         "tasks": entry("stage_tasks"),
+        "total_requirements": entry("total_nutrient_requirements"),
+        "stage_requirements": entry("stage_nutrient_requirements"),
         "water_usage": entry("water_usage_guidelines"),
     }
 

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -21,6 +21,10 @@ def test_get_plant_overview():
     assert isinstance(overview["environment"], dict)
     assert "water_usage" in overview
     assert overview["water_usage"]["fruiting"] == 320
+    assert "total_requirements" in overview
+    assert overview["total_requirements"]["N"] == 180
+    assert "stage_requirements" in overview
+    assert overview["stage_requirements"]["vegetative"]["N"] == 1.8
 
 
 def test_refresh_reference_data(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- include nutrient requirement datasets in `reference_data`
- expose new datasets via `get_plant_overview`
- verify overview includes nutrient requirement info

## Testing
- `pytest tests/test_reference_data.py -q`
- `pytest tests/test_nutrient_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f42c3db48330bdff28e04f40af6e