### PR TITLE
Improve fertilizer dilution checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Important categories include:
 - **Water usage guidelines** – typical daily irrigation volumes by stage
 - **Canopy area** – approximate canopy area by growth stage for transpiration calculations
 - **Fertilizer and product data** – WSDA fertilizer database and recipe suggestions
-- **Fertilizer dilution limits** – recommended maximum grams per liter for common products
+- **Fertilizer dilution limits** – recommended maximum grams per liter for common products, including the General Hydroponics Flora series
 - **Fertilizer ingredient profiles** – nutrient content, chemical formulas, physical form and aliases for raw salts. Use `plant_engine.ingredients.get_ingredient_profile()` to access them programmatically
 - **Stock solution recipes** – injection ratios for automated fertigation
 - **Fertilizer compatibility** – warnings for mixing products that react poorly

--- a/custom_components/horticulture_assistant/fertilizer_formulator.py
+++ b/custom_components/horticulture_assistant/fertilizer_formulator.py
@@ -15,7 +15,7 @@ from plant_engine.wsda_lookup import (
     recommend_products_for_nutrient as _wsda_recommend,
 )
 
-from plant_engine import nutrient_manager
+from plant_engine import nutrient_manager, fertilizer_limits
 
 from .catalog import CATALOG, Fertilizer
 
@@ -414,19 +414,7 @@ def check_solubility_limits(schedule: Mapping[str, float], volume_l: float) -> D
 def check_dilution_limits(schedule: Mapping[str, float], volume_l: float) -> Dict[str, float]:
     """Return grams per liter exceeding recommended dilution limits."""
 
-    if volume_l <= 0:
-        raise ValueError("volume_l must be positive")
-
-    limits = CATALOG.dilution_limits()
-    warnings: Dict[str, float] = {}
-    for fert_id, grams in schedule.items():
-        limit = limits.get(fert_id)
-        if limit is None:
-            continue
-        grams_per_l = grams / volume_l
-        if grams_per_l > limit:
-            warnings[fert_id] = round(grams_per_l - limit, 2)
-    return warnings
+    return fertilizer_limits.check_schedule(schedule, volume_l)
 
 
 def check_schedule_compatibility(schedule: Mapping[str, float]) -> Dict[str, Dict[str, str]]:

--- a/data/fertilizers/fertilizer_dilution_limits.json
+++ b/data/fertilizers/fertilizer_dilution_limits.json
@@ -1,5 +1,8 @@
 {
   "foxfarm_grow_big": 150,
   "magriculture": 200,
-  "intrepid_granular_potash_0_0_60": 100
+  "intrepid_granular_potash_0_0_60": 100,
+  "general_hydroponics_floramicro": 120,
+  "general_hydroponics_floragrow": 120,
+  "general_hydroponics_florabloom": 120
 }

--- a/plant_engine/fertilizer_limits.py
+++ b/plant_engine/fertilizer_limits.py
@@ -1,0 +1,48 @@
+"""Utility helpers for fertilizer dilution limits."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Mapping, Dict
+
+from .utils import load_dataset, normalize_key
+
+DATA_FILE = "fertilizers/fertilizer_dilution_limits.json"
+
+
+@lru_cache(maxsize=None)
+def _DATA() -> Dict[str, float]:
+    """Return normalized dilution limit mapping."""
+    raw = load_dataset(DATA_FILE) or {}
+    limits: Dict[str, float] = {}
+    for key, value in raw.items():
+        try:
+            limits[normalize_key(key)] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return limits
+
+
+def get_limit(fertilizer_id: str) -> float | None:
+    """Return grams per liter limit for ``fertilizer_id`` if defined."""
+    return _DATA().get(normalize_key(fertilizer_id))
+
+
+def check_schedule(schedule: Mapping[str, float], volume_l: float) -> Dict[str, float]:
+    """Return overage grams per liter for items exceeding limits."""
+    if volume_l <= 0:
+        raise ValueError("volume_l must be positive")
+
+    warnings: Dict[str, float] = {}
+    for fert_id, grams in schedule.items():
+        if grams <= 0:
+            continue
+        limit = get_limit(fert_id)
+        if limit is None:
+            continue
+        over = grams / volume_l - limit
+        if over > 0:
+            warnings[fert_id] = round(over, 2)
+    return warnings
+
+
+__all__ = ["get_limit", "check_schedule"]

--- a/tests/test_fertilizer_limits.py
+++ b/tests/test_fertilizer_limits.py
@@ -1,0 +1,21 @@
+from plant_engine import fertilizer_limits
+import pytest
+
+
+def test_get_limit_known():
+    assert fertilizer_limits.get_limit("foxfarm_grow_big") == 150
+    assert fertilizer_limits.get_limit("general_hydroponics_floramicro") == 120
+    assert fertilizer_limits.get_limit("unknown") is None
+
+
+def test_check_schedule():
+    schedule = {
+        "foxfarm_grow_big": 200,
+        "general_hydroponics_florabloom": 60,
+    }
+    warnings = fertilizer_limits.check_schedule(schedule, 1)
+    assert warnings["foxfarm_grow_big"] > 0
+    assert "general_hydroponics_florabloom" not in warnings
+
+    with pytest.raises(ValueError):
+        fertilizer_limits.check_schedule(schedule, 0)


### PR DESCRIPTION
## Summary
- extend the fertilizer dilution dataset with common Flora series values
- centralize dilution limit handling in new `plant_engine.fertilizer_limits`
- delegate `check_dilution_limits` to the new helper
- document dilution limits in the README
- cover dilution helper with unit tests

## Testing
- `pytest tests/test_fertilizer_limits.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688916b2afb88330ac8c2fe3f91fb24f