### PR TITLE
Add energy emission calculations

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -176,6 +176,7 @@
     "reference_et0_range.json": "Typical min and max ET0 values by month",
     "et0_climate_adjustments.json": "Multipliers adjusting ET0 for climate zones",
     "electricity_rates.json": "Electricity cost per kWh by region.",
+    "energy_emission_factors.json": "Kg CO2 emitted per kWh of electricity by source.",
     "water_costs.json": "Water cost per liter by region.",
     "feature/wsda_refactored_sharded/detail/": "Detailed WSDA product info (one file per product_id)",
     "feature/wsda_refactored_sharded/index_sharded/": "Sharded index of WSDA fertilizer products",

--- a/data/energy_emission_factors.json
+++ b/data/energy_emission_factors.json
@@ -1,0 +1,9 @@
+{
+  "default": 0.4,
+  "solar": 0.05,
+  "wind": 0.02,
+  "hydro": 0.04,
+  "nuclear": 0.05,
+  "coal": 0.9,
+  "natural_gas": 0.5
+}

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -9,6 +9,10 @@ from plant_engine.energy_manager import (
     get_electricity_rate,
     estimate_lighting_energy,
     estimate_lighting_cost,
+    get_emission_factor,
+    estimate_lighting_emissions,
+    estimate_hvac_emissions,
+    estimate_hvac_emissions_series,
     get_light_efficiency,
     estimate_dli_from_power,
 )
@@ -69,3 +73,24 @@ def test_light_efficiency_and_dli():
     dli = estimate_dli_from_power(200, 5, "led")
     # 200W for 5h at 2.5 umol/J over 1 m^2 -> 9 mol
     assert dli == pytest.approx(9.0, 0.1)
+
+
+def test_emission_factor_lookup():
+    assert get_emission_factor("solar") == 0.05
+    assert get_emission_factor("unknown") == 0.4
+
+
+def test_lighting_emissions():
+    kg = estimate_lighting_emissions(200, 5, "solar")
+    assert kg == pytest.approx(0.05, 0.001)
+
+
+def test_hvac_emissions_and_series():
+    kg = estimate_hvac_emissions(18, 20, 12, "heating", source="coal")
+    expected_energy = 0.5 * (2 * 12 / 24)
+    assert kg == pytest.approx(expected_energy * 0.9, 0.001)
+
+    temps = [20, 22]
+    series = estimate_hvac_emissions_series(18, temps, 4, "heating", source="coal")
+    expected_energy = round(0.5 * (2 * 4 / 24), 2)
+    assert series[0] == pytest.approx(expected_energy * 0.9, 0.001)


### PR DESCRIPTION
## Summary
- expand energy utilities with carbon emissions estimation helpers
- record energy emission factors dataset
- wire up dataset catalog for emission factors
- test HVAC and lighting emission helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688911674cf0833089cb04850a8df3ea