### PR TITLE
Use internal imports for plant engine modules

### DIFF
--- a/custom_components/horticulture_assistant/plant_engine/compute_transpiration.py
+++ b/custom_components/horticulture_assistant/plant_engine/compute_transpiration.py
@@ -16,7 +16,7 @@ MODIFIER_FILE = "coefficients/crop_coefficient_modifiers.json"
 # cached via load_dataset
 _MODIFIERS: Dict[str, Dict[str, float]] = load_dataset(MODIFIER_FILE)
 
-from plant_engine.et_model import (
+from .et_model import (
     calculate_et0,
     calculate_eta,
     calculate_et0_series,

--- a/custom_components/horticulture_assistant/plant_engine/engine.py
+++ b/custom_components/horticulture_assistant/plant_engine/engine.py
@@ -7,35 +7,38 @@ from pathlib import Path
 
 from functools import lru_cache
 
-from plant_engine.utils import save_json
-from custom_components.horticulture_assistant.utils.plant_profile_loader import (
-    load_profile_by_id,
-)
-from plant_engine.ai_model import analyze
-from plant_engine.compute_transpiration import compute_transpiration
-from plant_engine.water_deficit_tracker import update_water_balance
-from plant_engine.growth_model import update_growth_index
-from plant_engine.rootzone_model import (
+from .utils import save_json
+try:
+    from ..utils.plant_profile_loader import load_profile_by_id
+except ImportError:  # pragma: no cover - fallback when run as standalone
+    from custom_components.horticulture_assistant.utils.plant_profile_loader import (
+        load_profile_by_id,
+    )
+from .ai_model import analyze
+from .compute_transpiration import compute_transpiration
+from .water_deficit_tracker import update_water_balance
+from .growth_model import update_growth_index
+from .rootzone_model import (
     estimate_rootzone_depth,
     estimate_water_capacity,
 )
-from plant_engine.nutrient_efficiency import calculate_nue
-from plant_engine.approval_queue import queue_threshold_updates
-from plant_engine.environment_manager import (
+from .nutrient_efficiency import calculate_nue
+from .approval_queue import queue_threshold_updates
+from .environment_manager import (
     recommend_environment_adjustments,
     optimize_environment,
     normalize_environment_readings,
 )
-from plant_engine.nutrient_manager import get_recommended_levels
-from plant_engine.pest_manager import (
+from .nutrient_manager import get_recommended_levels
+from .pest_manager import (
     recommend_treatments as recommend_pest_treatments,
 )
-from plant_engine.disease_manager import (
+from .disease_manager import (
     recommend_treatments as recommend_disease_treatments,
 )
-from plant_engine.growth_stage import get_stage_info
-from plant_engine.report import DailyReport
-from plant_engine.constants import get_stage_multiplier, DEFAULT_ENV
+from .growth_stage import get_stage_info
+from .report import DailyReport
+from .constants import get_stage_multiplier, DEFAULT_ENV
 
 PLANTS_DIR = "plants"
 OUTPUT_DIR = "data/reports"

--- a/custom_components/horticulture_assistant/plant_engine/fertigation.py
+++ b/custom_components/horticulture_assistant/plant_engine/fertigation.py
@@ -1584,8 +1584,6 @@ def summarize_fertigation_schedule(
     )
 
     if fertilizers:
-        from plant_engine.fertigation import recommend_nutrient_mix_with_cost_breakdown
-
         _, total, breakdown = recommend_nutrient_mix_with_cost_breakdown(
             plant_type,
             stage,

--- a/custom_components/horticulture_assistant/plant_engine/wsda_lookup.py
+++ b/custom_components/horticulture_assistant/plant_engine/wsda_lookup.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Dict, Iterable, List, Mapping, Tuple
 
-from plant_engine import wsda_loader
+try:
+    from . import wsda_loader
+except ImportError:  # pragma: no cover - fallback when run as script
+    from plant_engine import wsda_loader  # type: ignore
 
 __all__ = [
     "get_product_npk_by_name",


### PR DESCRIPTION
## Summary
- use relative imports within plant_engine to drop legacy top-level references
- simplify fertigation schedule helper by removing self-import
- allow wsda_lookup to fall back to top-level loader when run standalone
- guard engine profile loader import for standalone execution and narrow wsda loader exception

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68956c9e8bd88330a710bd9ad86ec402