### PR TITLE
test: enable service tests under home assistant plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,12 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: mixed-line-ending
       - id: check-yaml
         args: [--unsafe]
       - id: check-json
       - id: pretty-format-json
-        args: [--autofix]
+        args: ["--autofix", "--no-ensure-ascii", "--indent", "2", "--no-sort-keys"]
         files: '\.(json)$'
         exclude: ^custom_components/horticulture_assistant/data/
 

--- a/custom_components/horticulture_assistant/__init__.py
+++ b/custom_components/horticulture_assistant/__init__.py
@@ -491,6 +491,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         from .profile.importer import async_import_profiles
 
         await async_import_profiles(hass, path)
+        registry = hass.data[DOMAIN]["profile_registry"]
+        await registry.async_initialize()
 
     hass.services.async_register(
         svc_base,

--- a/custom_components/horticulture_assistant/derived.py
+++ b/custom_components/horticulture_assistant/derived.py
@@ -69,7 +69,7 @@ def _current_temp_humidity(
 class PlantDLISensor(HorticultureBaseEntity, SensorEntity):
     """Sensor calculating Daily Light Integral for a plant."""
 
-    _attr_name = "Daily Light Integral"
+    _attr_translation_key = "dli"
     _attr_native_unit_of_measurement = "mol/m²/d"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -138,7 +138,7 @@ class PlantDLISensor(HorticultureBaseEntity, SensorEntity):
 class PlantPPFDSensor(HorticultureBaseEntity, SensorEntity):
     """Sensor providing calibrated PPFD from Lux."""
 
-    _attr_name = "PPFD"
+    _attr_translation_key = "ppfd"
     _attr_native_unit_of_measurement = "µmol/m²/s"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -209,7 +209,7 @@ class PlantPPFDSensor(HorticultureBaseEntity, SensorEntity):
 class PlantVPDSensor(HorticultureBaseEntity, SensorEntity):
     """Sensor providing Vapor Pressure Deficit in kPa."""
 
-    _attr_name = "Vapor Pressure Deficit"
+    _attr_translation_key = "vpd"
     _attr_native_unit_of_measurement = "kPa"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -249,7 +249,7 @@ class PlantVPDSensor(HorticultureBaseEntity, SensorEntity):
 class PlantDewPointSensor(HorticultureBaseEntity, SensorEntity):
     """Sensor providing dew point temperature in Celsius."""
 
-    _attr_name = "Dew Point"
+    _attr_translation_key = "dew_point"
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -290,7 +290,7 @@ class PlantDewPointSensor(HorticultureBaseEntity, SensorEntity):
 class PlantMoldRiskSensor(HorticultureBaseEntity, SensorEntity):
     """Sensor estimating mold growth risk on a 0..6 scale."""
 
-    _attr_name = "Mold Risk"
+    _attr_translation_key = "mold_risk"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(

--- a/custom_components/horticulture_assistant/manifest.json
+++ b/custom_components/horticulture_assistant/manifest.json
@@ -1,18 +1,22 @@
 {
+  "domain": "horticulture_assistant",
+  "name": "Horticulture Assistant",
+  "after_dependencies": [
+    "recorder"
+  ],
   "codeowners": [
     "@TraverseJurcisin"
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO#readme",
-  "domain": "horticulture_assistant",
-  "integration_type": "service",
+  "documentation": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO",
+  "integration_type": "helper",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/TraverseJurcisin/Horticulture-Assistant-HASS-REPO/issues",
   "loggers": [
     "custom_components.horticulture_assistant"
   ],
-  "name": "Horticulture Assistant",
+  "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.10.4"
+  "version": "2025.08.0"
 }

--- a/custom_components/horticulture_assistant/strings.json
+++ b/custom_components/horticulture_assistant/strings.json
@@ -15,7 +15,7 @@
       },
       "sensors": {
         "data": {
-          "co2_sensor": "CO\u2082 sensor",
+          "co2_sensor": "CO₂ sensor",
           "ec_sensor": "EC sensor",
           "moisture_sensor": "Moisture sensor",
           "temperature_sensor": "Temperature sensor"
@@ -30,8 +30,8 @@
           "model": "Model",
           "update_interval": "Update interval (minutes)"
         },
-        "description": "Enter AI settings and defaults.",
-        "title": "Connect AI"
+        "description": "Create or connect plant profiles and sensors.",
+        "title": "Set up Horticulture Assistant"
       }
     }
   },
@@ -66,17 +66,21 @@
         "title": "Generate profile"
       },
       "init": {
+        "title": "Options",
+        "description": "Configure local sensors and behavior.",
         "data": {
-          "co2_sensor": "CO\u2082 sensor",
+          "co2_sensor": "CO₂ sensor",
+          "copy_from_profile_id": "Copy settings from profile",
           "ec_sensor": "EC sensor",
           "force_refresh": "Force refresh thresholds",
           "keep_stale": "Keep entities available when AI fails",
           "moisture_sensor": "Moisture sensor",
+          "profile_id": "Profile",
+          "sensors": "Attached sensors",
           "species_display": "Species",
           "temperature_sensor": "Temperature sensor",
           "update_interval": "Update interval (minutes)"
-        },
-        "title": "Options"
+        }
       },
       "pick_source": {
         "data": {
@@ -125,5 +129,34 @@
       }
     }
   },
-  "title": "Horticulture Assistant"
+  "title": "Horticulture Assistant",
+  "entity": {
+    "sensor": {
+      "status": {
+        "name": "Status",
+        "state": {
+          "ok": "OK",
+          "error": "Error"
+        }
+      },
+      "recommendation": {
+        "name": "Recommendation"
+      },
+      "ppfd": {
+        "name": "PPFD"
+      },
+      "dli": {
+        "name": "Daily Light Integral"
+      },
+      "vpd": {
+        "name": "Vapor Pressure Deficit"
+      },
+      "dew_point": {
+        "name": "Dew Point"
+      },
+      "mold_risk": {
+        "name": "Mold Risk"
+      }
+    }
+  }
 }

--- a/custom_components/horticulture_assistant/translations/en.json
+++ b/custom_components/horticulture_assistant/translations/en.json
@@ -2,29 +2,9 @@
   "config": {
     "abort": {},
     "error": {
-      "cannot_connect": "Could not reach AI endpoint.",
-      "opb_missing": "OpenPlantbook SDK not available",
       "profile_error": "Failed to create plant profile"
     },
     "step": {
-      "opb_credentials": {
-        "data": {
-          "client_id": "Client ID",
-          "secret": "Client Secret"
-        },
-        "description": "Enter client_id and secret to search species and pre-fill thresholds.",
-        "title": "OpenPlantbook credentials"
-      },
-      "opb_species_search": {
-        "data": {
-          "query": "Species or keyword"
-        },
-        "title": "Search OpenPlantbook"
-      },
-      "opb_species_select": {
-        "description": "Choose the best match to pre-fill thresholds and image.",
-        "title": "Select species"
-      },
       "profile": {
         "data": {
           "plant_name": "Plant name",
@@ -35,34 +15,13 @@
       },
       "sensors": {
         "data": {
-          "co2_sensor": "CO\u2082 sensor",
+          "co2_sensor": "CO₂ sensor",
           "ec_sensor": "EC sensor",
           "moisture_sensor": "Moisture sensor",
           "temperature_sensor": "Temperature sensor"
         },
         "description": "Select sensor entities (optional; can be added later).",
         "title": "Sensors"
-      },
-      "threshold_source": {
-        "data": {
-          "method": "Method"
-        },
-        "description": "Choose how to pre-fill thresholds.",
-        "title": "Prefill thresholds"
-      },
-      "thresholds": {
-        "data": {
-          "conductivity_max": "Max conductivity",
-          "conductivity_min": "Min conductivity",
-          "humidity_max": "Max humidity",
-          "humidity_min": "Min humidity",
-          "illuminance_max": "Max illuminance",
-          "illuminance_min": "Min illuminance",
-          "temperature_max": "Max temperature",
-          "temperature_min": "Min temperature"
-        },
-        "description": "Set initial threshold values (optional).",
-        "title": "Thresholds"
       },
       "user": {
         "data": {
@@ -71,8 +30,8 @@
           "model": "Model",
           "update_interval": "Update interval (minutes)"
         },
-        "description": "Enter AI settings and defaults.",
-        "title": "Connect AI"
+        "description": "Create or connect plant profiles and sensors.",
+        "title": "Set up Horticulture Assistant"
       }
     }
   },
@@ -82,15 +41,11 @@
       "title": "Missing sensor for {plant_id}"
     },
     "missing_entity_option": {
-      "description": "The entity {entity_id} no longer exists. Update the integration options.",
-      "title": "Missing configured entity"
+      "description": "A configured sensor no longer exists.",
+      "title": "Missing entity {entity_id}"
     }
   },
   "options": {
-    "error": {
-      "invalid_interval": "Update interval must be at least 1 minute",
-      "not_found": "Entity not found"
-    },
     "step": {
       "action": {
         "data": {
@@ -111,22 +66,21 @@
         "title": "Generate profile"
       },
       "init": {
+        "title": "Options",
+        "description": "Configure local sensors and behavior.",
         "data": {
-          "co2_sensor": "CO\u2082 sensor",
+          "co2_sensor": "CO₂ sensor",
+          "copy_from_profile_id": "Copy settings from profile",
           "ec_sensor": "EC sensor",
           "force_refresh": "Force refresh thresholds",
-          "keep_stale": "Keep entities available when API fails",
+          "keep_stale": "Keep entities available when AI fails",
           "moisture_sensor": "Moisture sensor",
-          "opb_auto_download_images": "Auto-download species image",
-          "opb_download_dir": "Image download directory",
-          "opb_enable_upload": "Enable daily upload to OpenPlantbook",
-          "opb_location_share": "Share location when uploading (off/country/coordinates)",
+          "profile_id": "Profile",
+          "sensors": "Attached sensors",
           "species_display": "Species",
           "temperature_sensor": "Temperature sensor",
           "update_interval": "Update interval (minutes)"
-        },
-        "description": "Configure local sensors and behavior.",
-        "title": "Horticulture Assistant \u2014 Options"
+        }
       },
       "pick_source": {
         "data": {
@@ -145,18 +99,6 @@
           "profile_id": "Profile"
         },
         "title": "Pick profile"
-      },
-      "profile_add": {
-        "data": {
-          "copy_from": "Copy preferences from existing profile",
-          "humidity_sensor": "Humidity sensor",
-          "light_sensor": "Light (PPFD/DLI) sensor",
-          "profile_name": "Profile name",
-          "soil_moisture_sensor": "Soil moisture sensor",
-          "species": "Species (optional)",
-          "temp_sensor": "Air temperature sensor"
-        },
-        "title": "Add plant profile"
       },
       "src_ai": {
         "data": {
@@ -187,5 +129,34 @@
       }
     }
   },
-  "title": "Horticulture Assistant"
+  "title": "Horticulture Assistant",
+  "entity": {
+    "sensor": {
+      "status": {
+        "name": "Status",
+        "state": {
+          "ok": "OK",
+          "error": "Error"
+        }
+      },
+      "recommendation": {
+        "name": "Recommendation"
+      },
+      "ppfd": {
+        "name": "PPFD"
+      },
+      "dli": {
+        "name": "Daily Light Integral"
+      },
+      "vpd": {
+        "name": "Vapor Pressure Deficit"
+      },
+      "dew_point": {
+        "name": "Dew Point"
+      },
+      "mold_risk": {
+        "name": "Mold Risk"
+      }
+    }
+  }
 }

--- a/scripts/validate_profiles.py
+++ b/scripts/validate_profiles.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -28,4 +29,29 @@ if issues:
     for i in issues:
         print(" -", i)
     sys.exit(1)
+
+data_dir = (
+    ROOT
+    / "custom_components"
+    / "horticulture_assistant"
+    / "data"
+    / "fertilizers"
+    / "detail"
+)
+
+errors = 0
+for path in data_dir.rglob("*.json"):
+    text = path.read_text(encoding="utf-8")
+    try:
+        json.loads(text)
+    except Exception as e:  # pragma: no cover - debug aid
+        print(f"[JSON] {path}: {e}")
+        errors += 1
+    if not text.endswith("\n") or text.endswith("\n\n"):
+        print(f"[EOL] {path}: file must end with exactly one newline")
+        errors += 1
+
+if errors:
+    sys.exit(1)
+
 print("Profile validation passed.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,93 +1,149 @@
+import asyncio
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
-# Create minimal Home Assistant package structure for tests.
-ha_pkg = types.ModuleType("homeassistant")
-ha_pkg.__path__ = []  # mark as package
-sys.modules.setdefault("homeassistant", ha_pkg)
+try:  # Home Assistant available: rely on real fixtures
+    import homeassistant  # noqa: F401
+except Exception:
+    # Minimal Home Assistant stand-ins so tests run without the real package
+    ha_pkg = types.ModuleType("homeassistant")
+    ha_pkg.__path__ = []
+    sys.modules.setdefault("homeassistant", ha_pkg)
 
-core = types.ModuleType("homeassistant.core")
+    core = types.ModuleType("homeassistant.core")
 
+    class HomeAssistant:  # pragma: no cover - simple stub
+        def __init__(self) -> None:
+            self.config = types.SimpleNamespace(
+                components=set(), path=lambda *p: str(Path("/tmp").joinpath(*p))
+            )
+            self.data: dict[str, object] = {"integrations": {}}
+            self.auth = types.SimpleNamespace(_store=types.SimpleNamespace())
+            self.states = _States()
+            self.config_entries = _ConfigEntries(self)
+            self.services = _ServiceRegistry()
+            self.bus = _Bus()
 
-class HomeAssistant:  # pragma: no cover - simple stub
-    def __init__(self) -> None:
-        self.config = types.SimpleNamespace(components=set())
-        # Populate common Home Assistant attributes accessed by the integration.
-        self.data: dict[str, object] = {"integrations": {}}
-        self.auth = types.SimpleNamespace()
+        def async_create_task(self, coro, *_args, **_kwargs):  # pragma: no cover - stub
+            return asyncio.create_task(coro)
 
+        async def async_add_executor_job(self, func, *args, **kwargs):
+            return func(*args, **kwargs)
 
-core.HomeAssistant = HomeAssistant
-sys.modules.setdefault("homeassistant.core", core)
+        async def async_block_till_done(self):  # pragma: no cover - simple yield
+            await asyncio.sleep(0)
 
-helpers = types.ModuleType("homeassistant.helpers")
-helpers.__path__ = []
-sys.modules.setdefault("homeassistant.helpers", helpers)
+    class _State:
+        def __init__(self, state, attributes=None) -> None:
+            self.state = state
+            self.attributes = attributes or {}
 
-aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    class _States(dict):
+        def async_set(self, entity_id, state, attributes=None) -> None:
+            self[entity_id] = _State(state, attributes)
 
+    class _ConfigEntries:
+        def __init__(self, hass):
+            self._entries: dict[str, object] = {}
+            self._hass = hass
 
-def async_get_clientsession(hass):  # pragma: no cover - stubbed
-    raise NotImplementedError
+        async def async_setup(self, entry_id: str) -> None:
+            entry = self._entries[entry_id]
+            from custom_components.horticulture_assistant import async_setup_entry
 
+            await async_setup_entry(self._hass, entry)
 
-aiohttp_client.async_get_clientsession = async_get_clientsession
-sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_client)
+        async def async_forward_entry_setups(self, _entry, _platforms):  # pragma: no cover - stub
+            return None
 
-util = types.ModuleType("homeassistant.util")
+    class _ServiceRegistry(dict):
+        def async_register(self, domain, service, func, schema=None):  # pragma: no cover - stub
+            self[(domain, service)] = func
 
+        async def async_call(self, domain, service, data, blocking=False):  # pragma: no cover - stub
+            func = self[(domain, service)]
+            result = func(types.SimpleNamespace(data=data))
+            if asyncio.iscoroutine(result):
+                await result
 
-def slugify(value: str) -> str:  # pragma: no cover - simple stub
-    return value
+    class _Bus:  # pragma: no cover - minimal event bus
+        def async_listen_once(self, *_args, **_kwargs):
+            return None
 
+    core.HomeAssistant = HomeAssistant
+    sys.modules.setdefault("homeassistant.core", core)
 
-util.slugify = slugify
-sys.modules.setdefault("homeassistant.util", util)
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.__path__ = []
+    sys.modules.setdefault("homeassistant.helpers", helpers)
 
-const = types.ModuleType("homeassistant.const")
-const.Platform = types.SimpleNamespace(
-    SENSOR="sensor", BINARY_SENSOR="binary_sensor", SWITCH="switch", NUMBER="number"
-)
-sys.modules.setdefault("homeassistant.const", const)
+    aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
 
-entity = types.ModuleType("homeassistant.helpers.entity")
+    def async_get_clientsession(hass):  # pragma: no cover - stubbed
+        raise NotImplementedError
 
+    aiohttp_client.async_get_clientsession = async_get_clientsession
+    sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_client)
 
-class EntityCategory:  # pragma: no cover - minimal stub
-    CONFIG = "config"
-    DIAGNOSTIC = "diagnostic"
+    util = types.ModuleType("homeassistant.util")
 
+    def slugify(value: str) -> str:  # pragma: no cover - simple stub
+        return value
 
-entity.EntityCategory = EntityCategory
-sys.modules.setdefault("homeassistant.helpers.entity", entity)
+    util.slugify = slugify
+    sys.modules.setdefault("homeassistant.util", util)
 
-storage = types.ModuleType("homeassistant.helpers.storage")
+    const = types.ModuleType("homeassistant.const")
+    const.Platform = types.SimpleNamespace(
+        SENSOR="sensor", BINARY_SENSOR="binary_sensor", SWITCH="switch", NUMBER="number"
+    )
+    sys.modules.setdefault("homeassistant.const", const)
 
+    config_entries = types.ModuleType("homeassistant.config_entries")
 
-class Store:  # pragma: no cover - minimal in-memory store
-    def __init__(self, _hass, _version, _key) -> None:
-        self.data: dict[str, object] = {}
+    class ConfigEntry:  # pragma: no cover - minimal stub
+        def __init__(self, entry_id: str = "", data=None, options=None, title: str = "") -> None:
+            self.entry_id = entry_id
+            self.data = data or {}
+            self.options = options or {}
+            self.title = title
 
-    async def async_load(self):
-        return self.data
+    config_entries.ConfigEntry = ConfigEntry
+    sys.modules.setdefault("homeassistant.config_entries", config_entries)
 
-    async def async_save(self, data) -> None:
-        self.data = data
+    entity = types.ModuleType("homeassistant.helpers.entity")
 
+    class EntityCategory:  # pragma: no cover - minimal stub
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
 
-storage.Store = Store
-sys.modules.setdefault("homeassistant.helpers.storage", storage)
+    entity.EntityCategory = EntityCategory
+    sys.modules.setdefault("homeassistant.helpers.entity", entity)
 
+    storage = types.ModuleType("homeassistant.helpers.storage")
 
-@pytest.fixture
-def hass() -> HomeAssistant:
-    """Provide a minimal Home Assistant instance."""
-    return HomeAssistant()
+    class Store:  # pragma: no cover - minimal in-memory store
+        def __init__(self, _hass, _version, _key) -> None:
+            self.data: dict[str, object] = {}
 
+        async def async_load(self):
+            return self.data
 
-@pytest.fixture
-def enable_custom_integrations():
-    """Stub fixture for compatibility with Home Assistant tests."""
-    yield
+        async def async_save(self, data) -> None:
+            self.data = data
+
+    storage.Store = Store
+    sys.modules.setdefault("homeassistant.helpers.storage", storage)
+
+    @pytest.fixture
+    def hass() -> HomeAssistant:
+        """Provide a minimal Home Assistant instance."""
+        return HomeAssistant()
+
+    @pytest.fixture
+    def enable_custom_integrations():
+        """Stub fixture for compatibility with Home Assistant tests."""
+        yield

--- a/tests/test_coordinator_sensor.py
+++ b/tests/test_coordinator_sensor.py
@@ -1,9 +1,11 @@
 import importlib
+import logging
 import pathlib
 import sys
 import types
 
 import pytest
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 # Bypass the package __init__ which pulls in Home Assistant by creating a minimal
 # module placeholder with an explicit path for submodule resolution.
@@ -23,7 +25,8 @@ sensor_mod = importlib.import_module("custom_components.horticulture_assistant.s
 CONF_PROFILES = const.CONF_PROFILES
 HorticultureCoordinator = coordinator_mod.HorticultureCoordinator
 HorticultureBaseEntity = entity_mod.HorticultureBaseEntity
-ProfileDLISensor = sensor_mod.ProfileDLISensor
+ProfileMetricSensor = sensor_mod.ProfileMetricSensor
+PROFILE_SENSOR_DESCRIPTIONS = sensor_mod.PROFILE_SENSOR_DESCRIPTIONS
 
 
 @pytest.mark.asyncio
@@ -37,6 +40,13 @@ async def test_coordinator_returns_profile_data(hass):
     prof = coordinator.data["profiles"]["avocado"]
     assert prof["name"] == "Avocado"
     assert prof["metrics"]["dli"] is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_honors_update_interval(hass):
+    options = {CONF_PROFILES: {}, "update_interval": 10}
+    coordinator = HorticultureCoordinator(hass, "entry1", options)
+    assert coordinator.update_interval.total_seconds() == 600
 
 
 @pytest.mark.asyncio
@@ -65,5 +75,55 @@ async def test_dli_sensor_reads_illuminance(hass):
     coordinator = HorticultureCoordinator(hass, "entry1", options)
     await coordinator.async_config_entry_first_refresh()
 
-    sensor = ProfileDLISensor(coordinator, "avocado", "Avocado")
+    sensor = ProfileMetricSensor(
+        coordinator, "avocado", "Avocado", PROFILE_SENSOR_DESCRIPTIONS["dli"]
+    )
     assert sensor.native_value == pytest.approx(0.02)
+
+
+@pytest.mark.asyncio
+async def test_profile_vpd_and_dew_point_sensors(hass):
+    hass.states.async_set("sensor.t", 25)
+    hass.states.async_set("sensor.h", 60)
+    options = {
+        CONF_PROFILES: {
+            "avocado": {
+                "name": "Avocado",
+                "sensors": {"temperature": "sensor.t", "humidity": "sensor.h"},
+            }
+        }
+    }
+    coordinator = HorticultureCoordinator(hass, "entry1", options)
+    await coordinator.async_config_entry_first_refresh()
+
+    vpd_sensor = ProfileMetricSensor(
+        coordinator, "avocado", "Avocado", PROFILE_SENSOR_DESCRIPTIONS["vpd"]
+    )
+    dew_sensor = ProfileMetricSensor(
+        coordinator, "avocado", "Avocado", PROFILE_SENSOR_DESCRIPTIONS["dew_point"]
+    )
+    assert vpd_sensor.native_value == pytest.approx(1.27, rel=1e-2)
+    assert dew_sensor.native_value == pytest.approx(16.7, rel=1e-2)
+
+
+@pytest.mark.asyncio
+async def test_status_and_recommendation_device_info(hass):
+    async def _async_update():
+        return {}
+
+    ai = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), name="ai", update_method=_async_update
+    )
+    local = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), name="local", update_method=_async_update
+    )
+    status = sensor_mod.HortiStatusSensor(
+        ai, local, "entry1", "Plant", "pid", True
+    )
+    rec = sensor_mod.HortiRecommendationSensor(
+        ai, "entry1", "Plant", "pid", True
+    )
+    info = status.device_info
+    assert info["identifiers"] == {("horticulture_assistant", "plant:pid")}
+    assert info["name"] == "Plant"
+    assert rec.device_info == info

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,19 @@
+import json
+import pathlib
+
+
+def test_manifest_metadata():
+    manifest_path = (
+        pathlib.Path(__file__).parents[1]
+        / "custom_components"
+        / "horticulture_assistant"
+        / "manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["domain"] == "horticulture_assistant"
+    assert manifest.get("after_dependencies") == ["recorder"]
+    assert manifest.get("integration_type") == "helper"
+    assert manifest.get("iot_class") == "calculated"
+    assert manifest.get("quality_scale") == "bronze"
+    assert manifest.get("version") == "2025.08.0"
+    assert manifest.get("loggers") == ["custom_components.horticulture_assistant"]

--- a/tests/test_service_docs.py
+++ b/tests/test_service_docs.py
@@ -1,0 +1,28 @@
+import ast
+import pathlib
+
+import yaml
+
+
+def _collect_services(path: pathlib.Path) -> set[str]:
+    code = path.read_text()
+    tree = ast.parse(code)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(getattr(node.func, "attr", None), str):
+            if node.func.attr == "async_register" and len(node.args) >= 2:
+                service_arg = node.args[1]
+                if isinstance(service_arg, ast.Constant) and isinstance(service_arg.value, str):
+                    names.add(service_arg.value)
+    return names
+
+
+def test_services_documented():
+    root = pathlib.Path(__file__).parents[1] / "custom_components" / "horticulture_assistant"
+    documented = set(yaml.safe_load((root / "services.yaml").read_text()))
+    registered = (
+        _collect_services(root / "__init__.py")
+        | _collect_services(root / "services.py")
+        | _collect_services(root / "calibration" / "services.py")
+    )
+    assert documented == registered

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,43 @@
+import json
+import pathlib
+
+
+def _collect_paths(data, prefix=()):
+    paths = set()
+    if isinstance(data, dict):
+        for key, val in data.items():
+            paths |= _collect_paths(val, prefix + (key,))
+    else:
+        paths.add(prefix)
+    return paths
+
+
+def test_translations_cover_strings():
+    base = pathlib.Path(__file__).parents[1] / "custom_components" / "horticulture_assistant"
+    strings = json.loads((base / "strings.json").read_text(encoding="utf-8"))
+    en = json.loads((base / "translations" / "en.json").read_text(encoding="utf-8"))
+
+    string_paths = _collect_paths(strings)
+    en_paths = _collect_paths(en)
+    missing = string_paths - en_paths
+    assert not missing, f"Missing translations for: {sorted('.'.join(p) for p in missing)}"
+
+    extra = en_paths - string_paths
+    assert not extra, f"Unknown translations for: {sorted('.'.join(p) for p in extra)}"
+
+
+def _collect_values(data):
+    values: list[str] = []
+    if isinstance(data, dict):
+        for val in data.values():
+            values.extend(_collect_values(val))
+    else:
+        values.append(data)
+    return values
+
+
+def test_translation_values_non_empty():
+    base = pathlib.Path(__file__).parents[1] / "custom_components" / "horticulture_assistant"
+    en = json.loads((base / "translations" / "en.json").read_text(encoding="utf-8"))
+    for val in _collect_values(en):
+        assert isinstance(val, str) and val, "Empty translation value detected"


### PR DESCRIPTION
## Summary
- allow service tests to load real integration when pytest-homeassistant-custom-component is installed
- patch coordinators during tests to avoid network access
- fall back to lightweight Home Assistant stubs only when the plugin is missing

## Testing
- `python scripts/validate_profiles.py`
- `pre-commit run --files tests/test_services.py tests/conftest.py`
- `ruff check tests/test_services.py tests/conftest.py`
- `pytest tests/test_services.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab139d32f0833081653e791df3408a