### PR TITLE
Enhance nutrient planner with cost reporting

### DIFF
--- a/tests/test_nutrient_planner.py
+++ b/tests/test_nutrient_planner.py
@@ -1,7 +1,9 @@
 import pytest
 from plant_engine.nutrient_planner import (
     generate_nutrient_management_report,
+    generate_nutrient_management_report_with_cost,
     NutrientManagementReport,
+    NutrientManagementCostReport,
 )
 
 
@@ -28,3 +30,16 @@ def test_generate_nutrient_management_report_invalid_volume():
             "seedling",
             volume_l=0,
         )
+
+
+def test_generate_nutrient_management_report_with_cost():
+    current = {"N": 50, "P": 10, "K": 40}
+    report = generate_nutrient_management_report_with_cost(
+        current,
+        "lettuce",
+        "seedling",
+        volume_l=5.0,
+    )
+    assert isinstance(report, NutrientManagementCostReport)
+    assert report.cost_total >= 0
+


### PR DESCRIPTION
## Summary
- extend nutrient planner to calculate cheapest fertilizer cost for correcting deficits
- expose `generate_nutrient_management_report_with_cost`
- test new cost-aware nutrient planner functionality

## Testing
- `pytest tests/test_nutrient_planner.py::test_generate_nutrient_management_report -q`
- `pytest tests/test_nutrient_planner.py::test_generate_nutrient_management_report_with_cost -q`
- `pytest tests/test_nutrient_planner.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889115e620c8330bbd53401a4c401e8