### PR TITLE
Improve nutrient efficiency tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 - Environment score and quality rating for sensor data
 - Infiltration-aware irrigation burst scheduling
 - Cost-optimized fertigation plans with injection volumes
+- Weekly nutrient usage metrics for efficiency tracking
 - Risk-adjusted pest monitoring summaries and scheduling
 - Automatic pesticide rotation planning
 - Root uptake factor calculation from soil temperature

--- a/tests/test_average_weekly_usage.py
+++ b/tests/test_average_weekly_usage.py
@@ -1,0 +1,18 @@
+import json
+from custom_components.horticulture_assistant.utils.nutrient_use_efficiency import NutrientUseEfficiency
+
+def test_average_weekly_usage(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    usage = {
+        "plant1": [
+            {"date": "2025-01-01", "nutrients": {"N": 100}, "stage": "veg"},
+            {"date": "2025-01-08", "nutrients": {"N": 150}, "stage": "veg"},
+        ]
+    }
+    (data_dir / "nutrient_use.json").write_text(json.dumps(usage))
+    (data_dir / "yield_logs.json").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+    nue = NutrientUseEfficiency()
+    avg = nue.average_weekly_usage("plant1")
+    assert avg["N"] == 125.0


### PR DESCRIPTION
## Summary
- add `ApplicationRecord` dataclass and weekly usage calculations
- expose new `average_weekly_usage` helper
- keep usage log writing resilient to dataclass objects
- document weekly nutrient metrics
- test new usage calculations

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_nutrient_use_efficiency_util.py tests/test_efficiency_targets.py tests/test_efficiency_report.py tests/test_average_weekly_usage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68891151e7a88330b76bdd32df9cdadd