### PR TITLE
Add cycle nutrient totals helper and tests

### DIFF
--- a/custom_components/horticulture_assistant/utils/cycle_nutrient_totals.py
+++ b/custom_components/horticulture_assistant/utils/cycle_nutrient_totals.py
@@ -1,0 +1,28 @@
+"""Helpers for computing total nutrient requirements across a crop cycle."""
+from __future__ import annotations
+
+from typing import Dict
+
+from plant_engine import growth_stage
+from . import stage_nutrient_requirements
+
+__all__ = ["calculate_cycle_totals"]
+
+
+def calculate_cycle_totals(plant_type: str) -> Dict[str, float]:
+    """Return cumulative nutrient requirements for the full growth cycle.
+
+    The totals are derived from stage durations in :mod:`plant_engine.growth_stage`
+    combined with per-stage daily requirements from
+    :mod:`stage_nutrient_requirements`.
+    """
+
+    totals: Dict[str, float] = {}
+    for stage in growth_stage.list_growth_stages(plant_type):
+        days = growth_stage.get_stage_duration(plant_type, stage)
+        if not days:
+            continue
+        daily = stage_nutrient_requirements.get_stage_requirements(plant_type, stage)
+        for nutrient, value in daily.items():
+            totals[nutrient] = round(totals.get(nutrient, 0.0) + value * days, 2)
+    return totals

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -24,7 +24,6 @@ clear_dataset_cache()
 # Dataset cached via :func:`load_dataset` so this only happens once
 _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 _RATIO_DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(RATIO_DATA_FILE)
-_WEIGHTS: Dict[str, float] = load_dataset(WEIGHT_DATA_FILE)
 _RAW_TAG_MODIFIERS: Dict[str, Dict[str, float]] = load_dataset(TAG_MODIFIER_FILE)
 # Normalize modifier keys for consistent lookups regardless of hyphen/space use
 _TAG_MODIFIERS: Dict[str, Dict[str, float]] = {
@@ -131,13 +130,18 @@ def _deficiency_index_for_targets(current_levels: Mapping[str, float], targets: 
 
 
 def get_nutrient_weight(nutrient: str) -> float:
-    """Return importance weight for a nutrient.
+    """Return importance weight for ``nutrient``.
 
-    If no weight is defined the default ``1.0`` is returned.
+    The mapping is loaded on demand from :data:`WEIGHT_DATA_FILE` so changes to
+    the overlay directory during tests are respected.
+    Unknown nutrients default to ``1.0`` and invalid entries are ignored.
     """
 
+    # Refresh cached dataset in case the overlay directory changed during tests
+    clear_dataset_cache()
+    weights = load_dataset(WEIGHT_DATA_FILE)
     try:
-        return float(_WEIGHTS.get(nutrient, 1.0))
+        return float(weights.get(nutrient, 1.0))
     except (TypeError, ValueError):
         return 1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyyaml>=6.0
 pandas>=2.3
 voluptuous>=0.15
 numpy>=1.25
+pytest-asyncio>=0.21

--- a/tests/test_cycle_nutrient_totals.py
+++ b/tests/test_cycle_nutrient_totals.py
@@ -1,0 +1,26 @@
+from custom_components.horticulture_assistant.utils.cycle_nutrient_totals import calculate_cycle_totals
+from custom_components.horticulture_assistant.utils.nutrient_requirements import get_requirements
+from plant_engine import growth_stage
+from plant_engine.constants import get_stage_multiplier
+import json
+
+
+def compute_expected(plant_type: str):
+    with open('data/stage_nutrient_requirements.json') as f:
+        stage_req = json.load(f)
+    totals = {}
+    for stage in growth_stage.list_growth_stages(plant_type):
+        days = growth_stage.get_stage_duration(plant_type, stage)
+        reqs = stage_req.get(plant_type, {}).get(stage)
+        if reqs is None:
+            base = get_requirements(plant_type)
+            reqs = {n: get_stage_multiplier(stage) * v for n, v in base.items()}
+        for nutrient, val in reqs.items():
+            totals[nutrient] = totals.get(nutrient, 0.0) + val * days
+    return {n: round(v, 2) for n, v in totals.items()}
+
+
+def test_calculate_cycle_totals_tomato():
+    expected = compute_expected('tomato')
+    totals = calculate_cycle_totals('tomato')
+    assert totals == expected


### PR DESCRIPTION
## Summary
- add helper to compute cycle-wide nutrient requirements
- fix dataset catalog JSON formatting
- refresh nutrient weight dataset when loaded to avoid overlay cache issues
- add pytest-asyncio dependency
- test new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f43331ac833091df91dff670e1ec