### PR TITLE
Add pest rotation plan helper

### DIFF
--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -56,6 +56,7 @@ __all__ = [
     "list_effective_pesticides",
     "recommend_rotation_products",
     "estimate_rotation_plan_cost",
+    "suggest_pest_rotation_plan",
 ]
 
 
@@ -427,3 +428,25 @@ def estimate_rotation_plan_cost(
         total += estimate_application_cost(product, volume_l)
 
     return round(total, 2)
+
+
+def suggest_pest_rotation_plan(
+    pest: str, start_date: date, cycles: int
+) -> list[tuple[str, date]]:
+    """Return rotation plan for ``pest`` starting at ``start_date``.
+
+    The function selects recommended rotation products for ``pest`` using
+    :func:`recommend_rotation_products` and schedules ``cycles`` applications
+    using :func:`suggest_rotation_plan`. When no products are known an empty
+    list is returned.
+    """
+
+    if cycles <= 0:
+        raise ValueError("cycles must be positive")
+
+    products = recommend_rotation_products(pest)
+    if not products:
+        return []
+
+    sequence = [products[i % len(products)] for i in range(cycles)]
+    return suggest_rotation_plan(sequence, start_date)

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -18,6 +18,7 @@ from plant_engine.pesticide_manager import (
     get_pesticide_price,
     estimate_application_cost,
     estimate_rotation_plan_cost,
+    suggest_pest_rotation_plan,
 )
 
 
@@ -228,6 +229,15 @@ def test_estimate_rotation_plan_cost():
 
     with pytest.raises(ValueError):
         estimate_rotation_plan_cost(plan, 0)
+
+
+def test_suggest_pest_rotation_plan():
+    start = datetime.date(2024, 1, 1)
+    plan = suggest_pest_rotation_plan("aphids", start, 3)
+    assert plan[0][0] in {"imidacloprid", "spinosad", "pyrethrin"}
+    assert len(plan) == 3
+    # ensure intervals follow product guidelines
+    assert plan[1][1] > plan[0][1]
 
 
 


### PR DESCRIPTION
## Summary
- support generating pesticide rotation plans by pest name
- test pest rotation plan helper

## Testing
- `pytest tests/test_pesticide_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889115936e88330bbaf44719853f47a