### PR TITLE
Add replace_sensor service, DLI sensor, threshold entities, and species refresh option

### DIFF
--- a/custom_components/horticulture_assistant/const.py
+++ b/custom_components/horticulture_assistant/const.py
@@ -7,6 +7,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.NUMBER,
 ]
 
 CONF_API_KEY = "api_key"

--- a/custom_components/horticulture_assistant/number.py
+++ b/custom_components/horticulture_assistant/number.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_CORE_CONFIG_UPDATE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, CATEGORY_CONTROL
+from .entity_base import HorticultureBaseEntity
+from .utils.entry_helpers import get_entry_data, store_entry_data
+
+THRESHOLD_SPECS = [
+    ("temperature_min", UnitOfTemperature.CELSIUS),
+    ("temperature_max", UnitOfTemperature.CELSIUS),
+    ("humidity_min", "%"),
+    ("humidity_max", "%"),
+    ("illuminance_min", "lx"),
+    ("illuminance_max", "lx"),
+    ("conductivity_min", "µS/cm"),
+    ("conductivity_max", "µS/cm"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    stored = get_entry_data(hass, entry) or store_entry_data(hass, entry)
+    plant_id: str = stored["plant_id"]
+    plant_name: str = stored["plant_name"]
+    thresholds = entry.options.get("thresholds", {})
+
+    entities: list[ThresholdNumber] = []
+    for key, unit in THRESHOLD_SPECS:
+        entities.append(
+            ThresholdNumber(
+                hass,
+                entry,
+                plant_name,
+                plant_id,
+                key,
+                unit,
+                thresholds.get(key),
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class ThresholdNumber(HorticultureBaseEntity, NumberEntity):
+    """Configurable threshold number for a plant."""
+
+    _attr_entity_category = CATEGORY_CONTROL
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        plant_name: str,
+        plant_id: str,
+        key: str,
+        unit: str,
+        value: float | None,
+    ) -> None:
+        super().__init__(plant_name, plant_id)
+        self.hass = hass
+        self._entry = entry
+        self._key = key
+        self._attr_name = key.replace("_", " ").title()
+        self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{plant_id}_{key}"
+        self._unit = unit
+        self._attr_native_unit_of_measurement = None
+        self._value = float(value) if value is not None else None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        def _handle(event) -> None:
+            self.hass.add_job(self.async_write_ha_state)
+
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, _handle)
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        if self._value is None:
+            return None
+        if self._key.startswith("temperature"):
+            unit = self.hass.config.units.temperature_unit
+            if unit == UnitOfTemperature.FAHRENHEIT:
+                return self._value * 9 / 5 + 32
+        return self._value
+
+    async def async_set_native_value(self, value: float) -> None:
+        val = float(value)
+        if self._key.startswith("temperature"):
+            unit = self.hass.config.units.temperature_unit
+            if unit == UnitOfTemperature.FAHRENHEIT:
+                val = (val - 32) * 5 / 9
+        self._value = val
+        opts = dict(self._entry.options)
+        thresholds = dict(opts.get("thresholds", {}))
+        thresholds[self._key] = self._value
+        opts["thresholds"] = thresholds
+        self.hass.config_entries.async_update_entry(self._entry, options=opts)
+        self.async_write_ha_state()
+
+    @property
+    def native_unit_of_measurement(self):
+        if self._key.startswith("temperature"):
+            return self.hass.config.units.temperature_unit
+        return self._unit

--- a/custom_components/horticulture_assistant/services.yaml
+++ b/custom_components/horticulture_assistant/services.yaml
@@ -40,3 +40,22 @@ run_recommendation:
 refresh:
   name: Manual refresh
   description: Trigger both local and AI coordinators to refresh now.
+
+replace_sensor:
+  name: Replace a mapped sensor
+  description: Swap the source sensor feeding a plant profile.
+  fields:
+    plant_id:
+      required: true
+      selector:
+        text:
+    role:
+      required: true
+      example: moisture
+      selector:
+        text:
+    new_sensor:
+      required: true
+      selector:
+        entity:
+          domain: sensor

--- a/custom_components/horticulture_assistant/strings.json
+++ b/custom_components/horticulture_assistant/strings.json
@@ -44,7 +44,9 @@
           "moisture_sensor": "Moisture sensor",
           "temperature_sensor": "Temperature sensor",
           "ec_sensor": "EC sensor",
-          "co2_sensor": "CO₂ sensor"
+          "co2_sensor": "CO₂ sensor",
+          "species_display": "Species",
+          "force_refresh": "Force refresh thresholds"
         }
       }
     }

--- a/custom_components/horticulture_assistant/translations/en.json
+++ b/custom_components/horticulture_assistant/translations/en.json
@@ -20,6 +20,20 @@
           "plant_type": "Plant type (optional)"
         }
       },
+      "thresholds": {
+        "title": "Thresholds",
+        "description": "Set initial threshold values (optional).",
+        "data": {
+          "temperature_min": "Min temperature",
+          "temperature_max": "Max temperature",
+          "humidity_min": "Min humidity",
+          "humidity_max": "Max humidity",
+          "illuminance_min": "Min illuminance",
+          "illuminance_max": "Max illuminance",
+          "conductivity_min": "Min conductivity",
+          "conductivity_max": "Max conductivity"
+        }
+      },
       "sensors": {
         "title": "Sensors",
         "description": "Select sensor entities (optional; can be added later).",
@@ -47,7 +61,9 @@
           "moisture_sensor": "Moisture sensor",
           "temperature_sensor": "Temperature sensor",
           "ec_sensor": "EC sensor",
-          "co2_sensor": "CO₂ sensor"
+          "co2_sensor": "CO₂ sensor",
+          "species_display": "Species",
+          "force_refresh": "Force refresh thresholds"
         }
       }
     },

--- a/tests/test_dli_sensor.py
+++ b/tests/test_dli_sensor.py
@@ -1,0 +1,48 @@
+import pytest
+from datetime import datetime
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.helpers.entity_registry import async_get
+from homeassistant.util import dt as dt_util
+
+from custom_components.horticulture_assistant.const import DOMAIN, CONF_API_KEY
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
+
+async def test_dli_sensor_tracks_light(hass, monkeypatch):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={"sensors": {"illuminance": "sensor.light1"}},
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.light1", 0)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    unique_id = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dli"
+    reg = async_get(hass)
+    entity_id = reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None
+
+    # First day accumulation
+    monkeypatch.setattr(dt_util, "utcnow", lambda: datetime(2024, 1, 1, tzinfo=dt_util.UTC))
+    hass.states.async_set("sensor.light1", 1_000_000)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "1.11"
+
+    # Next day should reset and accumulate separately
+    monkeypatch.setattr(dt_util, "utcnow", lambda: datetime(2024, 1, 2, tzinfo=dt_util.UTC))
+    hass.states.async_set("sensor.light1", 1_000_000)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "1.11"

--- a/tests/test_threshold_numbers.py
+++ b/tests/test_threshold_numbers.py
@@ -1,0 +1,65 @@
+import pytest
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.const import Platform, UnitOfTemperature, EVENT_CORE_CONFIG_UPDATE
+
+from custom_components.horticulture_assistant.const import DOMAIN, CONF_API_KEY
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
+
+async def test_threshold_numbers_persist_options(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k", "plant_id": "p1", "plant_name": "Plant 1"},
+        options={"thresholds": {"temperature_min": 5}},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "number.plant_1_temperature_min"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "5.0"
+
+    await hass.services.async_call(
+        Platform.NUMBER.value,
+        "set_value",
+        {"entity_id": entity_id, "value": 7},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["thresholds"]["temperature_min"] == 7.0
+
+
+async def test_threshold_numbers_follow_unit_system(hass):
+    hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k", "plant_id": "p1", "plant_name": "Plant 1"},
+        options={"thresholds": {"temperature_min": 0}},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "number.plant_1_temperature_min"
+    assert hass.states.get(entity_id).state == "0.0"
+
+    hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    hass.bus.async_fire(EVENT_CORE_CONFIG_UPDATE, {})
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "32.0"
+
+    await hass.services.async_call(
+        Platform.NUMBER.value,
+        "set_value",
+        {"entity_id": entity_id, "value": 68},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["thresholds"]["temperature_min"] == pytest.approx(20)


### PR DESCRIPTION
## Summary
- add `replace_sensor` service for updating plant sensor mapping
- add Daily Light Integral sensor that rolls up light exposure per plant
- expose editable threshold numbers per plant stored in config entry options
- capture initial threshold values during config flow and retain existing mappings when editing options
- allow species name edits and optional threshold refresh in options flow
- convert temperature threshold numbers when Home Assistant's unit system changes
- reset DLI sensor each day and report running total

## Testing
- `python -m pre_commit run --files custom_components/horticulture_assistant/sensor.py tests/test_dli_sensor.py`
- `pytest tests/test_threshold_numbers.py tests/test_dli_sensor.py tests/test_services.py -k "threshold_numbers_persist_options or threshold_numbers_follow_unit_system or dli_sensor_tracks_light or replace_sensor_service" -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5cc6aca8c8330a95d333b0eabb464