### PR TITLE
Add VPD, dew point, mold risk sensors and irrigation bridge

### DIFF
--- a/custom_components/horticulture_assistant/derived.py
+++ b/custom_components/horticulture_assistant/derived.py
@@ -1,0 +1,258 @@
+"""Derived environmental sensors for Horticulture Assistant."""
+from __future__ import annotations
+
+import math
+from datetime import date
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import TemperatureConverter
+
+from .const import DOMAIN
+from .entity_base import HorticultureBaseEntity
+
+
+def _svp_kpa(t_c: float) -> float:
+    """Return saturation vapor pressure in kPa."""
+    return 0.6108 * math.exp((17.27 * t_c) / (t_c + 237.3))
+
+
+def dew_point_c(t_c: float, rh: float) -> float:
+    """Return dew point temperature in Celsius using Magnus formula."""
+    a, b = 17.27, 237.3
+    alpha = ((a * t_c) / (b + t_c)) + math.log(max(rh, 1e-6) / 100.0)
+    return (b * alpha) / (a - alpha)
+
+
+def _current_temp_humidity(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> tuple[float | None, float | None]:
+    """Return current temperature (°C) and humidity (%)."""
+    sensors = entry.options.get("sensors", {})
+    temp_id = sensors.get("temperature")
+    hum_id = sensors.get("humidity")
+
+    temp_state = hass.states.get(temp_id) if temp_id else None
+    try:
+        t = float(temp_state.state) if temp_state else None
+    except (TypeError, ValueError):
+        t = None
+    if t is not None and temp_state:
+        unit = temp_state.attributes.get("unit_of_measurement")
+        if unit == UnitOfTemperature.FAHRENHEIT:
+            t = TemperatureConverter.convert(
+                t, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
+            )
+
+    hum_state = hass.states.get(hum_id) if hum_id else None
+    try:
+        h = float(hum_state.state) if hum_state else None
+    except (TypeError, ValueError):
+        h = None
+
+    return t, h
+
+
+class PlantDLISensor(HorticultureBaseEntity, SensorEntity):
+    """Sensor calculating Daily Light Integral for a plant."""
+
+    _attr_name = "Daily Light Integral"
+    _attr_native_unit_of_measurement = "mol/m²/d"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        plant_name: str,
+        plant_id: str,
+    ) -> None:
+        super().__init__(plant_name, plant_id)
+        self.hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{plant_id}_dli"
+        self._value: float | None = None
+        self._accum: float = 0.0
+        self._last_day: date | None = None
+        self._last_ts = None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        light_sensor = self._entry.options.get("sensors", {}).get("illuminance")
+        if light_sensor:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, [light_sensor], self._on_illuminance
+                )
+            )
+
+    @callback
+    def _on_illuminance(self, event) -> None:
+        state = event.data.get("new_state")
+        try:
+            lx = float(state.state) if state else None
+        except (TypeError, ValueError):
+            lx = None
+        if lx is None:
+            return
+        now = dt_util.utcnow()
+        day = now.date()
+        if self._last_day is None or day != self._last_day:
+            self._accum = 0.0
+            self._last_day = day
+            self._last_ts = None
+        coeff = self._entry.options.get("thresholds", {}).get("lux_to_ppfd", 0.0185)
+        ppfd = lx * coeff
+        if self._last_ts is None:
+            seconds = 60
+        else:
+            seconds = (now - self._last_ts).total_seconds()
+        self._accum += (ppfd * seconds) / 1_000_000
+        self._value = round(self._accum, 2)
+        self._last_ts = now
+        self.async_write_ha_state()
+
+
+class PlantVPDSensor(HorticultureBaseEntity, SensorEntity):
+    """Sensor providing Vapor Pressure Deficit in kPa."""
+
+    _attr_name = "Vapor Pressure Deficit"
+    _attr_native_unit_of_measurement = "kPa"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, plant_name: str, plant_id: str) -> None:
+        super().__init__(plant_name, plant_id)
+        self.hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{plant_id}_vpd"
+        self._value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        sensors = self._entry.options.get("sensors", {})
+        temp = sensors.get("temperature")
+        hum = sensors.get("humidity")
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [e for e in (temp, hum) if e], self._on_state
+            )
+        )
+        self.hass.loop.call_soon(self._on_state, None)
+
+    @callback
+    def _on_state(self, _event) -> None:
+        t, h = _current_temp_humidity(self.hass, self._entry)
+        if t is None or h is None:
+            self._value = None
+        else:
+            self._value = round(
+                _svp_kpa(t) * (1 - max(min(h, 100.0), 0.0) / 100.0), 3
+            )
+        self.async_write_ha_state()
+
+
+class PlantDewPointSensor(HorticultureBaseEntity, SensorEntity):
+    """Sensor providing dew point temperature in Celsius."""
+
+    _attr_name = "Dew Point"
+    _attr_native_unit_of_measurement = "°C"
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, plant_name: str, plant_id: str) -> None:
+        super().__init__(plant_name, plant_id)
+        self.hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{plant_id}_dew_point"
+        self._value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        sensors = self._entry.options.get("sensors", {})
+        temp = sensors.get("temperature")
+        hum = sensors.get("humidity")
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [e for e in (temp, hum) if e], self._on_state
+            )
+        )
+        self.hass.loop.call_soon(self._on_state, None)
+
+    @callback
+    def _on_state(self, _event) -> None:
+        t, h = _current_temp_humidity(self.hass, self._entry)
+        if t is None or h is None:
+            self._value = None
+        else:
+            self._value = round(dew_point_c(t, h), 1)
+        self.async_write_ha_state()
+
+
+class PlantMoldRiskSensor(HorticultureBaseEntity, SensorEntity):
+    """Sensor estimating mold growth risk on a 0..6 scale."""
+
+    _attr_name = "Mold Risk"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, plant_name: str, plant_id: str) -> None:
+        super().__init__(plant_name, plant_id)
+        self.hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{plant_id}_mold_risk"
+        self._value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        sensors = self._entry.options.get("sensors", {})
+        temp = sensors.get("temperature")
+        hum = sensors.get("humidity")
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [e for e in (temp, hum) if e], self._on_state
+            )
+        )
+        self.hass.loop.call_soon(self._on_state, None)
+
+    @callback
+    def _on_state(self, _event) -> None:
+        t, h = _current_temp_humidity(self.hass, self._entry)
+        if t is None or h is None:
+            self._value = None
+        else:
+            dp = dew_point_c(t, h)
+            proximity = max(0.0, 1.0 - (t - dp) / 5.0)
+            if h < 70:
+                base = 0
+            elif h < 80:
+                base = 1
+            elif h < 90:
+                base = 3
+            else:
+                base = 5
+            risk = min(6.0, base + proximity * 2.0)
+            self._value = round(risk, 1)
+        self.async_write_ha_state()

--- a/custom_components/horticulture_assistant/entity_base.py
+++ b/custom_components/horticulture_assistant/entity_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
+from .utils.entry_helpers import get_entry_data_by_plant_id
 
 
 class HorticultureBaseEntity(Entity):
@@ -27,3 +28,16 @@ class HorticultureBaseEntity(Entity):
             "manufacturer": "Horticulture Assistant",
             "model": self._model,
         }
+
+    @property
+    def entity_picture(self) -> str | None:
+        """Return a profile image if configured."""
+        if not self.hass:
+            return None
+        stored = get_entry_data_by_plant_id(self.hass, self._plant_id)
+        if not stored:
+            return None
+        entry = stored.get("config_entry")
+        if entry is None:
+            return None
+        return entry.options.get("image_url")

--- a/custom_components/horticulture_assistant/irrigation_bridge.py
+++ b/custom_components/horticulture_assistant/irrigation_bridge.py
@@ -1,0 +1,87 @@
+"""Simple adapters for irrigation providers."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DOMAIN
+from .entity_base import HorticultureBaseEntity
+
+
+async def async_apply_irrigation(
+    hass: HomeAssistant,
+    provider: str,
+    zone: str | None,
+    seconds: float,
+) -> None:
+    """Apply an irrigation run time using the selected provider.
+
+    provider -- either ``irrigation_unlimited`` or ``opensprinkler``.
+    zone -- zone/station identifier required by the provider.
+    seconds -- run time in seconds.
+    """
+    if provider == "irrigation_unlimited":
+        await hass.services.async_call(
+            "irrigation_unlimited",
+            "run_zone",
+            {"zone_id": zone, "time": float(seconds)},
+            blocking=True,
+        )
+        return
+    if provider == "opensprinkler":
+        await hass.services.async_call(
+            "opensprinkler",
+            "run_once",
+            {"station": zone, "duration": float(seconds)},
+            blocking=True,
+        )
+        return
+    raise ValueError(f"unknown provider {provider}")
+
+
+class PlantIrrigationRecommendationSensor(HorticultureBaseEntity, SensorEntity):
+    """Expose Smart Irrigation runtime recommendation."""
+
+    _attr_name = "Recommended Irrigation"
+    _attr_native_unit_of_measurement = "s"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, plant_name: str, plant_id: str
+    ) -> None:
+        super().__init__(plant_name, plant_id)
+        self.hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{plant_id}_irrigation_rec"
+        self._src = entry.options.get("sensors", {}).get("smart_irrigation")
+        self._value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._value
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self._src:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, [self._src], self._on_state
+                )
+            )
+            # prime value
+            self._on_state(None)
+
+    @callback
+    def _on_state(self, _event) -> None:
+        if not self._src:
+            self._value = None
+        else:
+            state = self.hass.states.get(self._src)
+            try:
+                self._value = float(state.state) if state else None
+            except (TypeError, ValueError):
+                self._value = None
+        self.async_write_ha_state()

--- a/custom_components/horticulture_assistant/number.py
+++ b/custom_components/horticulture_assistant/number.py
@@ -17,8 +17,13 @@ THRESHOLD_SPECS = [
     ("humidity_max", "%"),
     ("illuminance_min", "lx"),
     ("illuminance_max", "lx"),
+    ("moisture_min", "%"),
+    ("moisture_max", "%"),
     ("conductivity_min", "µS/cm"),
     ("conductivity_max", "µS/cm"),
+    ("vpd_min", "kPa"),
+    ("vpd_max", "kPa"),
+    ("lux_to_ppfd", "µmol/(m²·s·lx)"),
 ]
 
 

--- a/custom_components/horticulture_assistant/services.yaml
+++ b/custom_components/horticulture_assistant/services.yaml
@@ -45,17 +45,39 @@ replace_sensor:
   name: Replace a mapped sensor
   description: Swap the source sensor feeding a plant profile.
   fields:
-    plant_id:
+    profile_id:
       required: true
       selector:
         text:
-    role:
+    meter_entity:
       required: true
-      example: moisture
       selector:
-        text:
+        entity:
+          domain: sensor
     new_sensor:
       required: true
       selector:
         entity:
           domain: sensor
+
+apply_irrigation_plan:
+  name: Apply irrigation plan
+  description: Use Smart Irrigation recommendation and run via Irrigation Unlimited or OpenSprinkler.
+  fields:
+    profile_id:
+      required: true
+      selector:
+        text:
+    provider:
+      required: false
+      default: auto
+      selector:
+        select:
+          options:
+            - auto
+            - irrigation_unlimited
+            - opensprinkler
+    zone:
+      required: false
+      selector:
+        text:

--- a/tests/test_dli_sensor.py
+++ b/tests/test_dli_sensor.py
@@ -46,3 +46,98 @@ async def test_dli_sensor_tracks_light(hass, monkeypatch):
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == "1.11"
+
+
+async def test_entity_picture_from_entry_options(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {"illuminance": "sensor.light1"},
+            "image_url": "http://example.com/p1.jpg",
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.light1", 0)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    unique_id = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dli"
+    reg = async_get(hass)
+    entity_id = reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes.get("entity_picture") == "http://example.com/p1.jpg"
+
+
+async def test_dli_sensor_respects_time_delta(hass, monkeypatch):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={"sensors": {"illuminance": "sensor.light1"}},
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.light1", 0)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    unique_id = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dli"
+    reg = async_get(hass)
+    entity_id = reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None
+
+    # first reading at t0
+    monkeypatch.setattr(dt_util, "utcnow", lambda: datetime(2024, 1, 1, 0, 0, tzinfo=dt_util.UTC))
+    hass.states.async_set("sensor.light1", 400_000)
+    await hass.async_block_till_done()
+
+    # second reading 30 seconds later with different value to trigger update
+    monkeypatch.setattr(dt_util, "utcnow", lambda: datetime(2024, 1, 1, 0, 0, 30, tzinfo=dt_util.UTC))
+    hass.states.async_set("sensor.light1", 500_000)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "0.72"
+
+
+async def test_dli_sensor_uses_configured_coefficient(hass, monkeypatch):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {"illuminance": "sensor.light1"},
+            "thresholds": {"lux_to_ppfd": 0.02},
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.light1", 0)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    unique_id = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dli"
+    reg = async_get(hass)
+    entity_id = reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None
+
+    monkeypatch.setattr(dt_util, "utcnow", lambda: datetime(2024, 1, 1, tzinfo=dt_util.UTC))
+    hass.states.async_set("sensor.light1", 1_000_000)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "1.2"

--- a/tests/test_irrigation_bridge.py
+++ b/tests/test_irrigation_bridge.py
@@ -1,0 +1,35 @@
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.horticulture_assistant.const import DOMAIN, CONF_API_KEY
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
+
+async def test_apply_irrigation_plan_calls_provider(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "k", "plant_id": "p1", "plant_name": "Plant"},
+        options={"sensors": {"smart_irrigation": "sensor.runtime"}},
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.runtime", 30)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    calls: list = []
+
+    async def fake_run(call):
+        calls.append(call)
+
+    hass.services.async_register("irrigation_unlimited", "run_zone", fake_run)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "apply_irrigation_plan",
+        {"profile_id": "p1", "provider": "irrigation_unlimited", "zone": "z1"},
+        blocking=True,
+    )
+
+    assert calls
+    assert calls[0].data["time"] == 30.0

--- a/tests/test_mold_risk_sensor.py
+++ b/tests/test_mold_risk_sensor.py
@@ -1,0 +1,70 @@
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.helpers.entity_registry import async_get
+
+from custom_components.horticulture_assistant.const import DOMAIN, CONF_API_KEY
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
+
+async def test_initial_mold_risk(hass):
+    """Mold risk should compute from existing states on setup."""
+    hass.states.async_set("sensor.temp1", 25)
+    hass.states.async_set("sensor.hum1", 95)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {
+                "temperature": "sensor.temp1",
+                "humidity": "sensor.hum1",
+            }
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    reg = async_get(hass)
+    uid = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_mold_risk"
+    entity_id = reg.async_get_entity_id("sensor", DOMAIN, uid)
+    state = hass.states.get(entity_id)
+    assert state.state == "6.0"
+
+
+async def test_mold_risk_sensor(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {
+                "temperature": "sensor.temp1",
+                "humidity": "sensor.hum1",
+            }
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.temp1", 25)
+    hass.states.async_set("sensor.hum1", 95)
+    await hass.async_block_till_done()
+
+    reg = async_get(hass)
+    uid = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_mold_risk"
+    entity_id = reg.async_get_entity_id("sensor", DOMAIN, uid)
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "6.0"

--- a/tests/test_vpd_dew_point_sensor.py
+++ b/tests/test_vpd_dew_point_sensor.py
@@ -1,0 +1,124 @@
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.helpers.entity_registry import async_get
+
+from custom_components.horticulture_assistant.const import DOMAIN, CONF_API_KEY
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
+
+async def test_initial_values(hass):
+    """Sensors should compute values from existing states on setup."""
+    hass.states.async_set("sensor.temp1", 25)
+    hass.states.async_set("sensor.hum1", 50)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {
+                "temperature": "sensor.temp1",
+                "humidity": "sensor.hum1",
+            }
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    reg = async_get(hass)
+    uid_vpd = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_vpd"
+    uid_dp = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dew_point"
+    entity_vpd = reg.async_get_entity_id("sensor", DOMAIN, uid_vpd)
+    entity_dp = reg.async_get_entity_id("sensor", DOMAIN, uid_dp)
+    state_vpd = hass.states.get(entity_vpd)
+    state_dp = hass.states.get(entity_dp)
+    assert state_vpd.state == "1.584"
+    assert state_dp.state == "13.9"
+
+
+async def test_vpd_and_dew_point_sensors(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {
+                "temperature": "sensor.temp1",
+                "humidity": "sensor.hum1",
+            }
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.temp1", 25)
+    hass.states.async_set("sensor.hum1", 50)
+    await hass.async_block_till_done()
+
+    reg = async_get(hass)
+    uid_vpd = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_vpd"
+    uid_dp = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dew_point"
+    entity_vpd = reg.async_get_entity_id("sensor", DOMAIN, uid_vpd)
+    entity_dp = reg.async_get_entity_id("sensor", DOMAIN, uid_dp)
+    assert entity_vpd is not None
+    assert entity_dp is not None
+
+    state_vpd = hass.states.get(entity_vpd)
+    state_dp = hass.states.get(entity_dp)
+    assert state_vpd is not None
+    assert state_dp is not None
+    assert state_vpd.state == "1.584"
+    assert state_dp.state == "13.9"
+
+
+async def test_vpd_and_dew_point_sensors_fahrenheit(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_API_KEY: "k",
+            "plant_id": "p1",
+            "plant_name": "Plant 1",
+        },
+        options={
+            "sensors": {
+                "temperature": "sensor.temp1",
+                "humidity": "sensor.hum1",
+            }
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "sensor.temp1",
+        77,
+        {"unit_of_measurement": UnitOfTemperature.FAHRENHEIT},
+    )
+    hass.states.async_set("sensor.hum1", 50)
+    await hass.async_block_till_done()
+
+    reg = async_get(hass)
+    uid_vpd = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_vpd"
+    uid_dp = f"{DOMAIN}_{entry.entry_id}_{entry.data['plant_id']}_dew_point"
+    entity_vpd = reg.async_get_entity_id("sensor", DOMAIN, uid_vpd)
+    entity_dp = reg.async_get_entity_id("sensor", DOMAIN, uid_dp)
+    assert entity_vpd is not None
+    assert entity_dp is not None
+
+    state_vpd = hass.states.get(entity_vpd)
+    state_dp = hass.states.get(entity_dp)
+    assert state_vpd is not None
+    assert state_dp is not None
+    assert state_vpd.state == "1.584"
+    assert state_dp.state == "13.9"


### PR DESCRIPTION
## Summary
- add service and sensor to surface Smart Irrigation runtime recommendations and trigger Irrigation Unlimited or OpenSprinkler
- register apply_irrigation_plan in services schema and setup
- move entity registry import to module level for irrigation service
- centralize Daily Light Integral sensor into the derived module and improve its timing integration
- expose configured profile images via entity_picture on all plant entities
- allow configuring the DLI lux-to-PPFD conversion coefficient via a new threshold number
- expand threshold numbers with moisture and VPD ranges and refine the replace_sensor workflow
- handle Fahrenheit temperature sensors when computing VPD, dew point and mold-risk metrics
- compute initial VPD, dew point and mold risk readings by scheduling an immediate state evaluation and sharing a helper for temperature/humidity extraction

## Testing
- `pre-commit run --files custom_components/horticulture_assistant/derived.py tests/test_vpd_dew_point_sensor.py tests/test_mold_risk_sensor.py`
- `pytest tests/test_vpd_dew_point_sensor.py tests/test_mold_risk_sensor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a67336432483308e641b8d8675ce56