### PR TITLE
Allow creating profiles without preferences

### DIFF
--- a/custom_components/horticulture_assistant/strings.json
+++ b/custom_components/horticulture_assistant/strings.json
@@ -27,8 +27,9 @@
       "add_profile": {
         "title": "Add profile",
         "data": {
-          "name": "Profile name",
-          "copy_from": "Clone thresholds from (optional)"
+          "profile_name": "Profile name",
+          "clone_from": "Clone thresholds from (optional)",
+          "sensors": "Sensors (key:value map)"
         }
       },
       "attach_sensors": {

--- a/custom_components/horticulture_assistant/translations/en.json
+++ b/custom_components/horticulture_assistant/translations/en.json
@@ -27,8 +27,9 @@
       "add_profile": {
         "title": "Add profile",
         "data": {
-          "name": "Profile name",
-          "copy_from": "Clone thresholds from (optional)"
+          "profile_name": "Profile name",
+          "clone_from": "Clone thresholds from (optional)",
+          "sensors": "Sensors (key:value map)"
         }
       },
       "attach_sensors": {

--- a/tests/test_add_profile_without_prefs.py
+++ b/tests/test_add_profile_without_prefs.py
@@ -1,0 +1,32 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_NAME = "custom_components.horticulture_assistant.profile_store"
+MODULE_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "horticulture_assistant" / "profile_store.py"
+
+spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+sys.modules[MODULE_NAME] = module
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+ProfileStore = module.ProfileStore
+
+
+async def test_create_profile_without_prefs(hass, tmp_path: Path):
+    hass.config.config_dir = str(tmp_path)
+    store = ProfileStore(hass)
+    await store.async_init()
+
+    await store.async_create_profile("Test Plant")
+    names = await store.async_list_profiles()
+    normalized = {name.lower().replace(" ", "").replace("-", "").replace("_", "") for name in names}
+    assert "testplant" in normalized
+
+    # Verify thresholds present but empty
+    profiles_dir = store._base
+    profile_path = next(profiles_dir.glob("*.json"))
+    data = json.loads(profile_path.read_text(encoding="utf-8"))
+    assert data["thresholds"] == {}


### PR DESCRIPTION
## Summary
- simplify the options add-profile form to only capture profile name, optional clone source, and sensors
- initialize new ProfileStore entries with empty thresholds when none are supplied and support cloning by name
- update strings/translations and add coverage ensuring blank-threshold profiles persist correctly

## Testing
- pytest tests/test_add_profile_without_prefs.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb36391608330a9d1c8f9e1e9f87f