### PR TITLE
Pin PyYAML and update CI tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Upgrade pip, setuptools, and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: ${{ runner.os }}-pip-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
       - run: |
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ acme>=2.8.0,<3.0.0
 josepy>=1.13.0,<2.0.0
 numpy>=1.25
 pandas>=2.3
-pyyaml>=6.0
+PyYAML>=6.0.2
 pytest-asyncio>=0.23
 types-PyYAML
 voluptuous==0.13.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,12 +1,12 @@
 acme>=2.8.0,<3.0.0
-aiohttp>=3.8.0
-homeassistant>=2023.1.0
+aiohttp>=3.9.5,<3.11
+homeassistant==2024.12.5
 josepy>=1.13.0,<2.0.0
 numpy>=1.25
 pandas>=2.3
 pytest>=7.0
 pytest-asyncio>=0.23
 pytest-homeassistant-custom-component>=0.0.1
-pyyaml>=6.0
+PyYAML>=6.0.2
 types-PyYAML
 voluptuous==0.13.1


### PR DESCRIPTION
## Summary
- upgrade pip tooling before installing dependencies
- pin PyYAML to 6.0.2+ and align test dependencies with stable Home Assistant release

## Testing
- `python scripts/validate_profiles.py`
- `ruff check custom_components`
- `mypy --explicit-package-bases acme/crypto_util.py custom_components/horticulture_assistant/__init__.py custom_components/horticulture_assistant/api.py custom_components/horticulture_assistant/fertilizer_formulator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*
- `pip install -r requirements_test.txt` *(fails: No matching distribution found for homeassistant==2024.12.5)*

------
https://chatgpt.com/codex/tasks/task_e_689e9538d8f08330a9437e7d99c97ef1