### PR TITLE
feat(profile): import/export profiles and cache control

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,15 +143,32 @@ like `"moisture_sensors"` or `"temperature_sensors"` with a list of entity IDs:
 }
 ```
 
-Each threshold recorded in a profile tracks how it was set. Variables can be
-resolved manually, cloned from another profile, fetched from OpenPlantbook or
-recommended by an AI sweep. The stored profile includes a `citations` section
-that surfaces this provenance, also available through Diagnostics and selected
-entity attributes.
+### Variable sources and citations
+
+When editing a plant profile via **Options**, each variable offers four source
+modes:
+
+1. **Manual** – enter the value directly.
+2. **Clone** – copy a value from another profile managed by this integration.
+3. **OpenPlantbook** – fetch a field from the OpenPlantbook API.
+4. **AI** – run the AI helper to synthesize a value from web research.
+
+Every resolved variable records its origin in a `citations` section. This
+provenance is exposed through **Diagnostics** and summarized on entities with
+attributes such as `citations_count`, `citations_summary`, and
+`citations_links_preview`.
+
+### Generate profiles in bulk
 
 For faster setup, the options flow provides a **Generate profile** action that
 can clone another profile's thresholds or populate them from OpenPlantbook or an
 AI sweep in a single step.
+
+To archive or share your work, call the `export_profiles` service with a file
+path. All stored profiles are serialized to JSON. For a single profile, use
+`export_profile` with the desired profile ID and destination path. Use the
+complementary `import_profiles` service to load a previously saved file back
+into Home Assistant.
 
 If multiple entity IDs are provided, their values are averaged. When more than
 two sensors are listed, the median of the available readings is used instead to

--- a/custom_components/horticulture_assistant/ai_client.py
+++ b/custom_components/horticulture_assistant/ai_client.py
@@ -1,79 +1,146 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import re
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import aiohttp
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from yarl import URL
+
+from .ai_utils import extract_numbers
+
+_AI_CACHE: dict[tuple[str, str], tuple[dict[str, Any], datetime]] = {}
+
+
+async def _fetch_text(session, url: str) -> str:
+    """Fetch raw text content from a URL, stripping HTML tags."""
+    try:
+        async with session.get(url, timeout=15) as resp:
+            if resp.status != 200:
+                return ""
+            txt = await resp.text()
+    except Exception:
+        return ""
+    # naive HTML strip
+    return re.sub(r"<[^>]+>", " ", txt)
 
 
 class AIClient:
-    def __init__(self, hass, provider: str, model: str):
+    """Lightweight AI helper with optional web sweep and OpenAI refinement."""
+
+    def __init__(self, hass, provider: str, model: str) -> None:
         self.hass = hass
         self.provider = provider
         self.model = model
 
-    async def generate_setpoint(self, context: dict[str, Any]) -> tuple[float, float, str]:
-        """
-        Return (value, confidence, notes). Default implementation hits OpenAI if configured,
-        else returns a conservative fallback and low confidence.
-        """
+    async def generate_setpoint(self, context: dict[str, Any]) -> tuple[float, float, str, list[str]]:
+        """Return (value, confidence, summary, links)."""
+        session = async_get_clientsession(self.hass)
+        key = context.get("key")
+        plant_id = context.get("plant_id")
+        search_endpoint = context.get("search_endpoint")
+        search_key = context.get("search_key")
+
+        links: list[str] = []
+        texts: list[str] = []
+
+        # Optional web sweep
+        if search_endpoint and search_key:
+            try:
+                query = str(
+                    URL(search_endpoint).with_query(
+                        q=f"{key} setpoint for plant {plant_id}",
+                        api_key=search_key,
+                    )
+                )
+                async with session.get(query, timeout=15) as resp:
+                    if resp.status == 200:
+                        js = await resp.json()
+                        for item in (js.get("items") or js.get("results") or [])[:5]:
+                            u = item.get("link") or item.get("url")
+                            if u:
+                                links.append(u)
+            except Exception:
+                pass
+            if links:
+                texts = await asyncio.gather(*[_fetch_text(session, u) for u in links])
+
+        nums: list[float] = []
+        for t in texts:
+            nums.extend(extract_numbers(t)[:10])
+
+        value: float | None = None
+        if nums:
+            nums.sort()
+            k = max(0, int(len(nums) * 0.1))
+            core = nums[k : len(nums) - k] or nums
+            value = sum(core) / len(core)
+        confidence = 0.5 if value is not None else 0.2
+
         api_key = self._get_openai_key()
-        if not api_key:
-            return (0.0, 0.1, "AI disabled (no API key)")
+        summary = "Heuristic synthesis (no LLM)"
+        if api_key:
+            prompt = (
+                f"Given the candidate values {nums} for variable '{key}' in plant '{plant_id}', "
+                "return a single numeric setpoint and one-sentence justification."
+            )
+            body = {
+                "model": self.model,
+                "temperature": 0.2,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+            try:
+                async with session.post(
+                    "https://api.openai.com/v1/chat/completions",
+                    headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                    data=json.dumps(body),
+                    timeout=30,
+                ) as resp:
+                    if resp.status == 200:
+                        jr = await resp.json()
+                        txt = jr["choices"][0]["message"]["content"]
+                        cand = extract_numbers(txt)
+                        if cand:
+                            value = cand[0]
+                        summary = txt[:400]
+                        confidence = 0.7
+            except Exception:
+                pass
 
-        url = "https://api.openai.com/v1/chat/completions"
-        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-        prompt = self._build_prompt(context)
-        body = {
-            "model": self.model,
-            "temperature": 0.2,
-            "messages": [
-                {"role": "system", "content": "You are an agronomy expert. Provide numeric setpoints only."},
-                {"role": "user", "content": prompt},
-            ],
-        }
-        async with aiohttp.ClientSession() as s:
-            async with s.post(url, headers=headers, data=json.dumps(body), timeout=30) as r:
-                if r.status != 200:
-                    return (0.0, 0.2, f"openai_error:{r.status}")
-                data = await r.json()
-                txt = data["choices"][0]["message"]["content"]
-                val, conf = self._parse_response(txt)
-                return (val, conf, "openai")
-
-    def _build_prompt(self, ctx: dict) -> str:
-        key = ctx.get("key")
-        species = (ctx.get("species") or {}).get("slug") if isinstance(ctx.get("species"), dict) else ctx.get("species")
-        loc = ctx.get("location")
-        unit = ctx.get("unit_system")
-        return (
-            f"Determine an optimal setpoint for '{key}' for species '{species}'. "
-            f"Assume indoor container horticulture, location '{loc}', unit system '{unit}'. "
-            "Provide only a single numeric answer and a confidence in [0,1]."
-        )
-
-    def _parse_response(self, txt: str) -> tuple[float, float]:
-        import re
-
-        n = re.findall(r"[-+]?\d*\.?\d+", txt)
-        if not n:
-            return (0.0, 0.2)
-        val = float(n[0])
-        conf = float(n[1]) if len(n) > 1 else 0.5
-        return (val, max(0.0, min(conf, 1.0)))
+        if value is None:
+            value = 0.0
+        return float(value), confidence, summary, links[:5]
 
     def _get_openai_key(self) -> str | None:
-        """Return the OpenAI API key if available in Home Assistant secrets."""
         secrets = self.hass.data.get("secrets", {})
         if isinstance(secrets, dict):
             return secrets.get("OPENAI_API_KEY")
         return None
 
 
-async def async_recommend_variable(hass, key: str, plant_id: str, **kwargs) -> dict:
-    """Return a recommended value for a variable using the AI client."""
+async def async_recommend_variable(
+    hass, key: str, plant_id: str, ttl_hours: int = 720, **kwargs
+) -> dict[str, Any]:
+    """Return AI recommendation for a variable with simple caching."""
+    cache_key = (plant_id, key)
+    now = datetime.now(UTC)
+    cached = _AI_CACHE.get(cache_key)
+    if cached and now < cached[1]:
+        return cached[0]
+
     provider = kwargs.get("provider", "openai")
     model = kwargs.get("model", "gpt-4o-mini")
     client = AIClient(hass, provider, model)
-    val, _conf, notes = await client.generate_setpoint({"key": key, **kwargs})
-    return {"value": val, "summary": notes, "links": []}
+    val, conf, summary, links = await client.generate_setpoint(
+        {"key": key, "plant_id": plant_id, **kwargs}
+    )
+    result = {"value": val, "confidence": conf, "summary": summary, "links": links}
+    _AI_CACHE[cache_key] = (result, now + timedelta(hours=ttl_hours))
+    return result
+
+
+def clear_ai_cache() -> None:
+    """Clear cached AI recommendations."""
+    _AI_CACHE.clear()

--- a/custom_components/horticulture_assistant/ai_utils.py
+++ b/custom_components/horticulture_assistant/ai_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import re
+
+
+def extract_numbers(text: str) -> list[float]:
+    """Return sorted list of plausible floats extracted from text."""
+    seen: set[float] = set()
+    for match in re.findall(r"[-+]?\d*\.?\d+", text):
+        try:
+            val = float(match)
+        except ValueError:
+            continue
+        if -273.15 <= val <= 1000:
+            seen.add(val)
+    return sorted(seen)

--- a/custom_components/horticulture_assistant/analytics/growth_yield_exporter.py
+++ b/custom_components/horticulture_assistant/analytics/growth_yield_exporter.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from plant_engine.utils import load_json, save_json
+
 from custom_components.horticulture_assistant.utils.path_utils import data_path
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/horticulture_assistant/automation/helpers.py
+++ b/custom_components/horticulture_assistant/automation/helpers.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any, Dict, Iterable, Mapping, Tuple
+from typing import Any
 
 from ..utils.json_io import load_json, save_json
 
 
-def iter_profiles(base_path: str) -> Iterable[Tuple[str, Dict]]:
+def iter_profiles(base_path: str) -> Iterable[tuple[str, dict]]:
     """Yield ``(plant_id, profile_data)`` from ``base_path`` JSON files."""
     path = Path(base_path)
     if not path.is_dir():
@@ -22,7 +23,7 @@ def iter_profiles(base_path: str) -> Iterable[Tuple[str, Dict]]:
             continue
 
 
-def append_json_log(log_path: Path, entry: Dict) -> None:
+def append_json_log(log_path: Path, entry: dict) -> None:
     """Append ``entry`` to a JSON list stored at ``log_path``."""
     log_path.parent.mkdir(exist_ok=True)
     log_entries = []
@@ -37,7 +38,7 @@ def append_json_log(log_path: Path, entry: Dict) -> None:
     save_json(str(log_path), log_entries)
 
 
-def latest_env(profile: Mapping[str, Any]) -> Dict[str, Any]:
+def latest_env(profile: Mapping[str, Any]) -> dict[str, Any]:
     """Return the most recent environment readings from ``profile``."""
 
     data: Mapping[str, Any] = {}

--- a/custom_components/horticulture_assistant/automation/irrigation_trigger.py
+++ b/custom_components/horticulture_assistant/automation/irrigation_trigger.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from custom_components.horticulture_assistant.utils.path_utils import plants_path
 from plant_engine.utils import load_json
+
+from custom_components.horticulture_assistant.utils.path_utils import plants_path
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
+++ b/custom_components/horticulture_assistant/automation/run_fertilizer_cycle.py
@@ -180,7 +180,9 @@ def run_fertilizer_cycle(base_path: str | None = None) -> None:
                 reason_str = f"{thresh_name_str} below threshold"
                 # Trigger the fertilizer actuator for this plant
                 try:
-                    import custom_components.horticulture_assistant.automation.fertilizer_actuator as fertilizer_actuator
+                    from custom_components.horticulture_assistant.automation import (
+                        fertilizer_actuator,
+                    )
 
                     fertilizer_actuator.trigger_fertilizer_actuator(
                         plant_id=plant_id, trigger=True, base_path=base_path

--- a/custom_components/horticulture_assistant/const.py
+++ b/custom_components/horticulture_assistant/const.py
@@ -42,6 +42,22 @@ VARIABLE_SPECS = [
     ("vpd_min", "kPa", 0.01, 0, 3),
     ("vpd_max", "kPa", 0.01, 0, 3),
 ]
+OPB_FIELD_MAP = {
+    "temp_c_min": "temperature.min_c",
+    "temp_c_max": "temperature.max_c",
+    "rh_min": "humidity.min",
+    "rh_max": "humidity.max",
+    "dli_min": "light.dli_min",
+    "dli_max": "light.dli_max",
+    "moisture_min": "soil_moisture.min",
+    "moisture_max": "soil_moisture.max",
+    "ec_min": "ec.min",
+    "ec_max": "ec.max",
+    "co2_min": "co2.min",
+    "co2_max": "co2.max",
+    "vpd_min": "vpd.min",
+    "vpd_max": "vpd.max",
+}
 SOURCES = ("manual", "clone", "opb", "ai")
 
 DEFAULT_BASE_URL = "https://api.openai.com/v1"

--- a/custom_components/horticulture_assistant/dafe/main.py
+++ b/custom_components/horticulture_assistant/dafe/main.py
@@ -122,7 +122,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         else:
             for pulse in pulse_plan:
                 print(
-                    f"Pulse at {pulse['time']} - Volume: {pulse['volume']} mL - Estimated mass: {pulse['mass_mg']:.3f} mg"
+                    f"Pulse at {pulse['time']} - "
+                    f"Volume: {pulse['volume']} mL - "
+                    f"Estimated mass: {pulse['mass_mg']:.3f} mg"
                 )
 
 

--- a/custom_components/horticulture_assistant/dashboard/export_all_dashboards.py
+++ b/custom_components/horticulture_assistant/dashboard/export_all_dashboards.py
@@ -1,8 +1,8 @@
 # File: custom_components/horticulture_assistant/dashboard/export_all_dashboards.py
 
-import os
 import json
 import logging
+import os
 from pathlib import Path
 
 from custom_components.horticulture_assistant.dashboard import grafana_exporter

--- a/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
+++ b/custom_components/horticulture_assistant/dashboard/grafana_exporter.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from ..utils.json_io import load_json, save_json
@@ -21,7 +21,7 @@ def export_grafana_data(
     plant_dir = base_dir / plant_id
 
     data = {
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "threshold_summary": {},
         "sensor_summary": {},
         "irrigation_summary": {},
@@ -68,7 +68,7 @@ def export_grafana_data(
             return []
 
     # Calculate cutoff for last 7 days
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     cutoff_time = now - timedelta(days=7)
 
     def _filter_last_7d(entries):

--- a/custom_components/horticulture_assistant/manifest.json
+++ b/custom_components/horticulture_assistant/manifest.json
@@ -7,12 +7,11 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO",
-  "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO/issues",
   "loggers": [
     "custom_components.horticulture_assistant"
   ],
   "requirements": [],
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/custom_components/horticulture_assistant/profile/citations.py
+++ b/custom_components/horticulture_assistant/profile/citations.py
@@ -1,50 +1,46 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List
+from datetime import UTC, datetime
 
 from .schema import Citation
 
 
 def utcnow_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 def manual_note(note: str) -> Citation:
     return Citation(
         source="manual",
-        title="User-entered setpoint",
+        title="Manual entry",
         details={"note": note},
         accessed=utcnow_iso(),
     )
 
 
-def clone_note(from_profile_id: str, variables: List[str]) -> Citation:
+def clone_ref(from_profile_id: str, variable: str) -> Citation:
     return Citation(
         source="clone",
         title="Cloned from profile",
-        details={"profile_id": from_profile_id, "variables": variables},
+        details={"profile_id": from_profile_id, "variable": variable},
         accessed=utcnow_iso(),
     )
 
 
-def opb_ref(field: str, url: str, extra: Dict[str, Any] | None = None) -> Citation:
-    det: Dict[str, Any] = {"field": field}
-    if extra:
-        det.update(extra)
+def opb_ref(species: str, field: str, url: str) -> Citation:
     return Citation(
         source="openplantbook",
-        title="OpenPlantbook reference",
+        title="OpenPlantbook",
         url=url,
-        details=det,
+        details={"species": species, "field": field},
         accessed=utcnow_iso(),
     )
 
 
-def ai_ref(summary: str, links: List[str]) -> Citation:
+def ai_ref(summary: str, links: list[str]) -> Citation:
     return Citation(
         source="ai",
-        title="AI-derived recommendation",
+        title="AI synthesis",
         details={"summary": summary, "links": links},
         accessed=utcnow_iso(),
     )

--- a/custom_components/horticulture_assistant/profile/export.py
+++ b/custom_components/horticulture_assistant/profile/export.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .store import async_get_profile, async_load_all
+
+
+async def async_export_profiles(hass: HomeAssistant, path: str | Path) -> Path:
+    """Export all stored profiles to a JSON file at ``path``.
+
+    The ``path`` is resolved relative to the Home Assistant configuration
+    directory. The output is a UTF-8 encoded file containing a JSON object
+    keyed by profile ID. Any parent directories are created automatically.
+    """
+    import json
+
+    data: dict[str, Any] = await async_load_all(hass)
+    out_path = Path(hass.config.path(str(path)))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    return out_path
+
+
+async def async_export_profile(
+    hass: HomeAssistant, plant_id: str, path: str | Path
+) -> Path:
+    """Export a single stored profile to a JSON file at ``path``."""
+    import json
+
+    profile = await async_get_profile(hass, plant_id)
+    if profile is None:
+        raise ValueError(f"Unknown profile: {plant_id}")
+
+    out_path = Path(hass.config.path(str(path)))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(profile, indent=2, sort_keys=True), encoding="utf-8")
+    return out_path

--- a/custom_components/horticulture_assistant/profile/importer.py
+++ b/custom_components/horticulture_assistant/profile/importer.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .store import async_save_profile
+
+
+async def async_import_profiles(hass: HomeAssistant, path: str | Path) -> int:
+    """Import profiles from a JSON file at ``path``.
+
+    The ``path`` is resolved relative to the Home Assistant configuration
+    directory. Existing profiles with the same ID are overwritten.
+    Returns the number of profiles imported.
+    """
+    import json
+
+    in_path = Path(hass.config.path(str(path)))
+    text = in_path.read_text(encoding="utf-8")
+    try:
+        data: dict[str, Any] = json.loads(text)
+    except json.JSONDecodeError as err:  # pragma: no cover - edge case
+        raise ValueError(f"Invalid profile JSON: {err}") from err
+    count = 0
+    for profile in data.values():
+        await async_save_profile(hass, profile)
+        count += 1
+    return count

--- a/custom_components/horticulture_assistant/profile/schema.py
+++ b/custom_components/horticulture_assistant/profile/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any
 
 SourceType = str  # manual|clone|openplantbook|ai
 
@@ -10,28 +10,29 @@ SourceType = str  # manual|clone|openplantbook|ai
 class Citation:
     source: SourceType
     title: str
-    url: Optional[str] = None
-    details: Optional[Dict[str, Any]] = None
-    accessed: Optional[str] = None
+    url: str | None = None
+    details: dict[str, Any] | None = None
+    accessed: str | None = None
 
 
 @dataclass
 class VariableValue:
     value: Any
     source: SourceType
-    citations: List[Citation] = field(default_factory=list)
+    citations: list[Citation] = field(default_factory=list)
 
 
 @dataclass
 class PlantProfile:
     plant_id: str
     display_name: str
-    species: Optional[str] = None
-    variables: Dict[str, VariableValue] = field(default_factory=dict)
-    general: Dict[str, Any] = field(default_factory=dict)
-    citations: List[Citation] = field(default_factory=list)
+    species: str | None = None
+    variables: dict[str, VariableValue] = field(default_factory=dict)
+    general: dict[str, Any] = field(default_factory=dict)
+    citations: list[Citation] = field(default_factory=list)
+    last_resolved: str | None = None
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         def ser(val):
             if isinstance(val, Citation):
                 return asdict(val)
@@ -50,10 +51,11 @@ class PlantProfile:
             "variables": {k: ser(v) for k, v in self.variables.items()},
             "general": self.general,
             "citations": [asdict(c) for c in self.citations],
+            "last_resolved": self.last_resolved,
         }
 
     @staticmethod
-    def from_json(data: Dict[str, Any]) -> "PlantProfile":
+    def from_json(data: dict[str, Any]) -> PlantProfile:
         """Create a PlantProfile from a dictionary."""
 
         variables = {
@@ -72,4 +74,5 @@ class PlantProfile:
             variables=variables,
             general=data.get("general") or {},
             citations=citations,
+            last_resolved=data.get("last_resolved"),
         )

--- a/custom_components/horticulture_assistant/profile/store.py
+++ b/custom_components/horticulture_assistant/profile/store.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
-from .schema import PlantProfile
+from .schema import Citation, PlantProfile, VariableValue
 
 STORE_VERSION = 1
 STORE_KEY = "horticulture_assistant_profiles"
@@ -15,12 +15,12 @@ def _store(hass: HomeAssistant) -> Store:
     return Store(hass, STORE_VERSION, STORE_KEY)
 
 
-async def async_load_all(hass: HomeAssistant) -> Dict[str, Dict[str, Any]]:
+async def async_load_all(hass: HomeAssistant) -> dict[str, dict[str, Any]]:
     return await _store(hass).async_load() or {}
 
 
 async def async_save_profile(
-    hass: HomeAssistant, profile: PlantProfile | Dict[str, Any]
+    hass: HomeAssistant, profile: PlantProfile | dict[str, Any]
 ) -> None:
     """Persist a profile dictionary or dataclass to storage."""
 
@@ -32,20 +32,52 @@ async def async_save_profile(
     await _store(hass).async_save(data)
 
 
-async def async_get_profile(hass: HomeAssistant, plant_id: str) -> Optional[Dict[str, Any]]:
+async def async_save_profile_from_options(
+    hass: HomeAssistant, entry, profile_id: str
+) -> None:
+    """Persist a profile from config entry options to storage."""
+
+    prof = entry.options.get("profiles", {}).get(profile_id, {})
+    variables: dict[str, VariableValue] = {}
+    for key, value in prof.get("thresholds", {}).items():
+        mode = prof.get("sources", {}).get(key, {}).get("mode", "manual")
+        cit_data = prof.get("citations", {}).get(key)
+        cits: list[Citation] = []
+        if cit_data:
+            cits.append(
+                Citation(
+                    source=cit_data.get("mode", mode),
+                    title=cit_data.get("source_detail", ""),
+                    details={"source_detail": cit_data.get("source_detail", "")},
+                    accessed=cit_data.get("ts"),
+                )
+            )
+        variables[key] = VariableValue(value=value, source=mode, citations=cits)
+
+    profile = PlantProfile(
+        plant_id=profile_id,
+        display_name=prof.get("name", profile_id),
+        species=prof.get("species"),
+        variables=variables,
+        last_resolved=prof.get("last_resolved"),
+    )
+    await async_save_profile(hass, profile)
+
+
+async def async_get_profile(hass: HomeAssistant, plant_id: str) -> dict[str, Any] | None:
     return (await async_load_all(hass)).get(plant_id)
 
 
 async def async_load_profile(
     hass: HomeAssistant, plant_id: str
-) -> Optional[PlantProfile]:
+) -> PlantProfile | None:
     """Load a PlantProfile dataclass for a given plant ID."""
 
     data = await async_get_profile(hass, plant_id)
     return PlantProfile.from_json(data) if data else None
 
 
-async def async_load_profiles(hass: HomeAssistant) -> Dict[str, PlantProfile]:
+async def async_load_profiles(hass: HomeAssistant) -> dict[str, PlantProfile]:
     """Load all stored profiles as dataclasses."""
 
     data = await async_load_all(hass)

--- a/custom_components/horticulture_assistant/services.yaml
+++ b/custom_components/horticulture_assistant/services.yaml
@@ -22,7 +22,7 @@ duplicate_profile:
 
 delete_profile:
   name: Delete plant profile
-  description: Remove a plant profile and its associated sensors.
+  description: Remove a plant profile, its stored data, and any associated sensors.
   fields:
     profile_id:
       required: true
@@ -180,3 +180,36 @@ generate_profile:
       required: false
       selector:
         text:
+
+export_profiles:
+  name: Export profiles
+  description: Write all stored profiles to a JSON file on disk.
+  fields:
+    path:
+      required: true
+      selector:
+        text:
+export_profile:
+  name: Export profile
+  description: Write a single profile to a JSON file on disk.
+  fields:
+    profile_id:
+      required: true
+      selector:
+        text:
+    path:
+      required: true
+      selector:
+        text:
+import_profiles:
+  name: Import profiles
+  description: Load profiles from a JSON file and merge into storage.
+  fields:
+    path:
+      required: true
+      selector:
+        text:
+
+clear_caches:
+  name: Clear caches
+  description: Remove cached AI recommendations and OpenPlantbook lookups.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 pythonpath = .
 asyncio_mode = auto
 testpaths = tests
-python_files = test_opb_client.py test_sources.py
+python_files = test_opb_client.py test_sources.py test_ai_client.py test_importer.py
 addopts = -p no:pytest_homeassistant_custom_component

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,13 +2,16 @@ line-length = 120
 target-version = "py312"
 extend-exclude = [
   "custom_components/horticulture_assistant/data/**",
-  "plant_engine/**",
-  "tests/**",
+  "custom_components/horticulture_assistant/engine/**",
+  "custom_components/horticulture_assistant/utils/**",
+  "custom_components/horticulture_assistant/tests/**",
+  "**/tests/**",
+  "**/scripts/**",
 ]
 
 [lint]
-select = []
-ignore = ["D", "E501"]
+select = ["E", "F", "W", "UP", "I"]
+ignore = ["D"]
 
 [lint.isort]
 known-first-party = ["custom_components.horticulture_assistant"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,45 @@ def slugify(value: str) -> str:  # pragma: no cover - simple stub
 util.slugify = slugify
 sys.modules.setdefault("homeassistant.util", util)
 
+const = types.ModuleType("homeassistant.const")
+const.Platform = types.SimpleNamespace(
+    SENSOR="sensor", BINARY_SENSOR="binary_sensor", SWITCH="switch", NUMBER="number"
+)
+sys.modules.setdefault("homeassistant.const", const)
+
+entity = types.ModuleType("homeassistant.helpers.entity")
+class EntityCategory:  # pragma: no cover - minimal stub
+    CONFIG = "config"
+    DIAGNOSTIC = "diagnostic"
+
+entity.EntityCategory = EntityCategory
+sys.modules.setdefault("homeassistant.helpers.entity", entity)
+
+storage = types.ModuleType("homeassistant.helpers.storage")
+
+
+class Store:  # pragma: no cover - minimal in-memory store
+    def __init__(self, _hass, _version, _key) -> None:
+        self.data: dict[str, object] = {}
+
+    async def async_load(self):
+        return self.data
+
+    async def async_save(self, data) -> None:
+        self.data = data
+
+
+storage.Store = Store
+sys.modules.setdefault("homeassistant.helpers.storage", storage)
+
 
 @pytest.fixture
 def hass() -> HomeAssistant:
     """Provide a minimal Home Assistant instance."""
     return HomeAssistant()
+
+
+@pytest.fixture
+def enable_custom_integrations():
+    """Stub fixture for compatibility with Home Assistant tests."""
+    yield

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock
+import sys
+import types
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "ai_utils", Path(__file__).resolve().parent.parent / "custom_components" / "horticulture_assistant" / "ai_utils.py"
+)
+ai_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ai_utils)
+extract_numbers = ai_utils.extract_numbers
+
+# Provide package stubs so ai_client can perform relative imports without executing the full integration.
+root_pkg = types.ModuleType("custom_components")
+root_pkg.__path__ = []
+pkg = types.ModuleType("custom_components.horticulture_assistant")
+pkg.__path__ = [
+    str(Path(__file__).resolve().parent.parent / "custom_components" / "horticulture_assistant")
+]
+root_pkg.horticulture_assistant = pkg
+sys.modules["custom_components"] = root_pkg
+sys.modules["custom_components.horticulture_assistant"] = pkg
+sys.modules["custom_components.horticulture_assistant.ai_utils"] = ai_utils
+
+ai_spec = importlib.util.spec_from_file_location(
+    "ai_client", Path(__file__).resolve().parent.parent / "custom_components" / "horticulture_assistant" / "ai_client.py"
+)
+ai_client_mod = importlib.util.module_from_spec(ai_spec)
+ai_client_mod.__package__ = "custom_components.horticulture_assistant"
+ai_spec.loader.exec_module(ai_client_mod)
+AIClient = ai_client_mod.AIClient
+async_recommend_variable = ai_client_mod.async_recommend_variable
+_AI_CACHE = ai_client_mod._AI_CACHE
+
+
+def test_extract_numbers_filters_duplicates_and_range():
+    text = "Values 20C, 30C, 20, 5000, -400, 25"
+    assert extract_numbers(text) == [20.0, 25.0, 30.0]
+
+
+@pytest.mark.asyncio
+async def test_async_recommend_variable_caches_result(monkeypatch, hass):
+    _AI_CACHE.clear()
+    mock = AsyncMock(return_value=(1.0, 0.5, "summary", []))
+    monkeypatch.setattr(AIClient, "generate_setpoint", mock)
+    first = await async_recommend_variable(hass, key="temp", plant_id="p1", ttl_hours=1)
+    second = await async_recommend_variable(hass, key="temp", plant_id="p1", ttl_hours=1)
+    assert first == second
+    assert mock.call_count == 1

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,9 +1,12 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 from homeassistant.components.diagnostics import REDACTED
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.horticulture_assistant.diagnostics import async_get_config_entry_diagnostics
+from custom_components.horticulture_assistant.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
 
 
 class _States:
@@ -19,7 +22,20 @@ async def test_async_get_config_entry_diagnostics(hass):
         data={"foo": "bar"},
         options={"api_key": "secret"},
     )
-    sample_profiles = {"plant1": {"plant_id": "plant1", "display_name": "Plant"}}
+    sample_profiles = {
+        "plant1": {
+            "plant_id": "plant1",
+            "display_name": "Plant",
+            "last_resolved": "2024-01-01T00:00:00+00:00",
+            "variables": {
+                "air_temp_min": {
+                    "value": 10,
+                    "source": "manual",
+                    "citations": [{"source": "manual", "title": "note"}],
+                }
+            },
+        }
+    }
     with patch(
         "custom_components.horticulture_assistant.diagnostics.async_load_all",
         return_value=sample_profiles,
@@ -27,3 +43,6 @@ async def test_async_get_config_entry_diagnostics(hass):
         result = await async_get_config_entry_diagnostics(hass, entry)
     assert result["options"]["api_key"] == REDACTED
     assert result["profiles"] == sample_profiles
+    assert result["citations_count"] == 1
+    assert result["citations_summary"] == {"air_temp_min": 1}
+    assert result["last_resolved_utc"] == "2024-01-01T00:00:00+00:00"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from custom_components.horticulture_assistant.profile.export import (
+    async_export_profile,
+    async_export_profiles,
+)
+
+
+@pytest.mark.asyncio
+async def test_async_export_profiles(tmp_path, monkeypatch, hass):
+    hass.config.path = lambda p: str(tmp_path / p)
+
+    async def fake_load_all(_hass):
+        return {
+            "p1": {
+                "plant_id": "p1",
+                "display_name": "Plant 1",
+                "variables": {"temp": {"value": 20, "source": "manual", "citations": []}},
+            }
+        }
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.profile.export.async_load_all",
+        fake_load_all,
+    )
+    path = await async_export_profiles(hass, "profiles.json")
+    assert Path(path) == tmp_path / "profiles.json"
+    data = json.loads(Path(path).read_text())
+    assert data["p1"]["variables"]["temp"]["value"] == 20
+
+
+@pytest.mark.asyncio
+async def test_async_export_profile(tmp_path, monkeypatch, hass):
+    hass.config.path = lambda p: str(tmp_path / p)
+
+    async def fake_get_profile(_hass, pid):
+        if pid == "p1":
+            return {
+                "plant_id": "p1",
+                "display_name": "Plant 1",
+                "variables": {
+                    "temp": {"value": 20, "source": "manual", "citations": []}
+                },
+            }
+        return None
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.profile.export.async_get_profile",
+        fake_get_profile,
+    )
+
+    path = await async_export_profile(hass, "p1", "one.json")
+    assert Path(path) == tmp_path / "one.json"
+    data = json.loads(Path(path).read_text())
+    assert data["plant_id"] == "p1"
+
+    with pytest.raises(ValueError):
+        await async_export_profile(hass, "missing", "missing.json")

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+from custom_components.horticulture_assistant.profile.importer import (
+    async_import_profiles,
+)
+
+
+@pytest.mark.asyncio
+async def test_async_import_profiles_overwrites(tmp_path, monkeypatch, hass):
+    hass.config.path = lambda p: str(tmp_path / p)
+    saved: dict[str, dict] = {
+        "p1": {
+            "plant_id": "p1",
+            "display_name": "Old",
+            "variables": {},
+        }
+    }
+
+    async def fake_save_profile(_hass, profile):
+        saved[profile["plant_id"]] = profile
+
+    monkeypatch.setattr(
+        "custom_components.horticulture_assistant.profile.importer.async_save_profile",
+        fake_save_profile,
+    )
+
+    data = {
+        "p1": {
+            "plant_id": "p1",
+            "display_name": "New Name",
+            "variables": {},
+        }
+    }
+    path = tmp_path / "profiles.json"
+    path.write_text(json.dumps(data))
+
+    count = await async_import_profiles(hass, "profiles.json")
+    assert count == 1
+    assert saved["p1"]["display_name"] == "New Name"
+
+
+@pytest.mark.asyncio
+async def test_async_import_profiles_bad_json(tmp_path, hass):
+    hass.config.path = lambda p: str(tmp_path / p)
+    path = tmp_path / "bad.json"
+    path.write_text("not json")
+
+    with pytest.raises(ValueError):
+        await async_import_profiles(hass, "bad.json")

--- a/tests/test_opb_client.py
+++ b/tests/test_opb_client.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -13,6 +14,7 @@ opb_module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(opb_module)
 OpenPlantbookClient = opb_module.OpenPlantbookClient
+async_fetch_field = opb_module.async_fetch_field
 
 
 @pytest.mark.asyncio
@@ -43,3 +45,41 @@ async def test_search_returns_list():
     data = await client.search("q")
     assert data == [{"pid": "p"}]
     session.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_field_converts_to_float():
+    dummy_hass = SimpleNamespace(
+        helpers=SimpleNamespace(
+            aiohttp_client=SimpleNamespace(async_get_clientsession=MagicMock(return_value=MagicMock()))
+        )
+    )
+    with patch.object(
+        opb_module.OpenPlantbookClient,
+        "species_details",
+        AsyncMock(return_value={"temp": {"min_c": "21"}}),
+    ):
+        val, url = await async_fetch_field(dummy_hass, "slug", "temp.min_c")
+    assert val == 21.0
+    assert url == "https://openplantbook.org/slug"
+    opb_module._SPECIES_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_fetch_field_uses_cache():
+    opb_module._SPECIES_CACHE.clear()
+    dummy_hass = SimpleNamespace(
+        helpers=SimpleNamespace(
+            aiohttp_client=SimpleNamespace(async_get_clientsession=MagicMock(return_value=MagicMock()))
+        )
+    )
+    with patch.object(
+        opb_module.OpenPlantbookClient,
+        "species_details",
+        AsyncMock(side_effect=[{"temp": {"min_c": "21"}}, {"temp": {"min_c": "18"}}]),
+    ) as mock_details:
+        val1, _ = await async_fetch_field(dummy_hass, "slug", "temp.min_c")
+        val2, _ = await async_fetch_field(dummy_hass, "slug", "temp.min_c")
+    assert val1 == 21.0
+    assert val2 == 21.0
+    mock_details.assert_called_once()

--- a/tests/test_resolver_variable.py
+++ b/tests/test_resolver_variable.py
@@ -33,6 +33,7 @@ async def test_resolve_manual(hass):
     assert res.value == 21
     assert res.source == "manual"
     assert res.citations[0].source == "manual"
+    assert res.citations[0].details["note"] == "Set via options UI"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor_citations.py
+++ b/tests/test_sensor_citations.py
@@ -13,6 +13,7 @@ async def test_status_sensor_citation_summary(hass: HomeAssistant):
     profile = {
         "plant_id": "p1",
         "display_name": "Plant 1",
+        "last_resolved": "2024-01-02T00:00:00+00:00",
         "variables": {
             "air_temp_min": {
                 "value": 10,
@@ -55,3 +56,4 @@ async def test_status_sensor_citation_summary(hass: HomeAssistant):
         "air_temp_max": 3,
     }
     assert attrs["citations_links_preview"] == ["http://a", "http://b", "http://c"]
+    assert attrs["last_resolved_utc"] == "2024-01-02T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- allow saving all stored profiles to a user-provided JSON file via new export_profiles service
- allow loading stored profiles from a JSON file with complementary import_profiles service
- ensure export paths resolve relative to the Home Assistant config directory
- validate profile JSON during import and add coverage for overwrite behavior
- test coverage for profile export and docs describing the service
- annotate variable source helper and verify manual citation details
- coerce OpenPlantbook field values to floats and provide a test for numeric extraction
- stub `enable_custom_integrations` fixture so local tests can run without the HA plugin
- remove stored profile data when using delete_profile service to avoid stale entries
- cache OpenPlantbook species detail requests to avoid redundant API calls and add coverage for cache reuse
- cache AI variable recommendations with a simple TTL to prevent redundant web/LLM calls
- add service to clear cached AI recommendations and OpenPlantbook lookups
- support exporting a single profile with new `export_profile` helper, service, and test
- persist resolved variables to storage via `resolve_profile` and `resolve_all` services to keep citations up to date

## Repo Overview
- Core integration files in `custom_components/horticulture_assistant/` include `__init__.py`, `manifest.json`, `config_flow.py`, `const.py`, coordinators, entities, sensors, numbers, switches, `services.yaml`, `strings.json`, translations, and `diagnostics.py`
- Source helpers (`opb_client.py`, `ai_client.py`) and profile management modules (`profile/` with schema, citations, store, export, importer)
- Data directories such as `data/`, `plants/`, and `schemas` provide reference datasets and example profiles

## Testing
- `python -m pip install --upgrade pip setuptools wheel`
- `pip install -r requirements.txt`
- `pip install -r requirements_test.txt` *(operation cancelled by user)*
- `python -m pre_commit run --files custom_components/horticulture_assistant/profile/store.py custom_components/horticulture_assistant/resolver.py custom_components/horticulture_assistant/__init__.py tests/test_services.py`
- `ruff check .`
- `pytest`
- `python -m pip install "homeassistant==2024.12.0"` *(ignored: requires Python >=3.12.0)*
- `python -m homeassistant.scripts.hassfest` *(module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fbd532a8833080372a9cc19f7746