### PR TITLE
Fix import paths after reorg

### DIFF
--- a/custom_components/horticulture_assistant/custom_components/horticulture_assistant
+++ b/custom_components/horticulture_assistant/custom_components/horticulture_assistant
@@ -1,0 +1,1 @@
+../../horticulture_assistant

--- a/custom_components/horticulture_assistant/tests/conftest.py
+++ b/custom_components/horticulture_assistant/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 # Ensure project root is on path
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 os.environ.setdefault("WSDA_INDEX_DIR", str(ROOT / "feature/wsda_refactored_sharded/index_sharded"))

--- a/dafe/__init__.py
+++ b/dafe/__init__.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+from pathlib import Path
+
+package_path = Path(__file__).resolve().parent.parent / 'custom_components/horticulture_assistant/dafe'
+__path__ = [str(package_path)]
+
+_module = import_module('custom_components.horticulture_assistant.dafe')
+
+globals().update(_module.__dict__)
+__all__ = getattr(_module, '__all__', [])

--- a/plant_engine/__init__.py
+++ b/plant_engine/__init__.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+from pathlib import Path
+
+package_path = Path(__file__).resolve().parent.parent / 'custom_components/horticulture_assistant/plant_engine'
+__path__ = [str(package_path)]
+
+_module = import_module('custom_components.horticulture_assistant.plant_engine')
+
+globals().update(_module.__dict__)
+__all__ = getattr(_module, '__all__', [])

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+from pathlib import Path
+
+package_path = Path(__file__).resolve().parent.parent / 'custom_components/horticulture_assistant/scripts'
+__path__ = [str(package_path)]
+
+_module = import_module('custom_components.horticulture_assistant.scripts')
+
+globals().update(_module.__dict__)
+__all__ = getattr(_module, '__all__', [])


### PR DESCRIPTION
## Summary
- fix ROOT path in tests
- add namespace packages for plant_engine, dafe and scripts
- symlink nested custom_components path for legacy tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897deef8c883308db707a1a1f87724