### PR TITLE
Fix dataset catalog and isolate dataset weight tests

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyyaml>=6.0
 pandas>=2.3
 voluptuous>=0.15
 numpy>=1.25
+pytest-asyncio>=0.23

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -100,6 +100,11 @@ def test_score_nutrient_levels_weighted(tmp_path, monkeypatch):
     current = {"N": 80, "P": 30, "K": 60}
     score = nm.score_nutrient_levels(current, "tomato", "fruiting")
     assert 80 < score < 90
+    # restore default environment and reload module to avoid cross-test effects
+    monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR", raising=False)
+    from plant_engine import utils
+    utils.clear_dataset_cache()
+    importlib.reload(nm)
 
 
 def test_get_all_recommended_levels():


### PR DESCRIPTION
## Summary
- fix invalid JSON entries in `dataset_catalog.json`
- add `pytest-asyncio` to requirements
- ensure nutrient manager weight test cleans up overlay changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f427dcf0833083d40019bcdd6f8c