### PR TITLE
Add crop advisor utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Once you have at least one plant configured, open **Settings → Devices & Servi
 - Root uptake factor calculation from soil temperature
 - Summaries of reentry and harvest restrictions for applied pesticides
 - Automated fertigation planning with cost estimates
+- Holistic crop advice combining environment, nutrient and pest recommendations
 - Yield-based revenue and profit projections
 - Expected profit forecasts based on estimated production costs
 - ET₀-based daily water usage estimates using crop coefficients

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -41,6 +41,7 @@ from .nutrient_conversion import (
     get_conversion_factors,
     oxide_to_elemental,
 )
+from .crop_advisor import CropAdvice, generate_crop_advice
 from .growth_rate_manager import (
     list_supported_plants as list_growth_rate_plants,
     get_daily_growth_rate,
@@ -72,6 +73,8 @@ __all__ = sorted(
         "estimate_growth",
         "get_conversion_factors",
         "oxide_to_elemental",
+        "CropAdvice",
+        "generate_crop_advice",
     }
 )
 

--- a/plant_engine/crop_advisor.py
+++ b/plant_engine/crop_advisor.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Iterable, Dict
+
+from .environment_manager import recommend_environment_adjustments
+from .nutrient_planner import generate_nutrient_management_report, NutrientManagementReport
+from .pest_manager import build_pest_management_plan
+
+__all__ = ["CropAdvice", "generate_crop_advice"]
+
+
+@dataclass(slots=True)
+class CropAdvice:
+    """Aggregated management recommendations for a crop."""
+
+    environment: Dict[str, str]
+    nutrients: NutrientManagementReport
+    pests: Dict[str, Any]
+
+
+def generate_crop_advice(
+    current_environment: Mapping[str, float],
+    nutrient_levels: Mapping[str, float],
+    pests: Iterable[str],
+    plant_type: str,
+    stage: str,
+    volume_l: float,
+    *,
+    zone: str | None = None,
+) -> CropAdvice:
+    """Return combined environment, nutrient and pest recommendations."""
+
+    env_actions = recommend_environment_adjustments(
+        current_environment, plant_type, stage, zone
+    )
+    nutrient_report = generate_nutrient_management_report(
+        nutrient_levels, plant_type, stage, volume_l
+    )
+    pest_plan = build_pest_management_plan(plant_type, pests)
+
+    return CropAdvice(
+        environment=env_actions,
+        nutrients=nutrient_report,
+        pests=pest_plan,
+    )

--- a/tests/test_crop_advisor.py
+++ b/tests/test_crop_advisor.py
@@ -1,0 +1,14 @@
+from plant_engine.crop_advisor import generate_crop_advice, CropAdvice
+
+
+def test_generate_crop_advice():
+    env = {"temp_c": 35, "humidity_pct": 90, "light_ppfd": 100, "co2_ppm": 300}
+    nutrients = {"N": 50, "P": 10, "K": 40}
+    pests = ["aphids"]
+
+    advice = generate_crop_advice(env, nutrients, pests, "lettuce", "seedling", volume_l=5.0)
+
+    assert isinstance(advice, CropAdvice)
+    assert "temperature" in advice.environment
+    assert advice.nutrients.analysis.recommended["N"] == 80
+    assert "aphids" in advice.pests


### PR DESCRIPTION
## Summary
- add `crop_advisor` module for consolidated recommendations
- expose new helper from `plant_engine.__init__`
- document new functionality in README
- cover crop advisor with unit tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_crop_advisor.py -q`
- `pytest -q` *(fails: test_deficiency_manager.py::test_calculate_deficiency_index, test_deficiency_manager.py::test_summarize_deficiencies)*

------
https://chatgpt.com/codex/tasks/task_e_688916ae99d88330a0d8679c2c12af09