### PR TITLE
Enhance dataset loader

### DIFF
--- a/plant_engine/nutrient_efficiency.py
+++ b/plant_engine/nutrient_efficiency.py
@@ -25,13 +25,14 @@ TARGET_FILE = "nutrient_efficiency_targets.json"
 # Default storage locations can be overridden with environment variables. This
 # makes the module more flexible for testing and deployment scenarios where the
 # repository's ``data`` directory is not writable.
-NUTRIENT_DIR = Path(os.getenv("HORTICULTURE_NUTRIENT_DIR", "data/nutrients_applied"))
-YIELD_DIR = Path(os.getenv("HORTICULTURE_YIELD_DIR", "data/yield"))
+NUTRIENT_DIR = os.getenv("HORTICULTURE_NUTRIENT_DIR", "data/nutrients_applied")
+YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 
 def _load_totals(plant_id: str) -> Tuple[Dict[str, float], float]:
     """Return total nutrients applied (mg) and total yield (g)."""
 
-    path_nutrients = NUTRIENT_DIR / f"{plant_id}.json"
+    nutrient_base = Path(NUTRIENT_DIR)
+    path_nutrients = nutrient_base / f"{plant_id}.json"
     if not path_nutrients.exists():
         raise FileNotFoundError(f"No nutrient record found for {plant_id}")
 
@@ -42,7 +43,8 @@ def _load_totals(plant_id: str) -> Tuple[Dict[str, float], float]:
         for k, v in entry.get("nutrients_mg", {}).items():
             total_applied_mg[k] = total_applied_mg.get(k, 0.0) + float(v)
 
-    path_yield = YIELD_DIR / f"{plant_id}.json"
+    yield_base = Path(YIELD_DIR)
+    path_yield = yield_base / f"{plant_id}.json"
     if not path_yield.exists():
         raise FileNotFoundError(f"No yield record found for {plant_id}")
 


### PR DESCRIPTION
## Summary
- add TTL-based refresh to `lazy_dataset`
- make nutrient efficiency helper robust when patched in tests
- test TTL refresh behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f75f9b448330b9d35b08e9a9e0aa