### PR TITLE
Add plant overview CLI with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ useful commands is available in [`docs/scripts_overview.md`](docs/scripts_overvi
 `pest_plan.py` generates a JSON pest management plan with treatments,
   prevention tips and beneficial release suggestions.
 - `dataset_info.py` lists available datasets and categories.
+- `plant_overview.py` prints consolidated reference information for a crop.
 - `validate_datasets.py` verifies that all dataset files can be parsed.
 - `backup_profiles.py` manages ZIP backups of plant profiles and the registry. Use `--list` to view archives, `--restore` to unpack one, `--verify` to check an archive, `--retain` to limit how many are kept, and `--root` to operate on an alternate data directory.
 - `upload_profile_cache.py` sends cached profiles in `data/profile_cache/` to a remote service for training future models. Add `--delete` to remove files after upload.

--- a/scripts/plant_overview.py
+++ b/scripts/plant_overview.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Display consolidated reference info for a plant type."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import ensure_repo_root_on_path
+
+ROOT = ensure_repo_root_on_path()
+
+from plant_engine.reference_data import get_plant_overview
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Show nutrient, environment and pest reference data for a plant type"
+    )
+    parser.add_argument("plant_type", help="Crop identifier")
+    parser.add_argument(
+        "--output", type=Path, help="Optional path to write the overview JSON"
+    )
+    args = parser.parse_args(argv)
+
+    overview = get_plant_overview(args.plant_type)
+    text = json.dumps(overview, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_plant_overview_script.py
+++ b/tests/test_plant_overview_script.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/plant_overview.py"
+
+
+def test_plant_overview_cli(tmp_path: Path):
+    out_file = tmp_path / "overview.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "tomato", "--output", str(out_file)],
+        check=True,
+    )
+    data = json.loads(out_file.read_text())
+    assert "nutrients" in data
+    assert "environment" in data
+
+
+def test_plant_overview_cli_stdout():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "tomato"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(result.stdout)
+    assert "pests" in data
+


### PR DESCRIPTION
## Summary
- include new `plant_overview.py` script to display reference data
- document the helper in README
- add tests covering the CLI utility

## Testing
- `pytest tests/test_plant_overview_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688916abc9ac83308fd6a8590fc77099