### PR TITLE
Fix dataset catalog and nutrient weight reload

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -19,12 +19,15 @@ WEIGHT_DATA_FILE = "nutrient_weights.json"
 TAG_MODIFIER_FILE = "nutrient_tag_modifiers.json"
 
 
-# Ensure dataset cache respects overlay changes on reload
-clear_dataset_cache()
 # Dataset cached via :func:`load_dataset` so this only happens once
 _DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(DATA_FILE)
 _RATIO_DATA: Dict[str, Dict[str, Dict[str, float]]] = load_dataset(RATIO_DATA_FILE)
-_WEIGHTS: Dict[str, float] = load_dataset(WEIGHT_DATA_FILE)
+
+def _load_weights() -> Dict[str, float]:
+    """Return nutrient weight mapping loaded from dataset."""
+    clear_dataset_cache()
+    data = load_dataset(WEIGHT_DATA_FILE)
+    return data if isinstance(data, dict) else {}
 _RAW_TAG_MODIFIERS: Dict[str, Dict[str, float]] = load_dataset(TAG_MODIFIER_FILE)
 # Normalize modifier keys for consistent lookups regardless of hyphen/space use
 _TAG_MODIFIERS: Dict[str, Dict[str, float]] = {
@@ -136,8 +139,9 @@ def get_nutrient_weight(nutrient: str) -> float:
     If no weight is defined the default ``1.0`` is returned.
     """
 
+    weights = _load_weights()
     try:
-        return float(_WEIGHTS.get(nutrient, 1.0))
+        return float(weights.get(nutrient, 1.0))
     except (TypeError, ValueError):
         return 1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyyaml>=6.0
 pandas>=2.3
 voluptuous>=0.15
 numpy>=1.25
+pytest-asyncio>=1.1


### PR DESCRIPTION
## Summary
- ensure dataset catalog JSON is valid
- refresh nutrient weights each time to avoid stale cache
- add pytest-asyncio dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f41710088330b555f3521a85c849