### PR TITLE
Fix dataset catalog json and refresh toxicity weight loading

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/plant_engine/toxicity_manager.py
+++ b/plant_engine/toxicity_manager.py
@@ -106,7 +106,11 @@ def calculate_toxicity_index(
     if not thresholds:
         return 0.0
 
-    from .nutrient_manager import get_nutrient_weight
+    from .utils import clear_dataset_cache, load_dataset
+
+    # Reload weights to honor any environment changes that may have occurred
+    clear_dataset_cache()
+    weights: Mapping[str, float] = load_dataset("nutrient_weights.json") or {}
 
     total_weight = 0.0
     score = 0.0
@@ -118,7 +122,10 @@ def calculate_toxicity_index(
         if current <= limit:
             continue
         ratio = (current - limit) / limit
-        weight = get_nutrient_weight(nutrient)
+        try:
+            weight = float(weights.get(nutrient, 1.0))
+        except (TypeError, ValueError):
+            weight = 1.0
         score += weight * ratio
         total_weight += weight
 


### PR DESCRIPTION
## Summary
- fix JSON syntax in `dataset_catalog.json`
- reload nutrient weights in `calculate_toxicity_index` so test overlays don't persist
- include dataset cache refresh to handle overlay environments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f41185f08330bdcc14e66b2574c7