### PR TITLE
Improve sensor map merging

### DIFF
--- a/custom_components/horticulture_assistant/utils/sensor_map.py
+++ b/custom_components/horticulture_assistant/utils/sensor_map.py
@@ -42,15 +42,15 @@ def merge_sensor_maps(
 ) -> Dict[str, list[str]]:
     """Return ``base`` merged with ``update`` with duplicates removed."""
 
-    merged: Dict[str, list[str]] = {k: list(v) for k, v in base.items()}
+    merged_sets: Dict[str, set[str]] = {
+        key: set(values) for key, values in base.items()
+    }
+
     for key, values in update.items():
         if not values:
             continue
-        if isinstance(values, str):
-            values = [values]
-        existing = merged.get(key, [])
-        for item in values:
-            if item not in existing:
-                existing.append(item)
-        merged[key] = existing
-    return merged
+        if isinstance(values, str) or not isinstance(values, Iterable):
+            values = [str(values)]
+        merged_sets.setdefault(key, set()).update(map(str, values))
+
+    return {k: sorted(v) for k, v in merged_sets.items()}

--- a/tests/test_sensor_map.py
+++ b/tests/test_sensor_map.py
@@ -37,7 +37,9 @@ def test_merge_sensor_maps():
     base = {"moisture_sensors": ["a"], "ec_sensors": ["ec1"]}
     update = {"moisture_sensors": ["b", "a"], "temperature_sensors": ["t1"]}
     result = merge_sensor_maps(base, update)
-    assert result == {
+    assert {
+        key: sorted(values) for key, values in result.items()
+    } == {
         "moisture_sensors": ["a", "b"],
         "ec_sensors": ["ec1"],
         "temperature_sensors": ["t1"],
@@ -49,3 +51,15 @@ def test_merge_sensor_maps_ignore_empty():
     update = {"moisture_sensors": []}
     result = merge_sensor_maps(base, update)
     assert result == {"moisture_sensors": ["a"]}
+
+
+def test_merge_sensor_maps_string_values():
+    base = {"moisture_sensors": "a"}
+    update = {"moisture_sensors": "b", "light_sensors": "l1"}
+    result = merge_sensor_maps(base, update)
+    assert {
+        key: sorted(values) for key, values in result.items()
+    } == {
+        "moisture_sensors": ["a", "b"],
+        "light_sensors": ["l1"],
+    }


### PR DESCRIPTION
## Summary
- optimize `merge_sensor_maps` using sets
- adjust sensor map tests and add new case for string inputs

## Testing
- `pytest tests/test_sensor_map.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688916b82f84833096bac1abef395a2c