### PR TITLE
Enhance pest monitoring with yield loss estimates

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -98,6 +98,7 @@
     "pest_severity_actions.json": "Actions to take based on pest severity level.",
     "pest_severity_thresholds.json": "Population levels defining pest severity categories.",
     "pest_severity_scores.json": "Numeric scores for pest severity levels.",
+    "pest_yield_loss.json": "Estimated yield loss percentage per pest severity level.",
     "ph_adjustment_factors.json": "Acid/base amounts for pH corrections.",
     "ph_guidelines.json": "Optimal pH ranges for nutrient uptake.",
     "growth_medium_ph_ranges.json": "Recommended pH ranges for common growing media.",

--- a/data/pest_yield_loss.json
+++ b/data/pest_yield_loss.json
@@ -1,0 +1,5 @@
+{
+  "aphids": {"low": 2, "moderate": 5, "severe": 10},
+  "scale": {"low": 1, "moderate": 3, "severe": 6},
+  "mites": {"low": 2, "moderate": 5, "severe": 8}
+}

--- a/tests/test_pest_monitor.py
+++ b/tests/test_pest_monitor.py
@@ -22,6 +22,7 @@ from plant_engine.pest_monitor import (
     calculate_pest_management_index,
     calculate_pest_management_index_series,
     calculate_severity_index,
+    estimate_yield_loss,
     estimate_adjusted_pest_risk_series,
     get_sample_size,
 )
@@ -253,6 +254,18 @@ def test_report_includes_severity_index():
     obs = {"aphids": 6}
     report = generate_pest_report("citrus", obs)
     assert report["severity_index"] > 0
+
+
+def test_estimate_yield_loss():
+    severity = {"aphids": "moderate", "scale": "low"}
+    loss = estimate_yield_loss(severity)
+    assert loss == 6.0
+
+
+def test_report_includes_yield_loss():
+    obs = {"aphids": 6, "scale": 2}
+    report = generate_pest_report("citrus", obs)
+    assert report.get("yield_loss") is not None
 
 
 def test_get_sample_size():


### PR DESCRIPTION
## Summary
- add new `pest_yield_loss.json` dataset
- register dataset in `dataset_catalog.json`
- extend pest monitor to estimate yield loss from severity
- include yield loss in generated pest reports
- test new functionality

## Testing
- `pytest tests/test_pest_monitor.py::test_estimate_yield_loss -q`
- `pytest tests/test_pest_monitor.py::test_report_includes_yield_loss -q`
- `pytest tests/test_pest_monitor.py tests/test_pest_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688911622f3c83308425ed58c24ff406