### PR TITLE
feat: add OpenPlantbook species prefill

### DIFF
--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import logging
+from datetime import timedelta
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
@@ -31,6 +32,8 @@ from aiohttp import ClientError
 import asyncio
 from .entity_utils import ensure_entities_exist
 from .utils.entry_helpers import store_entry_data
+from homeassistant.helpers.event import async_track_time_interval
+from .openplantbook_client import OpenPlantbookClient
 
 SENSORS_SCHEMA = vol.Schema({str: [cv.entity_id]}, extra=vol.PREVENT_EXTRA)
 
@@ -105,6 +108,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 translation_key="missing_entity_option",
                 placeholders={"entity_id": entity_id},
             )
+
+    if entry.options.get("opb_enable_upload"):
+        async def _opb_upload(_now):
+            opb = entry.options.get("opb_credentials")
+            pid = entry.options.get("species_pid")
+            sensors_map: dict[str, str] = entry.options.get("sensors", {})
+            if not opb or not pid or not sensors_map:
+                return
+            client = OpenPlantbookClient(
+                hass, opb.get("client_id", ""), opb.get("secret", "")
+            )
+            values: dict[str, float] = {}
+            for role, entity_id in sensors_map.items():
+                state = hass.states.get(entity_id)
+                if state is None:
+                    continue
+                try:
+                    values[role] = float(state.state)
+                except (ValueError, TypeError):
+                    continue
+            if not values:
+                return
+            loc = entry.options.get("opb_location_share", "off")
+            kwargs: dict[str, float | str] = {}
+            if loc == "country":
+                if hass.config.country:
+                    kwargs["location_country"] = hass.config.country
+            elif loc == "coordinates":
+                if hass.config.country:
+                    kwargs["location_country"] = hass.config.country
+                if hass.config.longitude is not None and hass.config.latitude is not None:
+                    kwargs["location_lon"] = float(hass.config.longitude)
+                    kwargs["location_lat"] = float(hass.config.latitude)
+            await client.upload(entry.entry_id, pid, values, **kwargs)
+
+        entry_data["opb_unsub"] = async_track_time_interval(
+            hass, _opb_upload, timedelta(days=1)
+        )
 
     async def _handle_refresh(call):
         await ai_coord.async_request_refresh()
@@ -217,6 +258,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     data = hass.data.get(DOMAIN, {}).pop(entry.entry_id, {})
+    unsub = data.get("opb_unsub")
+    if unsub:
+        try:
+            unsub()
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass
     for key in ("coordinator_ai", "coordinator_local", "coordinator"):
         coord = data.get(key)
         if coord and hasattr(coord, "async_shutdown"):

--- a/custom_components/horticulture_assistant/manifest.json
+++ b/custom_components/horticulture_assistant/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO#readme",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO/issues",
-  "requirements": [],
+  "requirements": ["openplantbook-sdk>=0.1.0"],
   "version": "0.1.0"
 }

--- a/custom_components/horticulture_assistant/openplantbook_client.py
+++ b/custom_components/horticulture_assistant/openplantbook_client.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+import asyncio
+import logging
+
+import aiohttp
+from yarl import URL
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import slugify
+
+try:
+    from openplantbook_sdk import OpenPlantBookApi  # MIT-licensed SDK
+except ImportError:  # pragma: no cover
+    OpenPlantBookApi = None  # type: ignore[assignment]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OpenPlantbookClient:
+    """Minimal async wrapper around openplantbook-sdk + image download helpers."""
+
+    def __init__(self, hass: HomeAssistant, client_id: str, secret: str) -> None:
+        if OpenPlantBookApi is None:
+            raise RuntimeError("openplantbook-sdk is not installed")
+        self.hass = hass
+        self._api = OpenPlantBookApi(client_id, secret)
+
+    async def search(self, query: str) -> list[dict[str, Any]]:
+        """Return list of {pid, display} results for a free-text query."""
+        res: dict[str, Any] = await self._api.async_plant_search(query)
+        items: list[dict[str, Any]] = []
+        for it in (res or {}).get("results", []):
+            pid = it.get("pid") or it.get("species") or it.get("name")
+            display = it.get("name") or it.get("display_name") or pid
+            if pid:
+                items.append({"pid": pid, "display": display})
+        return items
+
+    async def get_details(self, pid: str) -> dict[str, Any]:
+        """Return full plant details dict for a PID (thresholds, image_url, etc.)."""
+        return await self._api.async_plant_detail_get(pid)
+
+    async def download_image(
+        self,
+        species_name: str,
+        image_url: str,
+        download_dir: Path,
+        rewrite_local_when_www: bool = True,
+    ) -> Optional[str]:
+        """Download image to download_dir; return URL path suitable for Lovelace.
+
+        If path includes 'www/', return '/local/...'; otherwise return original URL.
+        Never overwrites existing files.
+        """
+        if not image_url:
+            return None
+
+        await self.hass.async_add_executor_job(
+            download_dir.mkdir, parents=True, exist_ok=True
+        )
+        url_path = Path(URL(image_url).path)
+        ext = url_path.suffix or ".jpg"
+        safe = slugify(species_name) if species_name else slugify(url_path.stem)
+        dst = download_dir / f"{safe}{ext}"
+        if not dst.exists():
+            session = async_get_clientsession(self.hass)
+            try:
+                async with session.get(
+                    image_url, timeout=aiohttp.ClientTimeout(total=30)
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.read()
+            except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+                _LOGGER.warning("Failed to download image %s: %s", image_url, err)
+                return image_url
+            try:
+                await self.hass.async_add_executor_job(dst.write_bytes, data)
+            except OSError as err:  # pragma: no cover - disk issues
+                _LOGGER.warning("Failed to write image %s: %s", dst, err)
+                return image_url
+
+        if rewrite_local_when_www:
+            www_path = Path(self.hass.config.path("www")).resolve()
+            try:
+                rel = dst.resolve().relative_to(www_path)
+            except (FileNotFoundError, ValueError):
+                pass
+            else:
+                return f"/local/{rel.as_posix()}"
+        return image_url
+
+    async def upload(
+        self,
+        custom_id: str,
+        pid: str,
+        sensors: dict[str, float],
+        *,
+        location_country: str | None = None,
+        location_lon: float | None = None,
+        location_lat: float | None = None,
+        location_by_ip: bool | None = None,
+    ) -> None:
+        """Register plant instance and upload sensor data to OpenPlantbook."""
+        from datetime import datetime
+        from json_timeseries import JtsDocument, TimeSeries, TsRecord
+
+        await self._api.async_plant_instance_register(
+            {custom_id: pid},
+            location_by_ip=location_by_ip,
+            location_country=location_country,
+            location_lon=location_lon,
+            location_lat=location_lat,
+        )
+
+        doc = JtsDocument()
+        now = datetime.utcnow()
+        for name, value in sensors.items():
+            ts = TimeSeries(name)
+            ts.insert(TsRecord(now, value))
+            doc.addSeries(ts)
+
+        await self._api.async_plant_data_upload(doc)

--- a/custom_components/horticulture_assistant/translations/en.json
+++ b/custom_components/horticulture_assistant/translations/en.json
@@ -43,11 +43,30 @@
           "ec_sensor": "EC sensor",
           "co2_sensor": "CO₂ sensor"
         }
+      },
+      "threshold_source": {
+        "title": "Prefill thresholds",
+        "description": "Choose how to pre-fill thresholds.",
+        "data": {"method": "Method"}
+      },
+      "opb_credentials": {
+        "title": "OpenPlantbook credentials",
+        "description": "Enter client_id and secret to search species and pre-fill thresholds.",
+        "data": {"client_id": "Client ID", "secret": "Client Secret"}
+      },
+      "opb_species_search": {
+        "title": "Search OpenPlantbook",
+        "data": {"query": "Species or keyword"}
+      },
+      "opb_species_select": {
+        "title": "Select species",
+        "description": "Choose the best match to pre-fill thresholds and image."
       }
     },
     "error": {
       "cannot_connect": "Could not reach AI endpoint.",
-      "profile_error": "Failed to create plant profile"
+      "profile_error": "Failed to create plant profile",
+      "opb_missing": "OpenPlantbook SDK not available"
     },
     "abort": {}
   },
@@ -63,7 +82,11 @@
           "ec_sensor": "EC sensor",
           "co2_sensor": "CO₂ sensor",
           "species_display": "Species",
-          "force_refresh": "Force refresh thresholds"
+          "force_refresh": "Force refresh thresholds",
+          "opb_auto_download_images": "Auto-download species image",
+          "opb_download_dir": "Image download directory",
+          "opb_location_share": "Share location when uploading (off/country/coordinates)",
+          "opb_enable_upload": "Enable daily upload to OpenPlantbook"
         }
       }
     },

--- a/tests/test_opb_upload.py
+++ b/tests/test_opb_upload.py
@@ -1,0 +1,187 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.const import CONF_API_KEY
+
+from custom_components.horticulture_assistant import (
+    async_setup_entry,
+    async_unload_entry,
+    DOMAIN,
+)
+
+
+@pytest.mark.asyncio
+async def test_opb_upload_with_coordinates(hass):
+    hass.config.country = "US"
+    hass.config.latitude = 10.0
+    hass.config.longitude = 20.0
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k"},
+        options={
+            "sensors": {"moisture": "sensor.moisture"},
+            "opb_enable_upload": True,
+            "opb_credentials": {"client_id": "id", "secret": "sec"},
+            "species_pid": "pid",
+            "opb_location_share": "coordinates",
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.moisture", "42")
+
+    with patch("custom_components.horticulture_assistant.ChatApi"), \
+        patch("custom_components.horticulture_assistant.HortiAICoordinator") as mock_ai, \
+        patch("custom_components.horticulture_assistant.HortiLocalCoordinator") as mock_local, \
+        patch("custom_components.horticulture_assistant.LocalStore") as mock_store, \
+        patch("custom_components.horticulture_assistant.ensure_local_data_paths", AsyncMock()), \
+        patch("custom_components.horticulture_assistant.ensure_entities_exist"), \
+        patch("custom_components.horticulture_assistant.OpenPlantbookClient") as mock_client, \
+        patch("custom_components.horticulture_assistant.async_track_time_interval") as mock_track, \
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()):
+        mock_store.return_value.load = AsyncMock(return_value={})
+        mock_ai.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_local.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_client.return_value.upload = AsyncMock()
+
+        await async_setup_entry(hass, entry)
+
+        upload_cb = mock_track.call_args[0][1]
+        await upload_cb(None)
+        await async_unload_entry(hass, entry)
+
+        mock_client.return_value.upload.assert_awaited_once()
+        args, kwargs = mock_client.return_value.upload.call_args
+        assert args[0] == entry.entry_id
+        assert args[1] == "pid"
+        assert args[2] == {"moisture": 42.0}
+        assert kwargs["location_country"] == "US"
+        assert kwargs["location_lon"] == 20.0
+        assert kwargs["location_lat"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_opb_upload_country_only(hass):
+    hass.config.country = "US"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k"},
+        options={
+            "sensors": {"moisture": "sensor.moisture"},
+            "opb_enable_upload": True,
+            "opb_credentials": {"client_id": "id", "secret": "sec"},
+            "species_pid": "pid",
+            "opb_location_share": "country",
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.moisture", "42")
+
+    with patch("custom_components.horticulture_assistant.ChatApi"), \
+        patch("custom_components.horticulture_assistant.HortiAICoordinator") as mock_ai, \
+        patch("custom_components.horticulture_assistant.HortiLocalCoordinator") as mock_local, \
+        patch("custom_components.horticulture_assistant.LocalStore") as mock_store, \
+        patch("custom_components.horticulture_assistant.ensure_local_data_paths", AsyncMock()), \
+        patch("custom_components.horticulture_assistant.ensure_entities_exist"), \
+        patch("custom_components.horticulture_assistant.OpenPlantbookClient") as mock_client, \
+        patch("custom_components.horticulture_assistant.async_track_time_interval") as mock_track, \
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()):
+        mock_store.return_value.load = AsyncMock(return_value={})
+        mock_ai.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_local.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_client.return_value.upload = AsyncMock()
+
+        await async_setup_entry(hass, entry)
+
+        upload_cb = mock_track.call_args[0][1]
+        await upload_cb(None)
+        await async_unload_entry(hass, entry)
+
+        mock_client.return_value.upload.assert_awaited_once()
+        args, kwargs = mock_client.return_value.upload.call_args
+        assert args[0] == entry.entry_id
+        assert args[1] == "pid"
+        assert args[2] == {"moisture": 42.0}
+        assert kwargs["location_country"] == "US"
+        assert "location_lon" not in kwargs
+        assert "location_lat" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_opb_upload_no_location(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k"},
+        options={
+            "sensors": {"moisture": "sensor.moisture"},
+            "opb_enable_upload": True,
+            "opb_credentials": {"client_id": "id", "secret": "sec"},
+            "species_pid": "pid",
+            "opb_location_share": "off",
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.moisture", "42")
+
+    with patch("custom_components.horticulture_assistant.ChatApi"), \
+        patch("custom_components.horticulture_assistant.HortiAICoordinator") as mock_ai, \
+        patch("custom_components.horticulture_assistant.HortiLocalCoordinator") as mock_local, \
+        patch("custom_components.horticulture_assistant.LocalStore") as mock_store, \
+        patch("custom_components.horticulture_assistant.ensure_local_data_paths", AsyncMock()), \
+        patch("custom_components.horticulture_assistant.ensure_entities_exist"), \
+        patch("custom_components.horticulture_assistant.OpenPlantbookClient") as mock_client, \
+        patch("custom_components.horticulture_assistant.async_track_time_interval") as mock_track, \
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()):
+        mock_store.return_value.load = AsyncMock(return_value={})
+        mock_ai.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_local.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_client.return_value.upload = AsyncMock()
+
+        await async_setup_entry(hass, entry)
+
+        upload_cb = mock_track.call_args[0][1]
+        await upload_cb(None)
+        await async_unload_entry(hass, entry)
+
+        mock_client.return_value.upload.assert_awaited_once()
+        args, kwargs = mock_client.return_value.upload.call_args
+        assert args[0] == entry.entry_id
+        assert args[1] == "pid"
+        assert args[2] == {"moisture": 42.0}
+        assert kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_opb_upload_unsub_on_unload(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k"},
+        options={
+            "opb_enable_upload": True,
+            "opb_credentials": {"client_id": "id", "secret": "sec"},
+            "species_pid": "pid",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    remove = AsyncMock()
+
+    with patch("custom_components.horticulture_assistant.ChatApi"), \
+        patch("custom_components.horticulture_assistant.HortiAICoordinator") as mock_ai, \
+        patch("custom_components.horticulture_assistant.HortiLocalCoordinator") as mock_local, \
+        patch("custom_components.horticulture_assistant.LocalStore") as mock_store, \
+        patch("custom_components.horticulture_assistant.ensure_local_data_paths", AsyncMock()), \
+        patch("custom_components.horticulture_assistant.ensure_entities_exist"), \
+        patch("custom_components.horticulture_assistant.OpenPlantbookClient") as mock_client, \
+        patch("custom_components.horticulture_assistant.async_track_time_interval", return_value=remove), \
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()):
+        mock_store.return_value.load = AsyncMock(return_value={})
+        mock_ai.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_local.return_value.async_config_entry_first_refresh = AsyncMock()
+        mock_client.return_value.upload = AsyncMock()
+
+        await async_setup_entry(hass, entry)
+        await async_unload_entry(hass, entry)
+
+        remove.assert_called_once()

--- a/tests/test_openplantbook_client.py
+++ b/tests/test_openplantbook_client.py
@@ -1,0 +1,166 @@
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+import aiohttp
+
+from custom_components.horticulture_assistant.openplantbook_client import OpenPlantbookClient
+
+
+class DummyApi:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_search_parses_results(hass):
+    """OpenPlantbook search returns normalized pid/display pairs."""
+    api = DummyApi()
+    api.async_plant_search = AsyncMock(
+        return_value={
+            "results": [
+                {"pid": "pid1", "name": "Alpha"},
+                {"species": "pid2", "display_name": "Beta"},
+                {"name": "NoPid"},
+            ]
+        }
+    )
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.OpenPlantBookApi",
+        return_value=api,
+    ):
+        client = OpenPlantbookClient(hass, "id", "secret")
+        results = await client.search("query")
+
+    assert results == [
+        {"pid": "pid1", "display": "Alpha"},
+        {"pid": "pid2", "display": "Beta"},
+        {"pid": "NoPid", "display": "NoPid"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_details_delegates(hass):
+    """get_details returns API payload unmodified."""
+    api = DummyApi()
+    api.async_plant_detail_get = AsyncMock(return_value={"foo": "bar"})
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.OpenPlantBookApi",
+        return_value=api,
+    ):
+        client = OpenPlantbookClient(hass, "id", "secret")
+        detail = await client.get_details("pid")
+
+    assert detail == {"foo": "bar"}
+
+
+def test_init_missing_sdk(hass):
+    """Creating client without SDK raises RuntimeError."""
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.OpenPlantBookApi",
+        None,
+    ):
+        with pytest.raises(RuntimeError):
+            OpenPlantbookClient(hass, "id", "secret")
+
+
+@pytest.mark.asyncio
+async def test_download_image_rewrites_local(hass, tmp_path):
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.OpenPlantBookApi",
+        DummyApi,
+    ):
+        client = OpenPlantbookClient(hass, "id", "secret")
+
+    resp = AsyncMock()
+    resp.__aenter__.return_value = resp
+    resp.__aexit__.return_value = None
+    resp.read.return_value = b"data"
+    resp.raise_for_status = MagicMock()
+    session = MagicMock()
+    session.get.return_value = resp
+
+    async def run_in_executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    def fake_path(*parts):
+        return str(Path(tmp_path, *parts))
+
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.async_get_clientsession",
+        return_value=session,
+    ), patch.object(hass, "async_add_executor_job", side_effect=run_in_executor), patch.object(
+        hass.config, "path", side_effect=fake_path
+    ):
+        url = "http://example.com/path/image.png"
+        dl = Path(hass.config.path("www")) / "images"
+        local = await client.download_image("Test Plant", url, dl)
+
+    assert (dl / "test_plant.png").exists()
+    assert local == "/local/images/test_plant.png"
+
+
+@pytest.mark.asyncio
+async def test_download_image_no_www_returns_original(hass, tmp_path):
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.OpenPlantBookApi",
+        DummyApi,
+    ):
+        client = OpenPlantbookClient(hass, "id", "secret")
+
+    resp = AsyncMock()
+    resp.__aenter__.return_value = resp
+    resp.__aexit__.return_value = None
+    resp.read.return_value = b"data"
+    resp.raise_for_status = MagicMock()
+    session = MagicMock()
+    session.get.return_value = resp
+
+    async def run_in_executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    def fake_path(*parts):
+        return str(Path(tmp_path, *parts))
+
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.async_get_clientsession",
+        return_value=session,
+    ), patch.object(hass, "async_add_executor_job", side_effect=run_in_executor), patch.object(
+        hass.config, "path", side_effect=fake_path
+    ):
+        url = "http://example.com/path/image.jpg"
+        dl = tmp_path / "images"
+        local = await client.download_image("Test Plant", url, dl)
+
+    assert (dl / "test_plant.jpg").exists()
+    assert local == url
+
+
+@pytest.mark.asyncio
+async def test_download_image_failure_returns_original(hass, tmp_path):
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.OpenPlantBookApi",
+        DummyApi,
+    ):
+        client = OpenPlantbookClient(hass, "id", "secret")
+
+    session = MagicMock()
+    session.get.side_effect = aiohttp.ClientError
+
+    async def run_in_executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    def fake_path(*parts):
+        return str(Path(tmp_path, *parts))
+
+    with patch(
+        "custom_components.horticulture_assistant.openplantbook_client.async_get_clientsession",
+        return_value=session,
+    ), patch.object(hass, "async_add_executor_job", side_effect=run_in_executor), patch.object(
+        hass.config, "path", side_effect=fake_path
+    ):
+        url = "http://example.com/path/image.jpg"
+        dl = Path(hass.config.path("www"))
+        result = await client.download_image("Test Plant", url, dl)
+
+    assert result == url
+    assert not (dl / "test_plant.jpg").exists()


### PR DESCRIPTION
## Summary
- add optional OpenPlantbook SDK dependency and client helper
- extend config flow with OpenPlantbook species search to prefill thresholds and images
- expose OpenPlantbook options for image handling, location sharing, and future uploads
- translate new setup steps and update tests
- add tests for OpenPlantbook species prefill, missing SDK error handling, and OpenPlantbook options persistence
- respect OpenPlantbook image download options and persist credentials in config entries
- upload plant sensor data to OpenPlantbook when enabled
- clean up OpenPlantbook upload scheduler and broaden upload tests for location sharing
- make OpenPlantbook image downloads asynchronous and keep original file extension
- use Path for robust local image rewriting and test the helper
- resolve local image rewriting by computing /local/ paths relative to Home Assistant's www directory
- gracefully handle OpenPlantbook network failures during species lookup and image downloads
- add unit tests covering OpenPlantbook client search and detail helpers

## Testing
- `pre-commit run --files tests/test_openplantbook_client.py`
- `pytest tests/test_openplantbook_client.py tests/test_config_flow.py tests/test_opb_upload.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e4aaa1b08330aff4a46747f438e3