### PR TITLE
Add async dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Datasets can be overridden by setting environment variables:
 - `HORTICULTURE_EXTRA_DATA_DIRS` to load additional datasets
 - `OPENAI_API_KEY` and `OPENAI_TEMPERATURE` configure the AI integration if you prefer not to store these values in the config file
 Call `plant_engine.utils.clear_dataset_cache()` after adjusting these variables so changes are reflected immediately. Use `plant_engine.utils.load_dataset_df()` to quickly load any dataset into a `pandas.DataFrame` for analysis. JSON, YAML and now CSV/TSV files are supported.
+For asynchronous applications, `plant_engine.utils.async_load_dataset()`
+returns the merged dataset without blocking the event loop.
 
 See [docs/custom_data_dirs.md](docs/custom_data_dirs.md) for examples of how to
 structure overlay and extra dataset directories.

--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import math
+import asyncio
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Mapping, Iterable, Union, IO, TextIO
@@ -17,6 +18,7 @@ __all__ = [
     "save_json",
     "load_data",
     "load_dataset",
+    "async_load_dataset",
     "load_datasets",
     "lazy_dataset",
     "load_dataset_df",
@@ -273,6 +275,12 @@ def load_dataset(filename: str) -> Dict[str, Any]:
                 data = extra
 
     return data
+
+
+async def async_load_dataset(filename: str) -> Dict[str, Any]:
+    """Asynchronously return dataset ``filename`` using a thread executor."""
+
+    return await asyncio.to_thread(load_dataset, filename)
 
 
 def lazy_dataset(filename: str):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,3 +107,10 @@ def test_load_datasets(monkeypatch, tmp_path):
     data = utils.load_datasets("one.json", "two.json")
     assert data == {"one.json": {"a": 1}, "two.json": {"b": 2}}
 
+
+@pytest.mark.asyncio
+async def test_async_load_dataset():
+    data = await utils.async_load_dataset("soil_moisture_guidelines.json")
+    assert isinstance(data, dict)
+    assert "citrus" in data
+


### PR DESCRIPTION
## Summary
- add async_load_dataset helper for async environments
- document async usage in README
- test async loader

## Testing
- `pytest tests/test_utils.py::test_async_load_dataset -q`
- `pytest tests/test_dataset_paths.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889114ba020833080edf49be38947bd