### PR TITLE
Fix tests after reorg

### DIFF
--- a/custom_components/horticulture_assistant/tests/conftest.py
+++ b/custom_components/horticulture_assistant/tests/conftest.py
@@ -3,8 +3,19 @@ import os
 from pathlib import Path
 
 # Ensure project root is on path
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-os.environ.setdefault("WSDA_INDEX_DIR", str(ROOT / "feature/wsda_refactored_sharded/index_sharded"))
-os.environ.setdefault("WSDA_DETAIL_DIR", str(ROOT / "feature/wsda_refactored_sharded/detail"))
+HA_PATH = ROOT / "custom_components" / "horticulture_assistant"
+if str(HA_PATH) not in sys.path:
+    sys.path.insert(0, str(HA_PATH))
+os.environ.setdefault(
+    "WSDA_INDEX_DIR",
+    str(
+        ROOT / "custom_components/horticulture_assistant/data/fertilizers/index_sharded"
+    ),
+)
+os.environ.setdefault(
+    "WSDA_DETAIL_DIR",
+    str(ROOT / "custom_components/horticulture_assistant/data/fertilizers/detail"),
+)

--- a/custom_components/horticulture_assistant/tests/test_binary_sensors.py
+++ b/custom_components/horticulture_assistant/tests/test_binary_sensors.py
@@ -4,13 +4,24 @@ import sys
 import types
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/binary_sensor.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/binary_sensor.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
     pkg = types.ModuleType(PACKAGE)
-    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
     sys.modules[PACKAGE] = pkg
-CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+CONST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/const.py"
+)
 const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
 const_mod = importlib.util.module_from_spec(const_spec)
 sys.modules[const_spec.name] = const_mod
@@ -24,13 +35,18 @@ sys.modules[spec.name] = binary_sensor
 ha = types.ModuleType("homeassistant")
 ha.components = types.ModuleType("homeassistant.components")
 ha_bs_mod = types.ModuleType("homeassistant.components.binary_sensor")
+
+
 class BinarySensorEntity:
     def __init__(self):
         self._attr_is_on = False
         self._attr_name = ""
+
     @property
     def is_on(self):
         return self._attr_is_on
+
+
 ha_bs_mod.BinarySensorEntity = BinarySensorEntity
 ha_bs_mod.DEVICE_CLASS_PROBLEM = "problem"
 ha_bs_mod.DEVICE_CLASS_MOISTURE = "moisture"
@@ -52,7 +68,9 @@ sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
 sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.entity", ha.helpers.entity)
-sys.modules.setdefault("homeassistant.helpers.entity_platform", ha.helpers.entity_platform)
+sys.modules.setdefault(
+    "homeassistant.helpers.entity_platform", ha.helpers.entity_platform
+)
 
 spec.loader.exec_module(binary_sensor)
 
@@ -60,16 +78,20 @@ SensorHealthBinarySensor = binary_sensor.SensorHealthBinarySensor
 IrrigationReadinessBinarySensor = binary_sensor.IrrigationReadinessBinarySensor
 FaultDetectionBinarySensor = binary_sensor.FaultDetectionBinarySensor
 
+
 class DummyStates:
     def __init__(self):
         self._data = {}
+
     def get(self, eid):
         val = self._data.get(eid)
         return types.SimpleNamespace(state=val) if val is not None else None
 
+
 class DummyHass:
     def __init__(self):
         self.states = DummyStates()
+
 
 def test_binary_sensor_behaviour():
     hass = DummyHass()

--- a/custom_components/horticulture_assistant/tests/test_config_flow.py
+++ b/custom_components/horticulture_assistant/tests/test_config_flow.py
@@ -4,13 +4,24 @@ import sys
 import types
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/config_flow.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/config_flow.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
     pkg = types.ModuleType(PACKAGE)
-    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
     sys.modules[PACKAGE] = pkg
-CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+CONST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/const.py"
+)
 const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
 const_mod = importlib.util.module_from_spec(const_spec)
 sys.modules[const_spec.name] = const_mod
@@ -22,8 +33,12 @@ sys.modules[spec.name] = config_flow
 
 # Minimal Home Assistant stubs
 ha = sys.modules.get("homeassistant", types.ModuleType("homeassistant"))
-ha.config_entries = sys.modules.get("homeassistant.config_entries", types.ModuleType("homeassistant.config_entries"))
+ha.config_entries = sys.modules.get(
+    "homeassistant.config_entries", types.ModuleType("homeassistant.config_entries")
+)
 ha.config_entries.ConfigEntry = object
+
+
 class ConfigFlowBase:
     def __init_subclass__(cls, **kwargs):
         pass
@@ -47,7 +62,11 @@ class ConfigFlowBase:
 
     def _abort_if_unique_id_configured(self):
         pass
+
+
 ha.config_entries.ConfigFlow = ConfigFlowBase
+
+
 class ConfigSubentryFlowBase:
     def __init__(self) -> None:
         self.created_entry = None
@@ -58,13 +77,21 @@ class ConfigSubentryFlowBase:
     def async_create_entry(self, **kwargs):
         self.created_entry = kwargs
         return {"type": "create_entry", **kwargs}
+
+
 ha.config_entries.ConfigSubentryFlow = ConfigSubentryFlowBase
 ha.config_entries.SubentryFlowResult = dict
 ha.core = sys.modules.get("homeassistant.core", types.ModuleType("homeassistant.core"))
+
+
 def callback(func):
     return func
+
+
 ha.core.callback = callback
 sys.modules["homeassistant.core"] = ha.core
+
+
 class OptionsFlowBase:
     def async_show_form(self, **kwargs):
         return {"type": "form", **kwargs}
@@ -72,11 +99,19 @@ class OptionsFlowBase:
     def async_create_entry(self, **kwargs):
         self.created_entry = kwargs
         return {"type": "create_entry", **kwargs}
+
+
 ha.config_entries.OptionsFlow = OptionsFlowBase
-ha.data_entry_flow = sys.modules.get("homeassistant.data_entry_flow", types.ModuleType("homeassistant.data_entry_flow"))
+ha.data_entry_flow = sys.modules.get(
+    "homeassistant.data_entry_flow", types.ModuleType("homeassistant.data_entry_flow")
+)
 ha.data_entry_flow.FlowResult = getattr(ha.data_entry_flow, "FlowResult", dict)
-ha.helpers = sys.modules.get("homeassistant.helpers", types.ModuleType("homeassistant.helpers"))
-ha.helpers.selector = sys.modules.get("homeassistant.helpers.selector", types.ModuleType("homeassistant.helpers.selector"))
+ha.helpers = sys.modules.get(
+    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
+)
+ha.helpers.selector = sys.modules.get(
+    "homeassistant.helpers.selector", types.ModuleType("homeassistant.helpers.selector")
+)
 ha.helpers.selector.BooleanSelector = object
 ha.helpers.selector.TextSelector = object
 ha.helpers.selector.EntitySelector = object
@@ -145,12 +180,14 @@ def test_options_flow(monkeypatch):
     entry = types.SimpleNamespace(data=flow.created_entry["data"])
     opt_flow = config_flow.HorticultureAssistantOptionsFlow(entry)
     result = asyncio.run(
-        opt_flow.async_step_init({
-            "moisture_sensors": "sensor.a",
-            "plant_type": "herb",
-            "zone_id": "5",
-            "enable_auto_approve": True,
-        })
+        opt_flow.async_step_init(
+            {
+                "moisture_sensors": "sensor.a",
+                "plant_type": "herb",
+                "zone_id": "5",
+                "enable_auto_approve": True,
+            }
+        )
     )
     assert result["type"] == "create_entry"
     assert opt_flow._data["moisture_sensors"] == ["sensor.a"]
@@ -166,7 +203,9 @@ def test_options_flow(monkeypatch):
 def test_init_menu(monkeypatch):
     flow = Flow()
     entries = [types.SimpleNamespace(entry_id="eid1", data={"plant_name": "Tom"})]
-    hass = types.SimpleNamespace(config_entries=types.SimpleNamespace(async_entries=lambda domain: entries))
+    hass = types.SimpleNamespace(
+        config_entries=types.SimpleNamespace(async_entries=lambda domain: entries)
+    )
     flow.hass = hass
     result = asyncio.run(flow.async_step_init())
     assert result["type"] == "menu"
@@ -175,7 +214,9 @@ def test_init_menu(monkeypatch):
 def test_settings_flow(tmp_path):
     hass = types.SimpleNamespace(
         config_entries=types.SimpleNamespace(async_entries=lambda domain: []),
-        config=types.SimpleNamespace(path=lambda *parts: str(tmp_path.joinpath(*parts))),
+        config=types.SimpleNamespace(
+            path=lambda *parts: str(tmp_path.joinpath(*parts))
+        ),
     )
     flow = Flow()
     flow.hass = hass

--- a/custom_components/horticulture_assistant/tests/test_deficiency_manager.py
+++ b/custom_components/horticulture_assistant/tests/test_deficiency_manager.py
@@ -19,15 +19,10 @@ from plant_engine.nutrient_manager import get_recommended_levels
 from plant_engine import utils
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def _reset_cache():
     utils.clear_dataset_cache()
-    from plant_engine import deficiency_manager as dm
-    dm._symptoms.cache_clear()
-    dm._treatments.cache_clear()
-    dm._mobility.cache_clear()
-    dm._thresholds.cache_clear()
-    dm._scores.cache_clear()
 
 
 def test_list_known_nutrients():
@@ -142,4 +137,3 @@ def test_summarize_deficiencies_with_ph_and_synergy():
     )
     assert summary["severity_index"] > 0
     assert "K" in summary["severity"]
-

--- a/custom_components/horticulture_assistant/tests/test_environment_score_sensor.py
+++ b/custom_components/horticulture_assistant/tests/test_environment_score_sensor.py
@@ -5,13 +5,24 @@ import types
 from pathlib import Path
 import json
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/sensor.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/sensor.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
     pkg = types.ModuleType(PACKAGE)
-    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
     sys.modules[PACKAGE] = pkg
-CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+CONST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/const.py"
+)
 const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
 const_mod = importlib.util.module_from_spec(const_spec)
 sys.modules[const_spec.name] = const_mod
@@ -24,18 +35,27 @@ sys.modules[spec.name] = sensor
 ha = types.ModuleType("homeassistant")
 ha.components = types.ModuleType("homeassistant.components")
 ha_sensor_mod = types.ModuleType("homeassistant.components.sensor")
+
+
 class SensorEntity:
     def __init__(self):
         self._attr_native_value = None
+
     @property
     def native_value(self):
         return getattr(self, "_attr_native_value", None)
+
+
 class SensorDeviceClass:
     MOISTURE = "moisture"
     PRECIPITATION = "precipitation"
     WEIGHT = "weight"
+
+
 class SensorStateClass:
     MEASUREMENT = "measurement"
+
+
 ha_sensor_mod.SensorEntity = SensorEntity
 ha_sensor_mod.SensorDeviceClass = SensorDeviceClass
 ha_sensor_mod.SensorStateClass = SensorStateClass
@@ -58,19 +78,24 @@ sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
 sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.entity", ha.helpers.entity)
-sys.modules.setdefault("homeassistant.helpers.entity_platform", ha.helpers.entity_platform)
+sys.modules.setdefault(
+    "homeassistant.helpers.entity_platform", ha.helpers.entity_platform
+)
 sys.modules.setdefault("homeassistant.const", ha.const)
 
 spec.loader.exec_module(sensor)
 EnvironmentScoreSensor = sensor.EnvironmentScoreSensor
 EnvironmentQualitySensor = sensor.EnvironmentQualitySensor
 
+
 class DummyStates:
     def __init__(self):
         self._data = {}
+
     def get(self, eid):
         val = self._data.get(eid)
         return types.SimpleNamespace(state=val) if val is not None else None
+
 
 class DummyConfig:
     def __init__(self, base: Path):
@@ -90,7 +115,9 @@ class DummyHass:
 def test_environment_score_sensor(tmp_path: Path):
     reg_dir = tmp_path / "data/local/plants"
     reg_dir.mkdir(parents=True)
-    (reg_dir / "plant_registry.json").write_text(json.dumps({"pid": {"plant_type": "citrus"}}))
+    (reg_dir / "plant_registry.json").write_text(
+        json.dumps({"pid": {"plant_type": "citrus"}})
+    )
     hass = DummyHass(tmp_path)
     sensor_entity = EnvironmentScoreSensor(hass, "Plant", "pid")
     hass.states._data = {
@@ -106,7 +133,9 @@ def test_environment_score_sensor(tmp_path: Path):
 def test_environment_quality_sensor(tmp_path: Path):
     reg_dir = tmp_path / "data/local/plants"
     reg_dir.mkdir(parents=True)
-    (reg_dir / "plant_registry.json").write_text(json.dumps({"pid": {"plant_type": "citrus"}}))
+    (reg_dir / "plant_registry.json").write_text(
+        json.dumps({"pid": {"plant_type": "citrus"}})
+    )
     hass = DummyHass(tmp_path)
     sensor_entity = EnvironmentQualitySensor(hass, "Plant", "pid")
     hass.states._data = {

--- a/custom_components/horticulture_assistant/tests/test_estimate_profit_script.py
+++ b/custom_components/horticulture_assistant/tests/test_estimate_profit_script.py
@@ -4,7 +4,7 @@ import sys
 import json
 import os
 
-SCRIPT = Path(__file__).resolve().parents[1] / "scripts/estimate_profit.py"
+SCRIPT_MODULE = "custom_components.horticulture_assistant.scripts.estimate_profit"
 
 
 def test_expected_profit_cli(tmp_path, monkeypatch):
@@ -17,11 +17,24 @@ def test_expected_profit_cli(tmp_path, monkeypatch):
     (data_dir / "yield" / "yield_estimates.json").write_text('{"lettuce": 1000}')
 
     monkeypatch.setenv("HORTICULTURE_DATA_DIR", str(data_dir))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(Path(__file__).resolve().parents[3]),
+            str(
+                Path(__file__).resolve().parents[3]
+                / "custom_components"
+                / "horticulture_assistant"
+            ),
+            env.get("PYTHONPATH", ""),
+        ]
+    )
     result = subprocess.run(
-        [sys.executable, str(SCRIPT), "expected", "lettuce"],
+        [sys.executable, "-m", SCRIPT_MODULE, "expected", "lettuce"],
         capture_output=True,
         text=True,
         check=True,
+        env=env,
     )
     assert result.stdout.strip() == "2.0"
 
@@ -33,10 +46,22 @@ def test_actual_profit_cli(tmp_path):
     yield_manager.record_harvest("profitplant", grams=1000)
     env = os.environ.copy()
     env["HORTICULTURE_YIELD_DIR"] = str(tmp_path)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(Path(__file__).resolve().parents[3]),
+            str(
+                Path(__file__).resolve().parents[3]
+                / "custom_components"
+                / "horticulture_assistant"
+            ),
+            env.get("PYTHONPATH", ""),
+        ]
+    )
     result = subprocess.run(
         [
             sys.executable,
-            str(SCRIPT),
+            "-m",
+            SCRIPT_MODULE,
             "actual",
             "profitplant",
             "lettuce",

--- a/custom_components/horticulture_assistant/tests/test_sensor_moving_average.py
+++ b/custom_components/horticulture_assistant/tests/test_sensor_moving_average.py
@@ -4,13 +4,24 @@ import sys
 import types
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/sensor.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/sensor.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
     pkg = types.ModuleType(PACKAGE)
-    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
     sys.modules[PACKAGE] = pkg
-CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+CONST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/const.py"
+)
 const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
 const_mod = importlib.util.module_from_spec(const_spec)
 sys.modules[const_spec.name] = const_mod
@@ -24,18 +35,27 @@ sys.modules[spec.name] = sensor
 ha = types.ModuleType("homeassistant")
 ha.components = types.ModuleType("homeassistant.components")
 ha_sensor_mod = types.ModuleType("homeassistant.components.sensor")
+
+
 class SensorEntity:
     def __init__(self):
         self._attr_native_value = None
+
     @property
     def native_value(self):
         return getattr(self, "_attr_native_value", None)
+
+
 class SensorDeviceClass:
     MOISTURE = "moisture"
     PRECIPITATION = "precipitation"
     WEIGHT = "weight"
+
+
 class SensorStateClass:
     MEASUREMENT = "measurement"
+
+
 ha_sensor_mod.SensorEntity = SensorEntity
 ha_sensor_mod.SensorDeviceClass = SensorDeviceClass
 ha_sensor_mod.SensorStateClass = SensorStateClass
@@ -58,7 +78,9 @@ sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
 sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.entity", ha.helpers.entity)
-sys.modules.setdefault("homeassistant.helpers.entity_platform", ha.helpers.entity_platform)
+sys.modules.setdefault(
+    "homeassistant.helpers.entity_platform", ha.helpers.entity_platform
+)
 sys.modules.setdefault("homeassistant.const", ha.const)
 
 spec.loader.exec_module(sensor)
@@ -66,12 +88,15 @@ spec.loader.exec_module(sensor)
 SmoothedMoistureSensor = sensor.SmoothedMoistureSensor
 ALPHA = sensor.MOVING_AVERAGE_ALPHA
 
+
 class DummyStates:
     def __init__(self):
         self._data = {}
+
     def get(self, eid):
         val = self._data.get(eid)
         return types.SimpleNamespace(state=val) if val is not None else None
+
 
 class DummyHass:
     def __init__(self):

--- a/custom_components/horticulture_assistant/tests/test_sensor_stateful.py
+++ b/custom_components/horticulture_assistant/tests/test_sensor_stateful.py
@@ -5,11 +5,24 @@ import types
 from datetime import datetime
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/sensor.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/sensor.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
-    sys.modules[PACKAGE] = types.ModuleType(PACKAGE)
-CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+    pkg = types.ModuleType(PACKAGE)
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
+    sys.modules[PACKAGE] = pkg
+CONST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/const.py"
+)
 const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
 const_mod = importlib.util.module_from_spec(const_spec)
 sys.modules[const_spec.name] = const_mod
@@ -23,18 +36,27 @@ sys.modules[spec.name] = sensor
 ha = types.ModuleType("homeassistant")
 ha.components = types.ModuleType("homeassistant.components")
 ha_sensor_mod = types.ModuleType("homeassistant.components.sensor")
+
+
 class SensorEntity:
     def __init__(self):
         self._attr_native_value = None
+
     @property
     def native_value(self):
         return getattr(self, "_attr_native_value", None)
+
+
 class SensorDeviceClass:
     MOISTURE = "moisture"
     PRECIPITATION = "precipitation"
     WEIGHT = "weight"
+
+
 class SensorStateClass:
     MEASUREMENT = "measurement"
+
+
 ha_sensor_mod.SensorEntity = SensorEntity
 ha_sensor_mod.SensorDeviceClass = SensorDeviceClass
 ha_sensor_mod.SensorStateClass = SensorStateClass
@@ -57,7 +79,9 @@ sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
 sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.entity", ha.helpers.entity)
-sys.modules.setdefault("homeassistant.helpers.entity_platform", ha.helpers.entity_platform)
+sys.modules.setdefault(
+    "homeassistant.helpers.entity_platform", ha.helpers.entity_platform
+)
 sys.modules.setdefault("homeassistant.const", ha.const)
 
 spec.loader.exec_module(sensor)
@@ -74,12 +98,15 @@ EstimatedWiltingPointSensor = sensor.EstimatedWiltingPointSensor
 DailyNitrogenAppliedSensor = sensor.DailyNitrogenAppliedSensor
 DOMAIN = sensor.DOMAIN
 
+
 class DummyStates:
     def __init__(self):
         self._data = {}
+
     def get(self, eid):
         val = self._data.get(eid)
         return types.SimpleNamespace(state=val) if val is not None else None
+
 
 class DummyHass:
     def __init__(self):
@@ -130,4 +157,3 @@ def test_daily_nitrogen_applied():
     )
     asyncio.run(sensor_entity.async_update())
     assert sensor_entity.native_value == 120.0
-

--- a/custom_components/horticulture_assistant/tests/test_setup_entry.py
+++ b/custom_components/horticulture_assistant/tests/test_setup_entry.py
@@ -4,11 +4,19 @@ import sys
 import types
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/__init__.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/__init__.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
     pkg = types.ModuleType(PACKAGE)
-    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
     sys.modules[PACKAGE] = pkg
 spec = importlib.util.spec_from_file_location(f"{PACKAGE}.__init__", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)
@@ -17,18 +25,23 @@ spec.loader.exec_module(module)
 DOMAIN = module.DOMAIN
 SERVICE_UPDATE_SENSORS = module.SERVICE_UPDATE_SENSORS
 
+
 class DummyServices:
     def __init__(self):
         self.registered = []
         self.removed = []
+
     def async_register(self, domain, name, func):
         self.registered.append((domain, name))
+
     def has_service(self, domain, name):
         return (domain, name) in self.registered and (domain, name) not in self.removed
+
     def async_remove(self, domain, name):
         if (domain, name) in self.registered:
             self.registered.remove((domain, name))
         self.removed.append((domain, name))
+
 
 class DummyConfigEntries:
     def __init__(self, hass):
@@ -44,11 +57,14 @@ class DummyConfigEntries:
         self.forwarded.append((entry, f"unload_{platform}"))
         return True
 
+
 class DummyConfig:
     def __init__(self, base: Path):
         self._base = base
+
     def path(self, name: str) -> str:
         return str(self._base / name)
+
 
 class DummyHass:
     def __init__(self, base: Path):
@@ -58,10 +74,12 @@ class DummyHass:
         self.config_entries = DummyConfigEntries(self)
         self.async_create_task = lambda coro: coro  # execute immediately
 
+
 class DummyEntry:
     def __init__(self, data):
         self.entry_id = "eid123"
         self.data = data
+
 
 def test_setup_entry(tmp_path: Path):
     hass = DummyHass(tmp_path)

--- a/custom_components/horticulture_assistant/tests/test_switch_entities.py
+++ b/custom_components/horticulture_assistant/tests/test_switch_entities.py
@@ -4,13 +4,24 @@ import sys
 import types
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/switch.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/switch.py"
+)
 PACKAGE = "custom_components.horticulture_assistant"
 if PACKAGE not in sys.modules:
     pkg = types.ModuleType(PACKAGE)
-    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant")]
+    pkg.__path__ = [
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components/horticulture_assistant"
+        )
+    ]
     sys.modules[PACKAGE] = pkg
-CONST_PATH = Path(__file__).resolve().parents[1] / "custom_components/horticulture_assistant/const.py"
+CONST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "custom_components/horticulture_assistant/const.py"
+)
 const_spec = importlib.util.spec_from_file_location(f"{PACKAGE}.const", CONST_PATH)
 const_mod = importlib.util.module_from_spec(const_spec)
 sys.modules[const_spec.name] = const_mod
@@ -24,18 +35,25 @@ sys.modules[spec.name] = switch
 ha = types.ModuleType("homeassistant")
 ha.components = types.ModuleType("homeassistant.components")
 ha_switch_mod = types.ModuleType("homeassistant.components.switch")
+
+
 class SwitchEntity:
     def __init__(self):
         self._attr_is_on = False
         self._attr_name = ""
+
     @property
     def is_on(self):
         return self._attr_is_on
+
     @property
     def name(self):
         return self._attr_name
+
     def async_write_ha_state(self):
         return None
+
+
 ha_switch_mod.SwitchEntity = SwitchEntity
 ha.components.switch = ha_switch_mod
 ha.config_entries = types.ModuleType("homeassistant.config_entries")
@@ -61,9 +79,11 @@ spec.loader.exec_module(switch)
 IrrigationSwitch = switch.IrrigationSwitch
 FertigationSwitch = switch.FertigationSwitch
 
+
 class DummyHass:
     def __init__(self):
         pass
+
 
 def test_switch_operations():
     hass = DummyHass()

--- a/custom_components/horticulture_assistant/tests/test_wsda_lookup.py
+++ b/custom_components/horticulture_assistant/tests/test_wsda_lookup.py
@@ -3,11 +3,21 @@ import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-os.environ.setdefault("WSDA_INDEX_DIR", str(ROOT / "feature/wsda_refactored_sharded/index_sharded"))
-os.environ.setdefault("WSDA_DETAIL_DIR", str(ROOT / "feature/wsda_refactored_sharded/detail"))
+ROOT = Path(__file__).resolve().parents[3]
+os.environ.setdefault(
+    "WSDA_INDEX_DIR",
+    str(
+        ROOT / "custom_components/horticulture_assistant/data/fertilizers/index_sharded"
+    ),
+)
+os.environ.setdefault(
+    "WSDA_DETAIL_DIR",
+    str(ROOT / "custom_components/horticulture_assistant/data/fertilizers/detail"),
+)
 
-module_path = ROOT / "plant_engine/wsda_lookup.py"
+module_path = (
+    ROOT / "custom_components/horticulture_assistant/plant_engine/wsda_lookup.py"
+)
 spec = importlib.util.spec_from_file_location("wsda_lookup", module_path)
 wsda = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = wsda
@@ -38,7 +48,9 @@ def test_lookup_by_number():
 
 
 def test_full_analysis_lookup():
-    by_name = get_product_analysis_by_name("1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6")
+    by_name = get_product_analysis_by_name(
+        "1ST CHOICE FERTILIZER EARTH-CARE PLUS 5-6-6"
+    )
     by_number = get_product_analysis_by_number("(#4083-0001)")
     assert by_name["N"] == 5.0
     assert by_number["K"] == 6.0

--- a/custom_components/horticulture_assistant/tests/test_wsda_product_index.py
+++ b/custom_components/horticulture_assistant/tests/test_wsda_product_index.py
@@ -1,9 +1,17 @@
 import os
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-os.environ.setdefault("WSDA_INDEX_DIR", str(ROOT / "feature/wsda_refactored_sharded/index_sharded"))
-os.environ.setdefault("WSDA_DETAIL_DIR", str(ROOT / "feature/wsda_refactored_sharded/detail"))
+ROOT = Path(__file__).resolve().parents[3]
+os.environ.setdefault(
+    "WSDA_INDEX_DIR",
+    str(
+        ROOT / "custom_components/horticulture_assistant/data/fertilizers/index_sharded"
+    ),
+)
+os.environ.setdefault(
+    "WSDA_DETAIL_DIR",
+    str(ROOT / "custom_components/horticulture_assistant/data/fertilizers/detail"),
+)
 
 from custom_components.horticulture_assistant.utils.wsda_product_index import (
     list_products,
@@ -34,4 +42,3 @@ def test_lookup_by_number():
 def test_search_products_brand():
     results = search_products("INTREPID", fields=["brand"])
     assert any(p.product_id == "C552F8" for p in results)
-

--- a/custom_components/horticulture_assistant/tests/test_wsda_search_script.py
+++ b/custom_components/horticulture_assistant/tests/test_wsda_search_script.py
@@ -3,19 +3,35 @@ import subprocess
 import sys
 import os
 
-ROOT = Path(__file__).resolve().parents[1]
-os.environ.setdefault("WSDA_INDEX_DIR", str(ROOT / "feature/wsda_refactored_sharded/index_sharded"))
-os.environ.setdefault("WSDA_DETAIL_DIR", str(ROOT / "feature/wsda_refactored_sharded/detail"))
-
-SCRIPT = ROOT / "scripts/wsda_search.py"
+ROOT = Path(__file__).resolve().parents[3]
+os.environ.setdefault(
+    "WSDA_INDEX_DIR",
+    str(
+        ROOT / "custom_components/horticulture_assistant/data/fertilizers/index_sharded"
+    ),
+)
+os.environ.setdefault(
+    "WSDA_DETAIL_DIR",
+    str(ROOT / "custom_components/horticulture_assistant/data/fertilizers/detail"),
+)
+SCRIPT_MODULE = "custom_components.horticulture_assistant.scripts.wsda_search"
 
 
 def test_search_cli(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(ROOT),
+            str(ROOT / "custom_components" / "horticulture_assistant"),
+            env.get("PYTHONPATH", ""),
+        ]
+    )
     result = subprocess.run(
-        [sys.executable, str(SCRIPT), "EARTH-CARE", "--limit", "1"],
+        [sys.executable, "-m", SCRIPT_MODULE, "EARTH-CARE", "--limit", "1"],
         capture_output=True,
         text=True,
         check=True,
+        env=env,
     )
     lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     assert lines
@@ -23,11 +39,20 @@ def test_search_cli(tmp_path):
 
 
 def test_number_cli():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(ROOT),
+            str(ROOT / "custom_components" / "horticulture_assistant"),
+            env.get("PYTHONPATH", ""),
+        ]
+    )
     result = subprocess.run(
-        [sys.executable, str(SCRIPT), "(#4083-0001)", "--number"],
+        [sys.executable, "-m", SCRIPT_MODULE, "(#4083-0001)", "--number"],
         capture_output=True,
         text=True,
         check=True,
+        env=env,
     )
     out = result.stdout
     assert "N" in out and "K" in out


### PR DESCRIPTION
## Summary
- fix dataset paths and PYTHONPATH setup in tests
- update script tests to run modules directly
- refresh wsda lookup test data paths
- adjust deficiency manager fixture

## Testing
- `pytest custom_components/horticulture_assistant/tests/test_wsda_lookup.py custom_components/horticulture_assistant/tests/test_wsda_search_script.py custom_components/horticulture_assistant/tests/test_estimate_profit_script.py custom_components/horticulture_assistant/tests/test_deficiency_manager.py::test_list_known_nutrients -q`

------
https://chatgpt.com/codex/tasks/task_e_68898578e0a4833098415a0cd85a6c07