### PR TITLE
Add pesticide rotation cost helper

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -166,7 +166,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
 
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -55,6 +55,7 @@ __all__ = [
     "get_pesticide_efficacy",
     "list_effective_pesticides",
     "recommend_rotation_products",
+    "estimate_rotation_plan_cost",
 ]
 
 
@@ -411,3 +412,18 @@ def recommend_rotation_products(pest: str, count: int = 3) -> list[str]:
             break
 
     return chosen
+
+
+def estimate_rotation_plan_cost(
+    plan: Iterable[tuple[str, date]], volume_l: float
+) -> float:
+    """Return total cost for executing a pesticide rotation plan."""
+
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    total = 0.0
+    for product, _ in plan:
+        total += estimate_application_cost(product, volume_l)
+
+    return round(total, 2)

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -17,6 +17,7 @@ from plant_engine.pesticide_manager import (
     suggest_rotation_plan,
     get_pesticide_price,
     estimate_application_cost,
+    estimate_rotation_plan_cost,
 )
 
 
@@ -206,6 +207,27 @@ def test_pesticide_efficacy_helpers():
     ranking = list_effective_pesticides("aphids")
     assert ranking[0][0] == "imidacloprid"
     assert ranking[0][1] >= ranking[-1][1]
+
+
+def test_estimate_rotation_plan_cost():
+    import importlib
+    from plant_engine import nutrient_manager as nm
+    import plant_engine.utils as utils
+
+    utils.clear_dataset_cache()
+    importlib.reload(nm)
+
+    start = datetime.date(2024, 1, 1)
+    plan = suggest_rotation_plan(["spinosad", "neem_oil"], start)
+    expected = (
+        estimate_application_cost("spinosad", 2.0)
+        + estimate_application_cost("neem_oil", 2.0)
+    )
+    cost = estimate_rotation_plan_cost(plan, 2.0)
+    assert cost == expected
+
+    with pytest.raises(ValueError):
+        estimate_rotation_plan_cost(plan, 0)
 
 
 


### PR DESCRIPTION
## Summary
- fix trailing comma in dataset_catalog.json
- add `estimate_rotation_plan_cost` to pesticide manager
- test rotation plan cost calculation and reload nutrient datasets before running

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f42e96408330af8967bf21f2fc45