### PR TITLE
Add plant hardiness zone helpers

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -186,5 +186,6 @@
     "species_precipitation_risk.json": "Species-specific mineral precipitation risks due to nutrient interactions.",
     "nighttime_strategies.json": "Nighttime growth habits and irrigation guidance by species.",
     "frost_dates.json": "Typical last and first frost dates by USDA hardiness zone.",
-    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones."
+    "hardiness_zone_temperatures.json": "Minimum winter temperature (\u00b0C) for USDA hardiness zones.",
+    "plant_hardiness_zones.json": "Recommended USDA hardiness zone range for each crop."
 }

--- a/data/plant_hardiness_zones.json
+++ b/data/plant_hardiness_zones.json
@@ -1,0 +1,5 @@
+{
+  "citrus": {"min_zone": "9", "max_zone": "11"},
+  "lettuce": {"min_zone": "4", "max_zone": "8"},
+  "tomato": {"min_zone": "5", "max_zone": "10"}
+}

--- a/plant_engine/hardiness_zone.py
+++ b/plant_engine/hardiness_zone.py
@@ -1,14 +1,22 @@
 """Helpers for working with USDA hardiness zone data."""
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Mapping
 
 from .utils import load_dataset
 
 DATA_FILE = "hardiness_zone_temperatures.json"
 _DATA = load_dataset(DATA_FILE)
+PLANT_FILE = "plant_hardiness_zones.json"
+_PLANT_ZONES: Mapping[str, Mapping[str, str]] = load_dataset(PLANT_FILE)
 
-__all__ = ["get_min_temperature", "suitable_zones"]
+__all__ = [
+    "get_min_temperature",
+    "suitable_zones",
+    "get_hardiness_range",
+    "is_plant_suitable_for_zone",
+    "plants_for_zone",
+]
 
 
 def get_min_temperature(zone: str) -> float | None:
@@ -32,3 +40,48 @@ def suitable_zones(min_temp_c: float) -> list[str]:
             zones.append(str(zone))
     zones.sort(key=lambda z: float(_DATA[z]))
     return zones
+
+
+def get_hardiness_range(plant_type: str) -> tuple[str, str] | None:
+    """Return (min_zone, max_zone) recommended for ``plant_type``."""
+    info = _PLANT_ZONES.get(plant_type.lower())
+    if not isinstance(info, Mapping):
+        return None
+    min_z = info.get("min_zone")
+    max_z = info.get("max_zone")
+    if isinstance(min_z, str) and isinstance(max_z, str):
+        return min_z, max_z
+    return None
+
+
+def is_plant_suitable_for_zone(plant_type: str, zone: str) -> bool:
+    """Return ``True`` if ``zone`` falls within the plant's recommended range."""
+    rng = get_hardiness_range(plant_type)
+    if not rng:
+        return True
+    min_z, max_z = rng
+    try:
+        zone_v = float(zone)
+        return float(min_z) <= zone_v <= float(max_z)
+    except (TypeError, ValueError):
+        return False
+
+
+def plants_for_zone(zone: str) -> list[str]:
+    """Return plant types whose recommended range includes ``zone``."""
+    results: list[str] = []
+    try:
+        zone_v = float(zone)
+    except (TypeError, ValueError):
+        return results
+    for plant, info in _PLANT_ZONES.items():
+        if not isinstance(info, Mapping):
+            continue
+        try:
+            min_z = float(info.get("min_zone", "0"))
+            max_z = float(info.get("max_zone", "0"))
+        except (TypeError, ValueError):
+            continue
+        if min_z <= zone_v <= max_z:
+            results.append(plant)
+    return sorted(results)

--- a/tests/test_hardiness_zone_recommendations.py
+++ b/tests/test_hardiness_zone_recommendations.py
@@ -1,0 +1,21 @@
+from plant_engine.hardiness_zone import (
+    get_hardiness_range,
+    is_plant_suitable_for_zone,
+    plants_for_zone,
+)
+
+
+def test_get_hardiness_range():
+    assert get_hardiness_range("citrus") == ("9", "11")
+    assert get_hardiness_range("unknown") is None
+
+
+def test_is_plant_suitable_for_zone():
+    assert is_plant_suitable_for_zone("citrus", "10")
+    assert not is_plant_suitable_for_zone("citrus", "5")
+
+
+def test_plants_for_zone():
+    plants = plants_for_zone("5")
+    assert "tomato" in plants
+    assert "citrus" not in plants


### PR DESCRIPTION
## Summary
- expand hardiness_zone module with new helper functions
- provide `plant_hardiness_zones.json` dataset and register it in the catalog
- add tests for plant hardiness zone recommendations

## Testing
- `pytest -q tests/test_hardiness_zone.py tests/test_hardiness_zone_recommendations.py tests/test_dataset_catalog.py::test_get_dataset_description -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f75a21708330a35205ece685ee8a