### PR TITLE
Add plant profile creation step to config flow

### DIFF
--- a/custom_components/horticulture_assistant/const.py
+++ b/custom_components/horticulture_assistant/const.py
@@ -18,6 +18,9 @@ CONF_TEMPERATURE_SENSOR = "temperature_sensor"
 CONF_EC_SENSOR = "ec_sensor"
 CONF_CO2_SENSOR = "co2_sensor"
 CONF_KEEP_STALE = "keep_stale"
+CONF_PLANT_NAME = "plant_name"
+CONF_PLANT_ID = "plant_id"
+CONF_PLANT_TYPE = "plant_type"
 
 DEFAULT_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MODEL = "gpt-4o"  # change to "gpt-5" if your account has it

--- a/custom_components/horticulture_assistant/strings.json
+++ b/custom_components/horticulture_assistant/strings.json
@@ -11,11 +11,29 @@
           "base_url": "Base URL",
           "update_interval": "Update interval (minutes)"
         }
-      }
+      },
+        "profile": {
+          "title": "Plant profile",
+          "description": "Create a plant profile.",
+          "data": {
+            "plant_name": "Plant name",
+            "plant_type": "Plant type (optional)"
+          }
+        },
+        "sensors": {
+          "title": "Sensors",
+          "description": "Select sensor entities (optional; can be added later).",
+          "data": {
+            "moisture_sensor": "Moisture sensor",
+            "temperature_sensor": "Temperature sensor",
+            "ec_sensor": "EC sensor",
+            "co2_sensor": "CO₂ sensor"
+          }
+        }
+      },
+      "error": {"profile_error": "Failed to create plant profile"},
+      "abort": {}
     },
-    "error": {},
-    "abort": {}
-  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/horticulture_assistant/translations/en.json
+++ b/custom_components/horticulture_assistant/translations/en.json
@@ -4,16 +4,37 @@
     "step": {
       "user": {
         "title": "Connect AI",
-        "description": "Enter API key and defaults.",
+        "description": "Enter AI settings and defaults.",
         "data": {
           "api_key": "API key",
           "model": "Model",
           "base_url": "Base URL",
           "update_interval": "Update interval (minutes)"
         }
+      },
+      "profile": {
+        "title": "Plant profile",
+        "description": "Create a plant profile.",
+        "data": {
+          "plant_name": "Plant name",
+          "plant_type": "Plant type (optional)"
+        }
+      },
+      "sensors": {
+        "title": "Sensors",
+        "description": "Select sensor entities (optional; can be added later).",
+        "data": {
+          "moisture_sensor": "Moisture sensor",
+          "temperature_sensor": "Temperature sensor",
+          "ec_sensor": "EC sensor",
+          "co2_sensor": "CO₂ sensor"
+        }
       }
     },
-    "error": { "cannot_connect": "Could not reach AI endpoint." },
+    "error": {
+      "cannot_connect": "Could not reach AI endpoint.",
+      "profile_error": "Failed to create plant profile"
+    },
     "abort": {}
   },
   "options": {

--- a/custom_components/horticulture_assistant/utils/json_io.py
+++ b/custom_components/horticulture_assistant/utils/json_io.py
@@ -1,10 +1,26 @@
-"""Compatibility wrapper for common JSON helpers.
+"""Lightweight JSON read/write helpers for profile management."""
 
-The original implementation duplicated utilities provided in
-:mod:`plant_engine.utils`. This module now simply re-exports
-:func:`load_json` and :func:`save_json` to centralise data handling.
-"""
+from __future__ import annotations
 
-from plant_engine.utils import load_json, save_json
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_json(path: str | Path) -> Dict[str, Any]:
+    """Return the parsed JSON contents of ``path``."""
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_json(path: str | Path, data: Dict[str, Any]) -> bool:
+    """Write ``data`` to ``path`` in JSON format."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+    return True
+
 
 __all__ = ["load_json", "save_json"]

--- a/custom_components/horticulture_assistant/utils/plant_registry.py
+++ b/custom_components/horticulture_assistant/utils/plant_registry.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
@@ -11,7 +10,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - tests run without HA
     HomeAssistant = None  # type: ignore
 
-from .json_io import load_json
+from .json_io import load_json, save_json
 from custom_components.horticulture_assistant.utils.path_utils import config_path
 
 PLANT_REGISTRY_FILE = "data/local/plants/plant_registry.json"
@@ -39,4 +38,22 @@ def get_plant_type(plant_id: str, hass: HomeAssistant | None = None) -> Optional
     ptype = meta.get("plant_type")
     return str(ptype) if ptype else None
 
-__all__ = ["PLANT_REGISTRY_FILE", "get_plant_metadata", "get_plant_type"]
+
+def register_plant(
+    plant_id: str, metadata: Dict[str, Any], hass: HomeAssistant | None = None
+) -> None:
+    """Add or update ``plant_id`` in the plant registry."""
+    path = config_path(hass, PLANT_REGISTRY_FILE)
+    try:
+        data = load_json(path)
+    except Exception:
+        data = {}
+    data[plant_id] = metadata
+    save_json(path, data)
+    _load_registry.cache_clear()
+__all__ = [
+    "PLANT_REGISTRY_FILE",
+    "get_plant_metadata",
+    "get_plant_type",
+    "register_plant",
+]


### PR DESCRIPTION
## Summary
- extend config flow with new profile step for plant name and profile generation
- translate new profile step and errors
- adjust config flow tests
- refine profile step with constants, validation, and executor usage
- extract reusable profile schema constant and cover missing-name validation
- prompt for optional sensor entities during initial setup
- allow skipping sensor attachments and note sensors can be added later
- persist chosen sensors into the generated plant profile
- register each new plant in the registry using lightweight JSON helpers
- capture optional plant type in profile setup and store it in profiles and registry
- use JSON helpers when saving sensor mappings
- update tests for plant type persistence and defaults
- persist sensor selections through options flow and allow removing sensors

## Testing
- `pre-commit run --files custom_components/horticulture_assistant/config_flow.py tests/test_config_flow.py`
- `pytest tests/test_config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a53a75a5808330ab7c8c3b1f32f18e