### PR TITLE
Add deficiency index series utility

### DIFF
--- a/plant_engine/nutrient_manager.py
+++ b/plant_engine/nutrient_manager.py
@@ -49,6 +49,7 @@ __all__ = [
     "score_nutrient_levels",
     "score_nutrient_series",
     "calculate_deficiency_index",
+    "calculate_deficiency_index_series",
     "recommend_ratio_adjustments",
     "calculate_nutrient_adjustments",
     "get_tag_modifier",
@@ -326,6 +327,17 @@ def calculate_deficiency_index(
         return 0.0
 
     return _deficiency_index_for_targets(current_levels, targets)
+
+
+def calculate_deficiency_index_series(
+    series: Iterable[Mapping[str, float]], plant_type: str, stage: str
+) -> float:
+    """Return the average deficiency index for a sequence of readings."""
+
+    indices = [calculate_deficiency_index(s, plant_type, stage) for s in series]
+    if not indices:
+        return 0.0
+    return round(sum(indices) / len(indices), 1)
 
 
 def get_all_recommended_levels(plant_type: str, stage: str) -> Dict[str, float]:

--- a/tests/test_nutrient_manager.py
+++ b/tests/test_nutrient_manager.py
@@ -139,6 +139,21 @@ def test_score_nutrient_series():
     assert score == (100.0 + score_nutrient_levels(s2, "tomato", "fruiting")) / 2
 
 
+def test_calculate_deficiency_index_series():
+    from plant_engine.nutrient_manager import (
+        calculate_deficiency_index_series,
+        calculate_deficiency_index,
+        get_all_recommended_levels,
+    )
+
+    guidelines = get_all_recommended_levels("tomato", "fruiting")
+    zero = {n: 0 for n in guidelines}
+    idx_single = calculate_deficiency_index(zero, "tomato", "fruiting")
+    avg = calculate_deficiency_index_series([zero, guidelines], "tomato", "fruiting")
+    assert avg == round((idx_single + 0.0) / 2, 1)
+    assert calculate_deficiency_index_series([], "tomato", "fruiting") == 0.0
+
+
 def test_apply_tag_modifiers():
     from plant_engine import nutrient_manager as nm
 


### PR DESCRIPTION
## Summary
- provide a helper to average deficiency indices across readings
- test deficiency index series utility

## Testing
- `pytest tests/test_nutrient_manager.py::test_calculate_deficiency_index_series -q`
- `pytest -q` *(fails: TypeError in nutrient_efficiency.py)*

------
https://chatgpt.com/codex/tasks/task_e_6888f754f9d483308cc333093dfaf89e