### PR TITLE
Fix dataset catalog and nutrient weight reloading

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -136,8 +136,12 @@ def get_nutrient_weight(nutrient: str) -> float:
     If no weight is defined the default ``1.0`` is returned.
     """
 
+    from .utils import clear_dataset_cache
+
+    clear_dataset_cache()
+    weights = load_dataset(WEIGHT_DATA_FILE)
     try:
-        return float(_WEIGHTS.get(nutrient, 1.0))
+        return float(weights.get(nutrient, 1.0))
     except (TypeError, ValueError):
         return 1.0
 


### PR DESCRIPTION
## Summary
- fix JSON syntax in `dataset_catalog.json`
- reload nutrient weights dynamically to avoid stale cache
- ensure dataset cache clears when getting nutrient weight

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f4185ee083309e0db64ba5672a25