### PR TITLE
Improve fertilizer catalog and add dilution limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Important categories include:
 - **Water usage guidelines** – typical daily irrigation volumes by stage
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions
+- **Fertilizer dilution limits** – recommended maximum grams per liter for common products
 - **Fertilizer ingredient profiles** – nutrient content, chemical formulas, physical form and aliases for raw salts. Use `plant_engine.ingredients.get_ingredient_profile()` to access them programmatically
 - **Stock solution recipes** – injection ratios for automated fertigation
 - **Fertilizer compatibility** – warnings for mixing products that react poorly

--- a/custom_components/horticulture_assistant/catalog.py
+++ b/custom_components/horticulture_assistant/catalog.py
@@ -1,0 +1,108 @@
+"""Dataset-backed catalog for fertilizer information."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict
+
+from plant_engine.utils import lazy_dataset
+
+DATA_FILE = "fertilizers/fertilizer_products.json"
+PRICE_FILE = "fertilizers/fertilizer_prices.json"
+SOLUBILITY_FILE = "fertilizer_solubility.json"
+APPLICATION_FILE = "fertilizers/fertilizer_application_methods.json"
+RATE_FILE = "fertilizers/fertilizer_application_rates.json"
+COMPAT_FILE = "fertilizers/fertilizer_compatibility.json"
+DILUTION_FILE = "fertilizers/fertilizer_dilution_limits.json"
+
+_DATA = lazy_dataset(DATA_FILE)
+_PRICES = lazy_dataset(PRICE_FILE)
+_SOLUBILITY = lazy_dataset(SOLUBILITY_FILE)
+_APPLICATION = lazy_dataset(APPLICATION_FILE)
+_RATES = lazy_dataset(RATE_FILE)
+_COMPAT = lazy_dataset(COMPAT_FILE)
+_DILUTION = lazy_dataset(DILUTION_FILE)
+
+
+@dataclass(frozen=True, slots=True)
+class Fertilizer:
+    """Fertilizer product information."""
+
+    density_kg_per_l: float
+    guaranteed_analysis: Dict[str, float]
+    product_name: str | None = None
+    wsda_product_number: str | None = None
+
+
+class FertilizerCatalog:
+    """Cached access to fertilizer datasets."""
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def inventory() -> Dict[str, Fertilizer]:
+        data = _DATA()
+        inv: Dict[str, Fertilizer] = {}
+        for name, info in data.items():
+            inv[name] = Fertilizer(
+                density_kg_per_l=info.get("density_kg_per_l", 1.0),
+                guaranteed_analysis=info.get("guaranteed_analysis", {}),
+                product_name=info.get("product_name"),
+                wsda_product_number=info.get("wsda_product_number"),
+            )
+        return inv
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def prices() -> Dict[str, float]:
+        return _PRICES()
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def solubility() -> Dict[str, float]:
+        return _SOLUBILITY()
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def application_methods() -> Dict[str, str]:
+        return _APPLICATION()
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def application_rates() -> Dict[str, float]:
+        return _RATES()
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def compatibility() -> Dict[str, Dict[str, str]]:
+        raw = _COMPAT()
+        mapping: Dict[str, Dict[str, str]] = {}
+        for fert, info in raw.items():
+            if not isinstance(info, dict):
+                continue
+            inner: Dict[str, str] = {}
+            for other, reason in info.items():
+                inner[str(other)] = str(reason)
+            if inner:
+                mapping[fert] = inner
+        return mapping
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def dilution_limits() -> Dict[str, float]:
+        return _DILUTION()
+
+    def list_products(self) -> list[str]:
+        inv = self.inventory()
+        return sorted(inv.keys(), key=lambda pid: inv[pid].product_name or pid)
+
+    def get_product_info(self, fertilizer_id: str) -> Fertilizer:
+        inv = self.inventory()
+        if fertilizer_id not in inv:
+            raise KeyError(f"Unknown fertilizer '{fertilizer_id}'")
+        return inv[fertilizer_id]
+
+
+CATALOG = FertilizerCatalog()
+
+__all__ = ["Fertilizer", "FertilizerCatalog", "CATALOG"]

--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -130,6 +130,7 @@
     "fertilizers/fertilizer_application_methods.json": "Recommended application methods for each fertilizer product.",
     "fertilizers/fertilizer_application_rates.json": "Recommended grams per liter of fertilizer product.",
     "fertilizers/fertilizer_compatibility.json": "Compatibility warnings for mixing fertilizer products.",
+    "fertilizers/fertilizer_dilution_limits.json": "Maximum recommended grams per liter for fertilizer products.",
     "ion_ec_factors.json": "EC contribution factors for nutrient ions (uS/cm per ppm).",
     "water_usage_guidelines.json": "Typical daily water use (mL) per plant stage.",
     "canopy_area.json": "Approximate canopy area (m²) per plant stage.",

--- a/data/fertilizers/fertilizer_dilution_limits.json
+++ b/data/fertilizers/fertilizer_dilution_limits.json
@@ -1,0 +1,5 @@
+{
+  "foxfarm_grow_big": 150,
+  "magriculture": 200,
+  "intrepid_granular_potash_0_0_60": 100
+}

--- a/tests/test_fertilizer_formulator.py
+++ b/tests/test_fertilizer_formulator.py
@@ -1,16 +1,12 @@
-import importlib.util
+import importlib
 import sys
 from pathlib import Path
 import pytest
 
-module_path = (
-    Path(__file__).resolve().parents[1]
-    / "custom_components/horticulture_assistant/fertilizer_formulator.py"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+fert_mod = importlib.import_module(
+    "custom_components.horticulture_assistant.fertilizer_formulator"
 )
-spec = importlib.util.spec_from_file_location("fertilizer_formulator", module_path)
-fert_mod = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = fert_mod
-spec.loader.exec_module(fert_mod)
 
 calculate_fertilizer_nutrients = fert_mod.calculate_fertilizer_nutrients
 convert_guaranteed_analysis = fert_mod.convert_guaranteed_analysis
@@ -29,6 +25,7 @@ calculate_mix_ppm = fert_mod.calculate_mix_ppm
 calculate_mix_density = fert_mod.calculate_mix_density
 estimate_solution_mass = fert_mod.estimate_solution_mass
 check_solubility_limits = fert_mod.check_solubility_limits
+check_dilution_limits = fert_mod.check_dilution_limits
 check_schedule_compatibility = fert_mod.check_schedule_compatibility
 estimate_cost_per_nutrient = fert_mod.estimate_cost_per_nutrient
 calculate_fertilizer_ppm = fert_mod.calculate_fertilizer_ppm
@@ -182,6 +179,18 @@ def test_check_solubility_limits():
 
     with pytest.raises(ValueError):
         check_solubility_limits(schedule, 0)
+
+
+def test_check_dilution_limits():
+    schedule = {"foxfarm_grow_big": 200}
+    warnings = check_dilution_limits(schedule, 1)
+    assert warnings["foxfarm_grow_big"] > 0
+
+    ok = check_dilution_limits({"foxfarm_grow_big": 50}, 1)
+    assert ok == {}
+
+    with pytest.raises(ValueError):
+        check_dilution_limits(schedule, 0)
 
 
 def test_check_schedule_compatibility():


### PR DESCRIPTION
## Summary
- add dataset for fertilizer dilution limits
- refactor fertilizer data loading into a new `catalog` module
- load new catalog in `fertilizer_formulator`
- check dilution limits for fertigation mixes
- update README and dataset catalog
- update and extend tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889114fe2f88330a8efb60c05fb4e54