### PR TITLE
Add max pesticide application data

### DIFF
--- a/data/dataset_catalog.json
+++ b/data/dataset_catalog.json
@@ -159,6 +159,7 @@
     "pesticide_prices.json": "Cost per unit of pesticide product.",
     "pesticide_active_ingredients.json": "Key properties for common pesticide active ingredients.",
     "pesticide_efficacy.json": "Relative effectiveness ratings of pesticides against specific pests.",
+    "pesticide_max_applications.json": "Maximum recommended applications per season for each pesticide product.",
     "risk_score_map.json": "Numeric weights for risk level scoring.",
     "silicon_guidelines.json": "Recommended silicon (Si) ppm levels for each plant stage.",
     "stock_solution_concentrations.json": "Nutrient concentrations for standard stock solutions.",

--- a/data/pesticide_max_applications.json
+++ b/data/pesticide_max_applications.json
@@ -1,0 +1,5 @@
+{
+  "imidacloprid": 3,
+  "spinosad": 6,
+  "pyrethrin": 8
+}

--- a/plant_engine/pesticide_manager.py
+++ b/plant_engine/pesticide_manager.py
@@ -16,6 +16,7 @@ PRICE_FILE = "pesticide_prices.json"
 ACTIVE_FILE = "pesticide_active_ingredients.json"
 EFFICACY_FILE = "pesticide_efficacy.json"
 PEST_ROTATION_FILE = "pest_rotation_moas.json"
+MAX_APPS_FILE = "pesticide_max_applications.json"
 
 # Cached withdrawal data mapping product names to waiting days
 _DATA = lazy_dataset(DATA_FILE)
@@ -28,6 +29,7 @@ _PRICES = lazy_dataset(PRICE_FILE)
 _ACTIVE = lazy_dataset(ACTIVE_FILE)
 _EFFICACY = lazy_dataset(EFFICACY_FILE)
 _PEST_ROTATION = lazy_dataset(PEST_ROTATION_FILE)
+_MAX_APPS = lazy_dataset(MAX_APPS_FILE)
 
 __all__ = [
     "get_withdrawal_days",
@@ -55,6 +57,7 @@ __all__ = [
     "get_pesticide_efficacy",
     "list_effective_pesticides",
     "recommend_rotation_products",
+    "get_max_applications",
     "estimate_rotation_plan_cost",
     "suggest_pest_rotation_plan",
 ]
@@ -450,3 +453,13 @@ def suggest_pest_rotation_plan(
 
     sequence = [products[i % len(products)] for i in range(cycles)]
     return suggest_rotation_plan(sequence, start_date)
+
+
+def get_max_applications(product: str) -> int | None:
+    """Return maximum recommended applications per season for ``product``."""
+
+    value = _MAX_APPS().get(product.lower())
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None

--- a/tests/test_pesticide_manager.py
+++ b/tests/test_pesticide_manager.py
@@ -240,4 +240,12 @@ def test_suggest_pest_rotation_plan():
     assert plan[1][1] > plan[0][1]
 
 
+def test_get_max_applications():
+    from plant_engine.pesticide_manager import get_max_applications
+
+    assert get_max_applications("imidacloprid") == 3
+    assert get_max_applications("pyrethrin") == 8
+    assert get_max_applications("unknown") is None
+
+
 


### PR DESCRIPTION
## Summary
- add `pesticide_max_applications.json` dataset
- update dataset catalog for new file
- expose `get_max_applications` in `pesticide_manager`
- test for new helper

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_pesticide_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688916b694a083309302fd01e34b0a6b