### PR TITLE
Improve parse_range utility

### DIFF
--- a/plant_engine/utils.py
+++ b/plant_engine/utils.py
@@ -1,10 +1,12 @@
-"""Utility helpers for reading data files used across the plant engine."""
+"""Utility helpers for reading datasets and parsing horticulture values."""
 
 from __future__ import annotations
 
 import json
 import os
+
 import math
+import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Mapping, Iterable, Union, IO, TextIO
@@ -38,6 +40,7 @@ __all__ = [
     "list_dataset_files",
 ]
 
+_RANGE_PATTERN = re.compile(r"(?<!\d)[-+]?\d*\.?\d+(?:e[-+]?\d+)?")
 
 PathType = Union[str, PathLike]
 
@@ -369,11 +372,8 @@ def parse_range(value: Iterable[float] | str) -> tuple[float, float] | None:
 
     numbers: list[float] = []
     if isinstance(value, str):
-        import re
-
         cleaned = re.sub(r"(?i)\bto\b", " ", value)
-        pattern = re.compile(r"(?<!\d)[-+]?\d*\.?\d+(?:e[-+]?\d+)?")
-        for match in pattern.finditer(cleaned):
+        for match in _RANGE_PATTERN.finditer(cleaned):
             try:
                 numbers.append(float(match.group()))
             except ValueError:

--- a/tests/test_parse_range.py
+++ b/tests/test_parse_range.py
@@ -33,3 +33,12 @@ def test_parse_range_reversed_order():
 def test_parse_range_non_finite():
     assert parse_range([float("inf"), 1]) is None
     assert parse_range([float("nan"), 2]) is None
+
+
+def test_parse_range_negative_values():
+    assert parse_range("-2 - -1") == (-2.0, -1.0)
+    assert parse_range([-5, -10]) == (-10.0, -5.0)
+
+
+def test_parse_range_decimals():
+    assert parse_range("1.5 to 2.5") == (1.5, 2.5)


### PR DESCRIPTION
## Summary
- optimize value parsing in `parse_range`
- document dataset helpers
- extend test coverage for negative and decimal values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688916ad197483309c00bb11819aa0aa