### PR TITLE
Add growth habit dataset and reference loader

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -101,6 +101,7 @@
     "ph_adjustment_factors.json": "Acid/base amounts for pH corrections.",
     "ph_guidelines.json": "Optimal pH ranges for nutrient uptake.",
     "growth_medium_ph_ranges.json": "Recommended pH ranges for common growing media.",
+    "growth_habits.json": "Growth habit classification for common crops.",
     "planting_depth_guidelines.json": "Recommended seeding or transplant depths.",
     "pruning_guidelines.json": "Stage-specific pruning recommendations.",
     "pruning_intervals.json": "Days between pruning events for each plant stage.",
@@ -166,8 +167,7 @@
     "nutrient_availability_ph.json": "Relative nutrient availability by solution pH.",
     "nutrient_absorption_rates.json": "Estimated nutrient absorption rates for each growth stage.",
     "root_temperature_uptake.json": "Relative nutrient uptake efficiency by root zone temperature.",
-    "root_temperature_optima.json": "Optimal root zone temperature by crop."
-
+    "root_temperature_optima.json": "Optimal root zone temperature by crop.",
     "pest_resistance_ratings.json": "Relative pest resistance ratings by crop.",
     "pest_scientific_names.json": "Common pests mapped to their scientific names.",
     "disease_resistance_ratings.json": "Relative disease resistance ratings by crop.",
@@ -185,5 +185,5 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
 }

--- a/data/growth_habits.json
+++ b/data/growth_habits.json
@@ -1,0 +1,5 @@
+{
+  "tomato": "indeterminate",
+  "basil": "bush",
+  "cucumber": "vine"
+}

--- a/plant_engine/reference_data.py
+++ b/plant_engine/reference_data.py
@@ -24,6 +24,8 @@ REFERENCE_FILES: dict[str, str] = {
     "disease_guidelines": "disease_guidelines.json",
     # daily water usage requirements per growth stage
     "water_usage_guidelines": "water_usage_guidelines.json",
+    # classification of plant growth habits
+    "growth_habits": "growth_habits.json",
 }
 
 __all__ = [
@@ -31,6 +33,7 @@ __all__ = [
     "get_reference_dataset",
     "get_plant_overview",
     "refresh_reference_data",
+    "register_reference_dataset",
     "REFERENCE_FILES",
 ]
 
@@ -85,6 +88,7 @@ def get_plant_overview(plant_type: str) -> Dict[str, Any]:
         "stages": entry("growth_stages"),
         "tasks": entry("stage_tasks"),
         "water_usage": entry("water_usage_guidelines"),
+        "growth_habit": entry("growth_habits"),
     }
 
 
@@ -93,3 +97,26 @@ def refresh_reference_data() -> None:
 
     load_reference_data.cache_clear()
     clear_dataset_cache()
+
+
+def register_reference_dataset(key: str, filename: str) -> None:
+    """Register a new reference dataset at runtime.
+
+    Parameters
+    ----------
+    key : str
+        Unique identifier used to access the dataset.
+    filename : str
+        Relative path of the dataset file inside the data directory.
+
+    Raises
+    ------
+    ValueError
+        If ``key`` already exists in :data:`REFERENCE_FILES`.
+    """
+
+    if key in REFERENCE_FILES:
+        raise ValueError(f"{key} already registered")
+
+    REFERENCE_FILES[key] = filename
+    refresh_reference_data()

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -100,6 +100,11 @@ def test_score_nutrient_levels_weighted(tmp_path, monkeypatch):
     current = {"N": 80, "P": 30, "K": 60}
     score = nm.score_nutrient_levels(current, "tomato", "fruiting")
     assert 80 < score < 90
+    # reload module with default datasets to avoid side effects
+    monkeypatch.delenv("HORTICULTURE_OVERLAY_DIR", raising=False)
+    import plant_engine.utils as utils
+    utils.clear_dataset_cache()
+    importlib.reload(nm)
 
 
 def test_get_all_recommended_levels():

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -43,3 +43,18 @@ def test_refresh_reference_data(tmp_path, monkeypatch):
     ref.refresh_reference_data()
     data3 = ref.load_reference_data()
     assert data3["dummy_dataset"]["tomato"]["fruiting"] == 500
+
+
+def test_register_reference_dataset(tmp_path, monkeypatch):
+    custom = tmp_path / "my_custom.json"
+    custom.write_text('{"demo": {"value": 42}}')
+
+    monkeypatch.setenv("HORTICULTURE_EXTRA_DATA_DIRS", str(tmp_path))
+    ref.register_reference_dataset("my_custom", custom.name)
+    try:
+        data = ref.get_reference_dataset("my_custom")
+        assert data["demo"]["value"] == 42
+    finally:
+        ref.REFERENCE_FILES.pop("my_custom", None)
+        ref.refresh_reference_data()
+        monkeypatch.delenv("HORTICULTURE_EXTRA_DATA_DIRS", raising=False)


### PR DESCRIPTION
## Summary
- include new `growth_habits.json` dataset describing plant growth habits
- load `growth_habits` through `REFERENCE_FILES`
- expose `register_reference_dataset()` for dynamic dataset registration
- return growth habit data from `get_plant_overview`
- ensure nutrient manager tests cleanly reset overlay
- test new registration helper

## Testing
- `pytest tests/test_reference_data.py::test_register_reference_dataset -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f429a478833090f4647e306fbe2b