### PR TITLE
Fix nutrient efficiency path handling

### DIFF
--- a/plant_engine/nutrient_efficiency.py
+++ b/plant_engine/nutrient_efficiency.py
@@ -25,13 +25,13 @@ TARGET_FILE = "nutrient_efficiency_targets.json"
 # Default storage locations can be overridden with environment variables. This
 # makes the module more flexible for testing and deployment scenarios where the
 # repository's ``data`` directory is not writable.
-NUTRIENT_DIR = Path(os.getenv("HORTICULTURE_NUTRIENT_DIR", "data/nutrients_applied"))
-YIELD_DIR = Path(os.getenv("HORTICULTURE_YIELD_DIR", "data/yield"))
+NUTRIENT_DIR = os.getenv("HORTICULTURE_NUTRIENT_DIR", "data/nutrients_applied")
+YIELD_DIR = os.getenv("HORTICULTURE_YIELD_DIR", "data/yield")
 
 def _load_totals(plant_id: str) -> Tuple[Dict[str, float], float]:
     """Return total nutrients applied (mg) and total yield (g)."""
 
-    path_nutrients = NUTRIENT_DIR / f"{plant_id}.json"
+    path_nutrients = Path(NUTRIENT_DIR) / f"{plant_id}.json"
     if not path_nutrients.exists():
         raise FileNotFoundError(f"No nutrient record found for {plant_id}")
 
@@ -42,7 +42,7 @@ def _load_totals(plant_id: str) -> Tuple[Dict[str, float], float]:
         for k, v in entry.get("nutrients_mg", {}).items():
             total_applied_mg[k] = total_applied_mg.get(k, 0.0) + float(v)
 
-    path_yield = YIELD_DIR / f"{plant_id}.json"
+    path_yield = Path(YIELD_DIR) / f"{plant_id}.json"
     if not path_yield.exists():
         raise FileNotFoundError(f"No yield record found for {plant_id}")
 

--- a/tests/test_ai_model.py
+++ b/tests/test_ai_model.py
@@ -1,4 +1,4 @@
-import pytest
+import asyncio
 from plant_engine import ai_model
 
 
@@ -13,10 +13,9 @@ def test_analyze_uses_mock_model():
     assert updated["leaf_temp"] == 19.0
 
 
-@pytest.mark.asyncio
-async def test_analyze_async_uses_mock_model():
+def test_analyze_async_uses_mock_model():
     data = {"thresholds": {"leaf_temp": 20}, "lifecycle_stage": "vegetative"}
-    updated = await ai_model.analyze_async(data)
+    updated = asyncio.run(ai_model.analyze_async(data))
     assert updated["leaf_temp"] == 19.0
 
 


### PR DESCRIPTION
## Summary
- ensure nutrient efficiency module handles str or Path for data directories
- update async test to avoid requiring pytest-asyncio

## Testing
- `pytest tests/test_ai_model.py tests/test_nutrient_efficiency_calc.py tests/test_nutrient_efficiency_env.py tests/test_nutrient_efficiency_eval.py tests/test_nutrient_efficiency_single.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f7ce14ac83308c4bc6127dcfde35