### PR TITLE
Optimize infiltration burst scheduling

### DIFF
--- a/plant_engine/irrigation_manager.py
+++ b/plant_engine/irrigation_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Mapping, Dict, Any
+import math
 
 from .utils import lazy_dataset, normalize_key, stage_value
 from .et_model import calculate_eta
@@ -619,12 +620,16 @@ def generate_infiltration_bursts(
     capacity_ml_h = rate * area_m2 * 1000
     max_burst = capacity_ml_h * max_hours
 
-    bursts: list[float] = []
-    remaining = volume_ml
-    while remaining > 0:
-        burst = min(remaining, max_burst)
-        bursts.append(round(burst, 1))
-        remaining -= burst
+    if max_burst <= 0:
+        return [round(volume_ml, 1)]
+
+    burst_count = math.ceil(volume_ml / max_burst)
+    base = volume_ml / burst_count
+    bursts = [round(base, 1) for _ in range(burst_count)]
+
+    diff = round(volume_ml - base * burst_count, 1)
+    if diff:
+        bursts[-1] = round(bursts[-1] + diff, 1)
 
     return bursts
 

--- a/tests/test_infiltration_bursts.py
+++ b/tests/test_infiltration_bursts.py
@@ -4,7 +4,7 @@ from plant_engine.irrigation_manager import generate_infiltration_bursts
 
 def test_generate_infiltration_bursts_basic():
     bursts = generate_infiltration_bursts(800, 0.1, "loam", max_hours=0.5)
-    assert bursts == [500.0, 300.0]
+    assert bursts == [400.0, 400.0]
 
 
 def test_generate_infiltration_bursts_unknown_texture():

--- a/tests/test_irrigation_manager.py
+++ b/tests/test_irrigation_manager.py
@@ -366,7 +366,7 @@ def test_adjust_irrigation_for_zone():
 def test_generate_cycle_infiltration_schedule():
     schedule = generate_cycle_infiltration_schedule("lettuce", 0.1, "clay")
     veg = schedule["vegetative"]
-    assert veg[1] == [200.0, 100.0]
+    assert veg[1] == [150.0, 150.0]
 
 
 def test_lazy_dataset_loading():


### PR DESCRIPTION
## Summary
- improve infiltration burst calculations in `generate_infiltration_bursts`
- adjust tests for even burst output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889114505308330b0627cac146a6052