### PR TITLE
Add area uptake calculations

### DIFF
--- a/plant_engine/nutrient_uptake.py
+++ b/plant_engine/nutrient_uptake.py
@@ -22,6 +22,8 @@ __all__ = [
     "get_uptake_ratio",
     "estimate_area_daily_uptake",
     "estimate_area_stage_uptake",
+    "estimate_area_total_uptake",
+    "estimate_area_cumulative_uptake",
 ]
 
 
@@ -149,4 +151,36 @@ def estimate_area_stage_uptake(
         return {}
 
     return {n: round(val * duration, 2) for n, val in daily_totals.items()}
+
+
+def estimate_area_total_uptake(plant_type: str, area_m2: float) -> Dict[str, float]:
+    """Return nutrient demand for the entire crop cycle over ``area_m2``."""
+
+    totals = estimate_total_uptake(plant_type)
+    if not totals:
+        return {}
+
+    spacing = get_spacing_cm(plant_type)
+    if spacing is None or spacing <= 0:
+        return {}
+
+    plants = area_m2 / ((spacing / 100) ** 2)
+    return {n: round(val * plants, 2) for n, val in totals.items()}
+
+
+def estimate_area_cumulative_uptake(
+    plant_type: str, stage: str, area_m2: float
+) -> Dict[str, float]:
+    """Return cumulative nutrient demand up to ``stage`` over ``area_m2``."""
+
+    totals = estimate_cumulative_uptake(plant_type, stage)
+    if not totals:
+        return {}
+
+    spacing = get_spacing_cm(plant_type)
+    if spacing is None or spacing <= 0:
+        return {}
+
+    plants = area_m2 / ((spacing / 100) ** 2)
+    return {n: round(val * plants, 2) for n, val in totals.items()}
 

--- a/tests/test_nutrient_uptake_totals.py
+++ b/tests/test_nutrient_uptake_totals.py
@@ -1,4 +1,11 @@
-from plant_engine.nutrient_uptake import estimate_stage_totals, estimate_total_uptake
+import pytest
+
+from plant_engine.nutrient_uptake import (
+    estimate_stage_totals,
+    estimate_total_uptake,
+    estimate_area_total_uptake,
+    estimate_area_cumulative_uptake,
+)
 
 
 def test_estimate_stage_totals():
@@ -12,3 +19,17 @@ def test_estimate_total_uptake():
     assert totals["N"] == 60 * 35 + 50 * 30
     assert totals["P"] == 20 * 35 + 15 * 30
     assert totals["K"] == 80 * 35 + 70 * 30
+
+
+def test_estimate_area_total_uptake():
+    totals = estimate_area_total_uptake("lettuce", 1.0)
+    plants = 1.0 / (0.25 ** 2)
+    expected_n = (60 * 35 + 50 * 30) * plants
+    assert totals["N"] == pytest.approx(expected_n, rel=1e-2)
+
+
+def test_estimate_area_cumulative_uptake():
+    totals = estimate_area_cumulative_uptake("lettuce", "vegetative", 1.0)
+    plants = 1.0 / (0.25 ** 2)
+    expected_n = 60 * 35 * plants
+    assert totals["N"] == pytest.approx(expected_n, rel=1e-2)


### PR DESCRIPTION
## Summary
- calculate area-adjusted total and cumulative nutrient uptake
- test new nutrient uptake calculations

## Testing
- `pytest tests/test_nutrient_uptake.py tests/test_nutrient_uptake_totals.py -q`
- `pytest -q` *(fails: 9 failed, 1294 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6888f415a3408330b6a7cb7dafa8a178