### PR TITLE
Improve media inference

### DIFF
--- a/data/media_sensor_profiles.json
+++ b/data/media_sensor_profiles.json
@@ -1,0 +1,6 @@
+{
+  "Peat Moss": {"retention": 0.9, "dryback": 0.2, "ec_buffer": 0.9},
+  "Coco Coir": {"retention": 0.8, "dryback": 0.3, "ec_buffer": 0.8},
+  "Rockwool": {"retention": 0.7, "dryback": 0.7, "ec_buffer": 0.1},
+  "Perlite Blend": {"retention": 0.5, "dryback": 0.9, "ec_buffer": 0.4}
+}

--- a/tests/test_media_inference.py
+++ b/tests/test_media_inference.py
@@ -1,0 +1,31 @@
+from custom_components.horticulture_assistant.utils.media_inference import (
+    infer_media_type,
+    MediaInferenceResult,
+)
+
+
+def test_infer_media_type_basic(tmp_path, monkeypatch):
+    # Use a temporary data path to avoid writing to repo
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.utils.media_inference.data_path",
+        lambda _hass, *parts: str(tmp_path.joinpath(*parts)),
+    )
+    result = infer_media_type(0.8, 0.3, 0.3, plant_id="test")
+    assert result["media_type"] == "Coco Coir"
+    assert 0 <= result["confidence"] <= 1
+    # result should be saved to file
+    assert (tmp_path / "media_type_estimates.json").exists()
+
+
+def test_infer_media_type_percent_input(monkeypatch):
+    # Bypass file writes
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.utils.media_inference.data_path",
+        lambda _hass, *parts: "dummy.json",
+    )
+    monkeypatch.setattr("os.makedirs", lambda *a, **k: None)
+    monkeypatch.setattr("builtins.open", lambda *a, **k: open(os.devnull, "w"))
+    result = infer_media_type(80, 30, 30)
+    assert isinstance(result, dict)
+    assert result["media_type"]
+


### PR DESCRIPTION
## Summary
- refactor media inference utility for clarity
- load media profiles from dataset
- return dataclass result and save JSON output
- add dataset for media sensor profiles
- test media inference behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889114133a483309d69ffb09beade4c