### PR TITLE
Enhance fertigation API with dataclass result

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ useful commands is available in [`docs/scripts_overview.md`](docs/scripts_overvi
 - `fertigation_plan.py` creates a JSON fertigation schedule for any crop stage.
 - `precision_fertigation.py` generates a detailed fertigation plan with stock
   solution injection volumes. Use `--use-synergy` to apply nutrient synergy
-  adjustments.
+  adjustments. The output is now returned as a `FertigationResult` dataclass
+  containing schedule, cost and injection details.
 - `growth_stage_targets.py` prints stage durations with environment and nutrient
   targets plus an optional harvest prediction.
 - `environment_optimize.py` prints recommended environment adjustments for

--- a/docs/scripts_overview.md
+++ b/docs/scripts_overview.md
@@ -6,7 +6,8 @@ Python. Some highlights are:
 
 - **precision_fertigation.py** – generate nutrient schedules and injector
   volumes for a crop stage. Supports optional nutrient synergy and stock
-  solution recipes.
+  solution recipes. The script now returns a `FertigationResult` dataclass
+  containing the full schedule, cost details and injection volumes.
 - **fertigation_plan.py** – output a daily fertigation schedule in JSON
   format for the specified number of days.
 - **environment_optimize.py** – recommend environment adjustments for the

--- a/scripts/precision_fertigation.py
+++ b/scripts/precision_fertigation.py
@@ -65,7 +65,7 @@ def main(argv: list[str] | None = None) -> None:
         "K": "intrepid_granular_potash_0_0_60",
     }
 
-    schedule, total, breakdown, warnings, diag, injection = recommend_precise_fertigation_with_injection(
+    result = recommend_precise_fertigation_with_injection(
         args.plant_type,
         args.stage,
         args.volume_l,
@@ -85,20 +85,20 @@ def main(argv: list[str] | None = None) -> None:
             args.volume_l,
         )
 
-    result = {
-        "schedule": schedule,
-        "cost_total": total,
-        "cost_breakdown": breakdown,
-        "warnings": warnings,
-        "diagnostics": diag,
-        "injection_volumes": injection,
+    payload = {
+        "schedule": result.schedule,
+        "cost_total": result.cost_total,
+        "cost_breakdown": result.cost_breakdown,
+        "warnings": result.warnings,
+        "diagnostics": result.diagnostics,
+        "injection_volumes": result.injection_volumes,
         "recipe_injection": recipe_injection,
     }
 
     if args.as_yaml:
-        print(yaml.safe_dump(result, sort_keys=False))
+        print(yaml.safe_dump(payload, sort_keys=False))
     else:
-        print(json.dumps(result, indent=2))
+        print(json.dumps(payload, indent=2))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_fertigation.py
+++ b/tests/test_fertigation.py
@@ -258,7 +258,7 @@ def test_recommend_precise_fertigation_with_injection():
         "K": "intrepid_granular_potash_0_0_60",
     }
 
-    sched, total, breakdown, warnings, diag, inject = recommend_precise_fertigation_with_injection(
+    result = recommend_precise_fertigation_with_injection(
         "tomato",
         "vegetative",
         10.0,
@@ -266,8 +266,11 @@ def test_recommend_precise_fertigation_with_injection():
         include_micro=False,
     )
 
-    assert sched
-    assert inject
+    # tuple unpacking remains supported
+    sched, total, *_ = result
+    assert sched == result.schedule
+    assert result.injection_volumes
+    assert total == result.cost_total
     assert total >= 0
 
 


### PR DESCRIPTION
## Summary
- add `FertigationResult` dataclass to organize fertigation output
- update `recommend_precise_fertigation_with_injection` to return the dataclass
- adjust precision fertigation script to use the new object
- document the structured output in README and docs
- update test to validate dataclass behavior

## Testing
- `pytest tests/test_fertigation.py::test_recommend_precise_fertigation_with_injection -q`
- `pytest tests/test_fertigation.py::test_generate_cycle_fertigation_plan -q`
- `pytest tests/test_nutrient_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f4144dc88330bb08824148b03763