### PR TITLE
Refactor path utilities for clearer directory handling

### DIFF
--- a/custom_components/horticulture_assistant/scripts/__init__.py
+++ b/custom_components/horticulture_assistant/scripts/__init__.py
@@ -7,8 +7,13 @@ import sys
 
 
 def ensure_repo_root_on_path() -> Path:
-    """Add the repository root to ``sys.path`` and return it."""
+    """Add the repository root to ``sys.path`` without overriding package order."""
     root = Path(__file__).resolve().parents[3]
-    if str(root) not in sys.path:
-        sys.path.insert(0, str(root))
+    path = str(root)
+    if path not in sys.path:
+        # ``sys.path``[0] is typically the custom component directory added by
+        # individual scripts. Insert the repository root *after* this so that
+        # bundled copies of packages (e.g. ``plant_engine``) take precedence
+        # over any stub modules at the repository root.
+        sys.path.insert(1, path)
     return root

--- a/custom_components/horticulture_assistant/utils/path_utils.py
+++ b/custom_components/horticulture_assistant/utils/path_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 try:
     from homeassistant.core import HomeAssistant
@@ -22,12 +22,17 @@ __all__ = [
 def config_path(hass: HomeAssistant | None, *parts: str) -> str:
     """Return an absolute path within the Home Assistant config directory.
 
-    If ``hass`` is ``None`` the path is joined relative to the current
-    working directory.
+    When ``hass`` is ``None`` the path is resolved relative to the current
+    working directory.  Internally ``pathlib`` is used for clearer path
+    handling and to avoid manual ``os.path`` manipulation.
     """
+
     if hass is not None:
+        # Home Assistant already handles path joins via its helper.
         return hass.config.path(*parts)
-    return os.path.join(*parts)
+    # ``Path()`` gives a relative path (``."``), matching previous
+    # behaviour when Home Assistant is not available.
+    return str(Path().joinpath(*parts))
 
 
 def data_path(hass: HomeAssistant | None, *parts: str) -> str:
@@ -42,9 +47,9 @@ def plants_path(hass: HomeAssistant | None, *parts: str) -> str:
 
 def ensure_dir(hass: HomeAssistant | None, *parts: str) -> str:
     """Return a config directory path and create it if missing."""
-    path = config_path(hass, *parts)
-    os.makedirs(path, exist_ok=True)
-    return path
+    path = Path(config_path(hass, *parts))
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def ensure_data_dir(hass: HomeAssistant | None, *parts: str) -> str:


### PR DESCRIPTION
## Summary
- use `pathlib.Path` in path utilities to simplify path operations
- avoid overriding package order when adding repo root to `sys.path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689573c63de8833081d1ba1a2c87ec10