### PR TITLE
Enhance environment metrics handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 - Daily report files summarizing environment and nutrient targets
 - Growth stage nutrient schedules for precise fertilization planning
 - Environment score and quality rating for sensor data
+- DataFrame-based environment metrics for bulk analysis
 - Infiltration-aware irrigation burst scheduling
 - Cost-optimized fertigation plans with injection volumes
 - Risk-adjusted pest monitoring summaries and scheduling

--- a/plant_engine/environment_manager.py
+++ b/plant_engine/environment_manager.py
@@ -447,6 +447,7 @@ __all__ = [
     "calculate_environment_deviation_series",
     "EnvironmentSummary",
     "calculate_environment_metrics_series",
+    "calculate_environment_metrics_dataframe",
     "generate_stage_environment_plan",
     "generate_stage_growth_plan",
     "generate_cycle_growth_plan",
@@ -2389,6 +2390,42 @@ def calculate_environment_metrics_series(
         plant_type=plant_type,
         stage=stage,
     )
+
+
+def calculate_environment_metrics_dataframe(
+    df: "pd.DataFrame",
+    plant_type: str | None = None,
+    stage: str | None = None,
+) -> "pd.DataFrame":
+    """Return :class:`EnvironmentMetrics` for each row of ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing ``temp_c`` and ``humidity_pct`` columns along with
+        optional additional environment readings.
+    plant_type : str, optional
+        Plant type used for calculations involving transpiration.
+    stage : str, optional
+        Growth stage for stage-specific parameters.
+    """
+
+    import pandas as pd
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    def _row_metrics(row: pd.Series) -> dict[str, float | None]:
+        metrics = calculate_environment_metrics(
+            row.get("temp_c"),
+            row.get("humidity_pct"),
+            env=row,
+            plant_type=plant_type,
+            stage=stage,
+        )
+        return metrics.as_dict()
+
+    return df.apply(_row_metrics, axis=1, result_type="expand")
 
 
 def optimize_environment(

--- a/tests/test_environment_manager.py
+++ b/tests/test_environment_manager.py
@@ -73,6 +73,7 @@ from plant_engine.environment_manager import (
     summarize_environment,
     summarize_environment_series,
     calculate_environment_metrics_series,
+    calculate_environment_metrics_dataframe,
     average_environment_readings,
     calculate_environment_variance,
     calculate_environment_stddev,
@@ -1089,6 +1090,30 @@ def test_calculate_environment_metrics_series():
     avg_temp = (20 + 22 + 21) / 3
     avg_hum = (60 + 65 + 55) / 3
     assert metrics.vpd == calculate_vpd(avg_temp, avg_hum)
+
+
+def test_calculate_environment_metrics_dataframe():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {"temp_c": 20, "humidity_pct": 60},
+            {"temp_c": 22, "humidity_pct": 65},
+            {"temp_c": 21, "humidity_pct": 55},
+        ]
+    )
+    metrics_df = calculate_environment_metrics_dataframe(df)
+    assert list(metrics_df.columns) == [
+        "vpd",
+        "dew_point_c",
+        "heat_index_c",
+        "absolute_humidity_g_m3",
+        "et0_mm_day",
+        "eta_mm_day",
+        "transpiration_ml_day",
+        "root_uptake_factor",
+    ]
+    assert metrics_df.iloc[0]["vpd"] == calculate_vpd(20, 60)
 
 
 def test_summarize_environment_series_generator():


### PR DESCRIPTION
## Summary
- add `calculate_environment_metrics_dataframe` for bulk metric calculation
- test DataFrame-based metrics
- document bulk metrics in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891148e8888330872556a8fced13e4