### PR TITLE
Fix derived from utility and add tests

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/tests/test_derived_from_decomposer.py
+++ b/tests/test_derived_from_decomposer.py
@@ -1,0 +1,29 @@
+from custom_components.horticulture_assistant.utils.derived_from_decomposer import (
+    decompose_derived_from,
+)
+
+
+def test_single_ingredient_exact_match():
+    analysis = {"N": 0.33}
+    result = decompose_derived_from(analysis, ["Ammonium Nitrate"])
+    assert result == [("Ammonium Nitrate", 1.0)]
+
+
+def test_multiple_ingredients():
+    analysis = {"N": 0.33, "K": 0.28, "P": 0.22}
+    result = decompose_derived_from(
+        analysis,
+        ["Ammonium Nitrate", "Monopotassium Phosphate"],
+    )
+    # Ammonium Nitrate limited by N leaving K and P for the second ingredient
+    assert result[0][0] == "Ammonium Nitrate"
+    assert result[1][0] == "Monopotassium Phosphate"
+    assert result[0][1] == 1.0
+    assert result[1][1] > 0
+
+
+def test_unknown_ingredient_ignored():
+    analysis = {"N": 0.33}
+    result = decompose_derived_from(analysis, ["Unknown", "Ammonium Nitrate"])
+    assert result == [("Ammonium Nitrate", 1.0)]
+

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -100,6 +100,9 @@ def test_score_nutrient_levels_weighted(tmp_path, monkeypatch):
     current = {"N": 80, "P": 30, "K": 60}
     score = nm.score_nutrient_levels(current, "tomato", "fruiting")
     assert 80 < score < 90
+    # Reset environment and reload module to avoid side effects on other tests
+    monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR")
+    importlib.reload(nm)
 
 
 def test_get_all_recommended_levels():


### PR DESCRIPTION
## Summary
- repair `derived_from_decomposer` utility and document it
- patch `dataset_catalog.json` to fix JSON syntax error
- add tests for derived-from decomposition helper
- reset overlay env in nutrient manager tests to avoid side effects

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f41b2fd48330a30d14dbab14d1be