### PR TITLE
Enhance pesticide manager with carrier volume utils

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -159,6 +159,7 @@
     "pesticide_prices.json": "Cost per unit of pesticide product.",
     "pesticide_active_ingredients.json": "Key properties for common pesticide active ingredients.",
     "pesticide_efficacy.json": "Relative effectiveness ratings of pesticides against specific pests.",
+    "pesticide_carrier_volumes.json": "Recommended spray solution volume (L/ha) for common pesticides.",
     "risk_score_map.json": "Numeric weights for risk level scoring.",
     "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
     "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/pesticide_carrier_volumes.json
+++ b/data/pesticide_carrier_volumes.json
@@ -1,0 +1,5 @@
+{
+  "spinosad": 500,
+  "neem_oil": 400,
+  "copper_fungicide": 600
+}

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -159,6 +159,22 @@ def test_calculate_application_amount():
         calculate_application_amount("unknown", 1.0)
 
 
+def test_carrier_volume_helpers():
+    from plant_engine.pesticide_manager import (
+        get_carrier_volume,
+        calculate_application_volume,
+    )
+
+    assert get_carrier_volume("spinosad") == 500
+    volume = calculate_application_volume("spinosad", 2000)
+    assert volume == 100.0
+
+    with pytest.raises(ValueError):
+        calculate_application_volume("spinosad", 0)
+    with pytest.raises(KeyError):
+        calculate_application_volume("unknown", 100)
+
+
 def test_summarize_pesticide_restrictions():
     from plant_engine.pesticide_manager import (
         summarize_pesticide_restrictions,


### PR DESCRIPTION
## Summary
- add pesticide carrier volume dataset and catalog entry
- support new carrier volume functions in `pesticide_manager`
- test carrier volume helpers

## Testing
- `pytest tests/test_pesticide_manager.py::test_carrier_volume_helpers -q`

------
https://chatgpt.com/codex/tasks/task_e_688916c161008330b01b5bc21705a75a