### PR TITLE
Refactor state helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data/pending_thresholds/
 data/water_balance/
 data/reports/
 custom_components/horticulture_assistant/analytics/all_plants_growth_yield.json
+custom_components/horticulture_assistant/data/pending_thresholds/
 *.zip
 *.tar
 *.tar.gz

--- a/custom_components/horticulture_assistant/tests/test_sensor_map.py
+++ b/custom_components/horticulture_assistant/tests/test_sensor_map.py
@@ -37,9 +37,7 @@ def test_merge_sensor_maps():
     base = {"moisture_sensors": ["a"], "ec_sensors": ["ec1"]}
     update = {"moisture_sensors": ["b", "a"], "temperature_sensors": ["t1"]}
     result = merge_sensor_maps(base, update)
-    assert {
-        key: sorted(values) for key, values in result.items()
-    } == {
+    assert result == {
         "moisture_sensors": ["a", "b"],
         "ec_sensors": ["ec1"],
         "temperature_sensors": ["t1"],
@@ -57,9 +55,7 @@ def test_merge_sensor_maps_string_values():
     base = {"moisture_sensors": "a"}
     update = {"moisture_sensors": "b", "light_sensors": "l1"}
     result = merge_sensor_maps(base, update)
-    assert {
-        key: sorted(values) for key, values in result.items()
-    } == {
+    assert result == {
         "moisture_sensors": ["a", "b"],
         "light_sensors": ["l1"],
     }

--- a/custom_components/horticulture_assistant/tests/test_state_helpers.py
+++ b/custom_components/horticulture_assistant/tests/test_state_helpers.py
@@ -12,6 +12,7 @@ from custom_components.horticulture_assistant.utils.state_helpers import (
     get_numeric_state,
     normalize_entities,
     aggregate_sensor_values,
+    parse_entities,
 )
 
 
@@ -27,6 +28,17 @@ class DummyStates:
 class DummyHass:
     def __init__(self):
         self.states = DummyStates()
+
+
+def test_parse_entities_dedup_and_strip():
+    result = parse_entities("sensor.a ; sensor.b, sensor.a")
+    assert result == ["sensor.a", "sensor.b"]
+
+
+def test_parse_entities_iterable_and_empty():
+    result = parse_entities(["sensor.a", "", "sensor.b", "sensor.a"])
+    assert result == ["sensor.a", "sensor.b"]
+    assert parse_entities(None) == []
 
 
 def test_get_numeric_state_basic():
@@ -55,9 +67,28 @@ def test_get_numeric_state_invalid():
     assert get_numeric_state(hass, "sensor.bad") is None
 
 
+def test_get_numeric_state_negative():
+    hass = DummyHass()
+    hass.states._data["sensor.negative"] = "-12.7 pH"
+    assert get_numeric_state(hass, "sensor.negative") == -12.7
+
+
 def test_normalize_entities_split_and_unique():
     result = normalize_entities("sensor.a, sensor.b; sensor.a", "sensor.default")
     assert result == ["sensor.a", "sensor.b"]
+
+
+def test_normalize_entities_iterable_and_default():
+    result = normalize_entities(
+        ["sensor.a", "sensor.b", "sensor.a", "sensor.c"], "sensor.default"
+    )
+    assert result == ["sensor.a", "sensor.b", "sensor.c"]
+    assert normalize_entities(None, "sensor.default") == ["sensor.default"]
+
+
+def test_normalize_entities_empty_inputs():
+    assert normalize_entities("", "sensor.default") == ["sensor.default"]
+    assert normalize_entities([], "sensor.default") == ["sensor.default"]
 
 
 def test_aggregate_sensor_values_average_and_median():
@@ -71,3 +102,44 @@ def test_aggregate_sensor_values_average_and_median():
     assert avg == 15.0
     med = aggregate_sensor_values(hass, ["sensor.one", "sensor.two", "sensor.three"])
     assert med == 20.0
+
+
+def test_aggregate_sensor_values_ignores_invalid_and_none_when_all_invalid():
+    hass = DummyHass()
+    hass.states._data = {
+        "sensor.good": "10",
+        "sensor.bad1": "unknown",
+        "sensor.bad2": "foo",
+    }
+    ids = (eid for eid in ["sensor.good", "sensor.bad1", "sensor.bad2"])
+    assert aggregate_sensor_values(hass, ids) == 10.0
+    assert aggregate_sensor_values(hass, ["sensor.bad1", "sensor.bad2"]) is None
+
+
+def test_aggregate_sensor_values_deduplicates_ids():
+    hass = DummyHass()
+    hass.states._data = {
+        "sensor.one": "10",
+        "sensor.two": "20",
+    }
+    # Duplicate sensors should not skew the average
+    result = aggregate_sensor_values(hass, ["sensor.one", "sensor.one", "sensor.two"])
+    assert result == 15.0
+
+
+def test_aggregate_sensor_values_parses_delimited_string():
+    hass = DummyHass()
+    hass.states._data = {
+        "sensor.one": "10",
+        "sensor.two": "20",
+    }
+    result = aggregate_sensor_values(hass, "sensor.one; sensor.one, sensor.two")
+    assert result == 15.0
+    assert aggregate_sensor_values(hass, "") is None
+
+
+def test_aggregate_sensor_values_skips_blank_entries():
+    hass = DummyHass()
+    hass.states._data = {"sensor.one": "10"}
+    # A mixture of delimiters and empty segments should resolve to just sensor.one
+    assert aggregate_sensor_values(hass, "sensor.one, ,; ;") == 10.0

--- a/custom_components/horticulture_assistant/utils/state_helpers.py
+++ b/custom_components/horticulture_assistant/utils/state_helpers.py
@@ -5,16 +5,24 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable
+from statistics import mean, median
+
 from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = ["get_numeric_state", "normalize_entities", "aggregate_sensor_values"]
+__all__ = [
+    "get_numeric_state",
+    "normalize_entities",
+    "aggregate_sensor_values",
+    "parse_entities",
+]
 
 # Pre-compiled pattern used to extract a numeric portion from a string. This
 # avoids recompiling the regex for every state lookup and handles optional
 # sign and decimal point.
 _NUM_RE = re.compile(r"[-+]?[0-9]*\.?[0-9]+")
+_SEP_RE = re.compile(r"[;,]")
 
 
 def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
@@ -45,43 +53,55 @@ def get_numeric_state(hass: HomeAssistant, entity_id: str) -> float | None:
         return None
 
 
-def normalize_entities(val: str | Iterable[str] | None, default: str) -> list[str]:
-    """Return a list of entity IDs from ``val`` or ``default``.
+def parse_entities(val: str | Iterable[str] | None) -> list[str]:
+    """Return a list of unique, stripped entity IDs from ``val``.
 
-    String inputs may be comma or semicolon separated. Any whitespace is
-    stripped and duplicate entries removed while preserving order.
+    ``val`` may be a string containing comma/semicolon-delimited IDs or any
+    iterable. Whitespace-only and duplicate entries are removed while
+    preserving the original order. An empty or ``None`` input yields an empty
+    list.
     """
 
     if not val:
-        return [default]
+        return []
 
-    entities: Iterable[str]
     if isinstance(val, str):
-        entities = [p.strip() for p in re.split(r"[;,]", val) if p.strip()]
+        parts = (p.strip() for p in _SEP_RE.split(val))
     else:
-        entities = [str(v).strip() for v in val if str(v).strip()]
+        parts = (str(v).strip() for v in val)
 
-    seen: set[str] = set()
-    result: list[str] = []
-    for ent in entities:
-        if ent not in seen:
-            seen.add(ent)
-            result.append(ent)
-    return result if result else [default]
+    return list(dict.fromkeys(filter(None, parts)))
+
+
+def normalize_entities(val: str | Iterable[str] | None, default: str) -> list[str]:
+    """Return a list of entity IDs from ``val`` or ``default``.
+
+    String inputs may be comma or semicolon separated. Whitespace is stripped
+    and duplicate entries removed while preserving order. Passing ``None`` or
+    an empty value results in ``[default]``.
+    """
+
+    entities = parse_entities(val)
+    return entities or [default]
 
 
 def aggregate_sensor_values(
-    hass: HomeAssistant, entity_ids: str | Iterable[str]
+    hass: HomeAssistant, entity_ids: str | Iterable[str] | None
 ) -> float | None:
-    """Return the average or median value of multiple sensors."""
+    """Return the average or median of numeric sensor values.
 
-    ids = [entity_ids] if isinstance(entity_ids, str) else list(entity_ids)
-    values = [get_numeric_state(hass, eid) for eid in ids]
-    values = [v for v in values if v is not None]
+    String inputs may contain multiple IDs separated by commas or semicolons.
+    Up to two sensors are averaged while three or more use the median.
+    Duplicate IDs are ignored, and non-numeric or unavailable sensors are
+    skipped. ``None`` is returned if no valid states are found or ``entity_ids``
+    is empty.
+    """
+
+    ids = parse_entities(entity_ids)
+    if not ids:
+        return None
+
+    values = [v for eid in ids if (v := get_numeric_state(hass, eid)) is not None]
     if not values:
         return None
-    if len(values) > 2:
-        from statistics import median
-
-        return median(values)
-    return sum(values) / len(values)
+    return median(values) if len(values) > 2 else mean(values)


### PR DESCRIPTION
## Summary
- precompile entity separator regex for faster normalization
- ignore duplicate IDs when aggregating sensor values
- allow aggregate_sensor_values to parse comma/semicolon-delimited strings
- expand tests for sensor aggregation edge cases
- centralize entity parsing logic for normalization and aggregation
- preserve insertion order when merging sensor maps
- expose shared `parse_entities` helper for reuse across modules
- modernize type hints for sensor map utilities and add targeted tests for `parse_entities`

## Testing
- `pytest custom_components/horticulture_assistant/tests/test_sensor_map.py -q`
- `pytest custom_components/horticulture_assistant/tests/test_state_helpers.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689575da825c83309aea3c677f6dabb5