### PR TITLE
Enhance growth stage utilities

### DIFF
--- a/plant_engine/growth_stage.py
+++ b/plant_engine/growth_stage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Dict, Any, List, Tuple
 from datetime import date, timedelta
 
+import pandas as pd
+
 from .utils import load_dataset, normalize_key
 
 DATA_FILE = "growth_stages.json"
@@ -52,6 +54,7 @@ __all__ = [
     "growth_stage_summary",
     "stage_bounds",
     "generate_stage_schedule",
+    "stage_schedule_df",
 ]
 
 
@@ -345,3 +348,15 @@ def generate_stage_schedule(plant_type: str, start_date: date) -> list[dict[str,
         current = end_date
 
     return schedule
+
+
+def stage_schedule_df(plant_type: str, start_date: date) -> "pd.DataFrame":
+    """Return stage schedule as a :class:`pandas.DataFrame`."""
+
+    schedule = generate_stage_schedule(plant_type, start_date)
+    if not schedule:
+        return pd.DataFrame()
+    df = pd.DataFrame(schedule)
+    df["start_date"] = pd.to_datetime(df["start_date"])  # type: ignore[arg-type]
+    df["end_date"] = pd.to_datetime(df["end_date"])  # type: ignore[arg-type]
+    return df

--- a/tests/test_growth_stage.py
+++ b/tests/test_growth_stage.py
@@ -20,6 +20,7 @@ from plant_engine.growth_stage import (
     days_until_next_stage,
     growth_stage_summary,
     generate_stage_schedule,
+    stage_schedule_df,
 )
 
 
@@ -187,5 +188,13 @@ def test_cycle_progress_from_dates():
     assert cycle_progress_from_dates("tomato", start, current) == 50.0
     with pytest.raises(ValueError):
         cycle_progress_from_dates("tomato", current, start)
+
+
+def test_stage_schedule_df():
+    start = date(2025, 1, 1)
+    df = stage_schedule_df("tomato", start)
+    assert not df.empty
+    assert list(df.columns) == ["stage", "start_date", "end_date"]
+    assert df.iloc[0]["stage"] == "seedling"
 
 


### PR DESCRIPTION
## Summary
- add pandas import for growth stage utilities
- expose `stage_schedule_df` for structured schedule reporting
- test the DataFrame helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688916c0967c83309807409e38aa8ea6