### PR TITLE
Refactor EC estimator

### DIFF
--- a/tests/test_ec_features.py
+++ b/tests/test_ec_features.py
@@ -1,0 +1,16 @@
+from custom_components.horticulture_assistant.utils.ec_estimator import ECFeatures
+
+
+def test_asdict_filters_none():
+    features = ECFeatures(
+        moisture=30,
+        temperature=20,
+        irrigation_ml=100,
+        solution_ec=1.5,
+        ambient_temp=None,
+        humidity=50,
+    )
+    data = features.asdict()
+    assert data["moisture"] == 30
+    assert "ambient_temp" not in data
+    assert data["humidity"] == 50


### PR DESCRIPTION
## Summary
- refactor EC estimator module for readability
- add new `ECFeatures` dataclass with conversion helper
- add regression test for `ECFeatures.asdict`

## Testing
- `pytest tests/test_ec_estimator.py::test_train_and_estimate -q`
- `pytest tests/test_ec_features.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891157f234833089758bb8eb1bf5dd