### PR TITLE
Refactor harvest planner and add helper

### DIFF
--- a/plant_engine/harvest_planner.py
+++ b/plant_engine/harvest_planner.py
@@ -1,12 +1,12 @@
 """Utilities for planning growth stage schedules."""
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date
 from typing import Dict, List
 
-from .growth_stage import list_growth_stages, get_stage_duration
+from .growth_stage import generate_stage_schedule, predict_harvest_date
 
-__all__ = ["build_stage_schedule"]
+__all__ = ["build_stage_schedule", "estimate_harvest_date"]
 
 
 def build_stage_schedule(plant_type: str, start_date: date) -> List[Dict[str, object]]:
@@ -25,19 +25,17 @@ def build_stage_schedule(plant_type: str, start_date: date) -> List[Dict[str, ob
         Each dictionary contains ``stage``, ``start_date``, ``end_date`` and
         ``duration_days`` keys. ``end_date`` is exclusive.
     """
-    stages = list_growth_stages(plant_type)
+    base = generate_stage_schedule(plant_type, start_date)
     schedule: List[Dict[str, object]] = []
-    current = start_date
-    for stage in stages:
-        duration = get_stage_duration(plant_type, stage) or 0
-        end = current + timedelta(days=duration)
-        schedule.append(
-            {
-                "stage": stage,
-                "start_date": current,
-                "end_date": end,
-                "duration_days": duration,
-            }
-        )
-        current = end
+    for entry in base:
+        start = entry["start_date"]
+        end = entry["end_date"]
+        duration = (end - start).days
+        schedule.append({**entry, "duration_days": duration})
     return schedule
+
+
+def estimate_harvest_date(plant_type: str, start_date: date) -> date | None:
+    """Return the predicted harvest date for the crop cycle."""
+
+    return predict_harvest_date(plant_type, start_date)

--- a/tests/test_harvest_planner.py
+++ b/tests/test_harvest_planner.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from plant_engine.harvest_planner import build_stage_schedule
+from plant_engine.harvest_planner import build_stage_schedule, estimate_harvest_date
 
 
 def test_build_stage_schedule():
@@ -13,3 +13,9 @@ def test_build_stage_schedule():
     # ensure durations sum to 120 days from dataset
     total = sum(entry["duration_days"] for entry in schedule)
     assert total == 120
+
+
+def test_estimate_harvest_date():
+    start = date(2025, 1, 1)
+    harvest = estimate_harvest_date("tomato", start)
+    assert harvest.isoformat() == "2025-05-01"


### PR DESCRIPTION
## Summary
- simplify stage schedule logic in `harvest_planner`
- expose `estimate_harvest_date` convenience helper
- test new function

## Testing
- `pytest tests/test_harvest_planner.py::test_build_stage_schedule tests/test_harvest_planner.py::test_estimate_harvest_date -q`
- `pytest -q` *(fails: nutrient efficiency calc)*

------
https://chatgpt.com/codex/tasks/task_e_6888f75dc7588330ada9c65f6265fd48